### PR TITLE
hotfix: `DistanceMatrix` definition

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "fleetbase/fleetops-api",
-    "version": "0.4.10",
+    "version": "0.4.11",
     "description": "Fleet & Transport Management Extension for Fleetbase",
     "keywords": [
         "fleetbase-extension",

--- a/extension.json
+++ b/extension.json
@@ -1,6 +1,6 @@
 {
     "name": "Fleet-Ops",
-    "version": "0.4.10",
+    "version": "0.4.11",
     "description": "Fleet & Transport Management Extension for Fleetbase",
     "repository": "https://github.com/fleetbase/fleetops",
     "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@fleetbase/fleetops-engine",
-    "version": "0.4.10",
+    "version": "0.4.11",
     "description": "Fleet & Transport Management Extension for Fleetbase",
     "fleetbase": {
         "route": "fleet-ops"

--- a/server/src/Support/DistanceMatrix.php
+++ b/server/src/Support/DistanceMatrix.php
@@ -17,9 +17,9 @@ namespace Fleetbase\FleetOps\Support;
 class DistanceMatrix
 {
     public ?float $distance;
-    public ?int $time;
+    public ?float $time;
 
-    public function __construct(?float $distance, ?int $time)
+    public function __construct(?float $distance, ?float $time)
     {
         $this->distance = $distance;
         $this->time     = $time;

--- a/server/src/Support/Utils.php
+++ b/server/src/Support/Utils.php
@@ -783,8 +783,8 @@ class Utils extends FleetbaseUtils
             ]
         )->json();
 
-        $distance = data_get($response, 'rows.0.elements.0.distance.value');
-        $time     = data_get($response, 'rows.0.elements.0.duration.value');
+        $distance = (float) data_get($response, 'rows.0.elements.0.distance.value', 0);
+        $time     = (float) data_get($response, 'rows.0.elements.0.duration.value', 0);
 
         $result = static::createObject(
             [
@@ -812,7 +812,7 @@ class Utils extends FleetbaseUtils
         $destination = static::getPointFromMixed($destination);
 
         $distance = Utils::vincentyGreatCircleDistance($origin, $destination);
-        $time     = round($distance / 100) * self::DRIVING_TIME_MULTIPLIER;
+        $time     = (float) round($distance / 100) * self::DRIVING_TIME_MULTIPLIER;
 
         return new DistanceMatrix($distance, $time);
     }


### PR DESCRIPTION
- Fixes deprecation error/warning which occurs in some environments `Implicit conversion from float x to int loses precision` when creating a `DistanceMatrix` object