### PR TITLE
Fix/dispatched flag control order creation

### DIFF
--- a/server/src/Http/Controllers/Internal/v1/OrderController.php
+++ b/server/src/Http/Controllers/Internal/v1/OrderController.php
@@ -168,13 +168,6 @@ class OrderController extends FleetOpsController
                     // Check dispatch flag with backward compatibility (default true)
                     $shouldDispatch = isset($input['dispatched']) ? (bool)$input['dispatched'] : true;
 
-
-                    // set driving distance and time
-                    $order->setPreliminaryDistanceAndTime();
-
-                    // if service quote attached purchase
-                    $order->purchaseServiceQuote($serviceQuote);
-
                     // dispatch if flagged true, otherwise ensure order stays in created state
                     if ($shouldDispatch) {
                         $order->firstDispatchWithActivity();
@@ -186,6 +179,13 @@ class OrderController extends FleetOpsController
                             'status' => 'created'
                         ]);
                     }
+
+                    // set driving distance and time
+                    $order->setPreliminaryDistanceAndTime();
+
+                    // if service quote attached purchase
+                    $order->purchaseServiceQuote($serviceQuote);
+
 
                     // Run background processes on queue
                     dispatch(function () use ($order): void {


### PR DESCRIPTION
This PR adds explicit control over order dispatch behavior during creation, allowing to create orders without automatically dispatching them.

  Changes:
  - Add optional dispatched parameter to order creation API
  - Maintain backward compatibility (defaults to true if not specified)
  - Prevent auto-dispatch when explicitly set to false
