### PR TITLE
Update service rate form template to use rate_fees relationship

### DIFF
--- a/addon/components/service-rate/form.hbs
+++ b/addon/components/service-rate/form.hbs
@@ -191,7 +191,7 @@
                             </tr>
                         </thead>
                         <tbody>
-                            {{#each @resource.perDropFees as |rateFee index|}}
+                            {{#each @resource.rate_fees as |rateFee|}}
                                 <tr>
                                     <td>
                                         <Input
@@ -215,7 +215,7 @@
                                         <MoneyInput class="w-full" @currency={{@resource.currency}} @value={{rateFee.fee}} disabled={{cannot-write @resource}} />
                                     </td>
                                     <td>
-                                        <Button @type="danger" @icon="trash" @onClick={{fn @resource.removePerDropFee index}} />
+                                        <Button @type="danger" @icon="trash" @onClick={{fn @resource.removePerDropFee rateFee}} />
                                     </td>
                                 </tr>
                             {{/each}}


### PR DESCRIPTION
- Change iteration from perDropFees to rate_fees in per-drop section
- Pass model instance to removePerDropFee instead of index
- This complements the model changes in fleetops-data to fix fee persistence

Works with fleetbase/fleetops-data#fix/service-rate-fee-persistence