### PR TITLE
Fix incorrect order filtering in TrackOrderDistanceAndTime

### DIFF
--- a/server/src/Console/Commands/TrackOrderDistanceAndTime.php
+++ b/server/src/Console/Commands/TrackOrderDistanceAndTime.php
@@ -69,7 +69,7 @@ class TrackOrderDistanceAndTime extends Command
      * - Not in 'completed' or 'canceled' status.
      * - Not marked as deleted (`deleted_at` is null).
      * - Associated with a company (`company_uuid` is not null).
-     * - The order process has started (`started` is not null).
+     * - The order process has started (`started_at` is not null).
      * - Contains a payload (`payload` relationship exists).
      * - Created within the past month.
      *
@@ -85,7 +85,7 @@ class TrackOrderDistanceAndTime extends Command
         return Order::whereNotIn('status', ['completed', 'canceled'])
                     ->whereNull('deleted_at')
                     ->whereNotNull('company_uuid')
-                    ->whereNotNull('started')
+                    ->whereNotNull('started_at')
                     ->where('created_at', '>=', $oneMonthAgo)
                     ->whereHas('payload')
                     ->with(['payload', 'payload.waypoints', 'payload.pickup', 'payload.dropoff'])


### PR DESCRIPTION
# Fix incorrect order filtering in TrackOrderDistanceAndTime

## Summary

This PR fixes issue #155 where the order query in `TrackOrderDistanceAndTime` was too broad.  
It was fetching all orders except those with status 'completed' or 'canceled', regardless of whether they had actually started.

## Changes

- Replaced `whereNotNull('started')` with `whereNotNull('started_at')` in the order query.
- Ensures only orders that have officially started are included.
- Reduces unnecessary processing and server resource consumption.

## Why this matters

The previous query allowed orders that had not started to be processed, causing:

- Unnecessary updates
- Increased server load
- Potential performance degradation

By filtering on `started_at` (which is `null` if not started), we improve efficiency and accuracy.

---

Closes #155
