### PR TITLE
feat: Add extension.js for boot-time setup

### DIFF
--- a/addon/extension.js
+++ b/addon/extension.js
@@ -1,0 +1,24 @@
+import { ExtensionComponent } from '@fleetbase/ember-core';
+
+export default {
+    setupExtension(universe) {
+        // Register menu items
+        universe.registerMenuItem('fleet-ops', 'Operations', {
+            icon: 'truck',
+            priority: 1
+        });
+
+        // Register dashboard widgets
+        universe.registerDashboardWidget(
+            new ExtensionComponent({
+                engineName: '@fleetbase/fleetops-engine',
+                componentPath: 'widget/orders-metrics'
+            })
+        );
+
+        // Register admin menu items
+        universe.registerAdminMenuItem('Fleet Settings', 'fleet-ops.settings', {
+            icon: 'cog'
+        });
+    }
+};


### PR DESCRIPTION
Add addon/extension.js that contains extension setup code. This file is inlined into the host app by the prebuild script, enabling extension setup to run at boot without loading the engine bundle.

Includes:
- Menu item registration
- Dashboard widget registration
- Admin menu items
- Uses ExtensionComponent pattern for lazy component loading