### PR TITLE
Fix: Add `driverAssigned` eager loading to public API `OrderController`

### DIFF
--- a/server/src/Http/Controllers/Api/v1/OrderController.php
+++ b/server/src/Http/Controllers/Api/v1/OrderController.php
@@ -532,6 +532,7 @@ class OrderController extends Controller
         set_time_limit(180);
 
         $results = Order::queryWithRequest($request, function (&$query, $request) {
+            $query->with('driverAssigned');
             $query->where('company_uuid', session('company'));
             $query->whereNotNull('payload_uuid');
 
@@ -726,6 +727,7 @@ class OrderController extends Controller
         // find for the order
         try {
             $order = Order::findRecordOrFail($id);
+            $order->load('driverAssigned');
         } catch (ModelNotFoundException $exception) {
             return response()->json(
                 [
@@ -1226,7 +1228,7 @@ class OrderController extends Controller
         }
 
         // Load required relations
-        $order->loadMissing(['payload.waypoints', 'payload.pickup', 'payload.dropoff']);
+        $order->loadMissing(['payload.waypoints', 'payload.pickup', 'payload.dropoff', 'driverAssigned']);
 
         // Get the order payload
         $payload = $order->payload;


### PR DESCRIPTION
### Summary
The refactor introduced in commit 9dd0d8b6 updated `OrderResource` to rely on `relationLoaded()` checks for the `driver_assigned` relationship. However, eager loading for this relation was only added to internal controllers (`OrderFilter` and `LiveController`) and was missed in the **public API `OrderController`**.

As a result, `driver_assigned` was always returned as `null` in public API responses, even when a driver was assigned.

This PR adds the missing eager loading to the public API controller to align it with the existing internal request pattern.

---

### Issue Fixed
- **Navigator app not displaying assigned drivers on adhoc orders**
- Related issue: Navigator App [Issue #96](https://github.com/fleetbase/navigator-app/issues/96)

---

### Changes
- Added `driverAssigned` eager loading to:
  - `query()` method
  - `find()` method
  - `setDestination()` method via `loadMissing`
- Ensures `driver_assigned` is correctly populated in public API responses

---

### Files Changed
- `server/src/Http/Controllers/Api/v1/OrderController.php`

---

### 🧠 Notes
This change maintains consistency with the eager loading strategy already used for internal requests and prevents unintended `null` values caused by `relationLoaded()` checks in `OrderResource`.
