### PR TITLE
fix: Resolve vehicle from uuid, public_id, or object when creating/updating driver

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "fleetbase/fleetops-api",
-    "version": "0.6.36",
+    "version": "0.6.37",
     "description": "Fleet & Transport Management Extension for Fleetbase",
     "keywords": [
         "fleetbase-extension",

--- a/extension.json
+++ b/extension.json
@@ -1,6 +1,6 @@
 {
     "name": "Fleet-Ops",
-    "version": "0.6.36",
+    "version": "0.6.37",
     "description": "Fleet & Transport Management Extension for Fleetbase",
     "repository": "https://github.com/fleetbase/fleetops",
     "license": "AGPL-3.0-or-later",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@fleetbase/fleetops-engine",
-    "version": "0.6.36",
+    "version": "0.6.37",
     "description": "Fleet & Transport Management Extension for Fleetbase",
     "fleetbase": {
         "route": "fleet-ops"

--- a/server/src/Http/Controllers/Internal/v1/DriverController.php
+++ b/server/src/Http/Controllers/Internal/v1/DriverController.php
@@ -285,7 +285,7 @@ class DriverController extends FleetOpsController
         }
 
         // create validation request
-        $updateDriverRequest = UpdateDriverRequest::createFrom($request);;
+        $updateDriverRequest = UpdateDriverRequest::createFrom($request);
         $rules               = $updateDriverRequest->rules();
 
         // manually validate request

--- a/server/src/Http/Controllers/Internal/v1/DriverController.php
+++ b/server/src/Http/Controllers/Internal/v1/DriverController.php
@@ -45,6 +45,17 @@ class DriverController extends FleetOpsController
     {
         $input = $request->input('driver');
 
+        // Normalize vehicle field - the frontend may send the full vehicle object,
+        // a UUID string, or a public_id string. Normalize to a single identifier
+        // so the ResolvableVehicle rule can validate it correctly.
+        if (isset($input['vehicle']) && is_array($input['vehicle'])) {
+            $input['vehicle'] = data_get($input['vehicle'], 'id')
+                ?? data_get($input['vehicle'], 'public_id')
+                ?? data_get($input['vehicle'], 'uuid')
+                ?? null;
+            $request->merge(['driver' => $input]);
+        }
+
         // create validation request
         $createDriverRequest = CreateDriverRequest::createFrom($request);
         $rules               = $createDriverRequest->rules();
@@ -262,8 +273,19 @@ class DriverController extends FleetOpsController
         // get input data
         $input = $request->input('driver');
 
+        // Normalize vehicle field - the frontend may send the full vehicle object,
+        // a UUID string, or a public_id string. Normalize to a single identifier
+        // so the ResolvableVehicle rule can validate it correctly.
+        if (isset($input['vehicle']) && is_array($input['vehicle'])) {
+            $input['vehicle'] = data_get($input['vehicle'], 'id')
+                ?? data_get($input['vehicle'], 'public_id')
+                ?? data_get($input['vehicle'], 'uuid')
+                ?? null;
+            $request->merge(['driver' => $input]);
+        }
+
         // create validation request
-        $updateDriverRequest = UpdateDriverRequest::createFrom($request);
+        $updateDriverRequest = UpdateDriverRequest::createFrom($request);;
         $rules               = $updateDriverRequest->rules();
 
         // manually validate request

--- a/server/src/Http/Requests/CreateDriverRequest.php
+++ b/server/src/Http/Requests/CreateDriverRequest.php
@@ -3,6 +3,7 @@
 namespace Fleetbase\FleetOps\Http\Requests;
 
 use Fleetbase\FleetOps\Rules\ResolvablePoint;
+use Fleetbase\FleetOps\Rules\ResolvableVehicle;
 use Fleetbase\Http\Requests\FleetbaseRequest;
 use Illuminate\Validation\Rule;
 
@@ -34,7 +35,7 @@ class CreateDriverRequest extends FleetbaseRequest
             'password'  => 'nullable|string',
             'country'   => 'nullable|size:2',
             'city'      => 'nullable|string',
-            'vehicle'   => 'nullable|string|starts_with:vehicle_|exists:vehicles,public_id',
+            'vehicle'   => ['nullable', new ResolvableVehicle()],
             'status'    => 'nullable|string|in:active,inactive',
             'vendor'    => 'nullable|exists:vendors,public_id',
             'job'       => 'nullable|exists:orders,public_id',

--- a/server/src/Http/Requests/CreateDriverRequest.php
+++ b/server/src/Http/Requests/CreateDriverRequest.php
@@ -3,7 +3,6 @@
 namespace Fleetbase\FleetOps\Http\Requests;
 
 use Fleetbase\FleetOps\Rules\ResolvablePoint;
-use Fleetbase\FleetOps\Rules\ResolvableVehicle;
 use Fleetbase\Http\Requests\FleetbaseRequest;
 use Illuminate\Validation\Rule;
 
@@ -35,7 +34,7 @@ class CreateDriverRequest extends FleetbaseRequest
             'password'  => 'nullable|string',
             'country'   => 'nullable|size:2',
             'city'      => 'nullable|string',
-            'vehicle'   => ['nullable', new ResolvableVehicle()],
+            'vehicle'   => 'nullable|string|starts_with:vehicle_|exists:vehicles,public_id',
             'status'    => 'nullable|string|in:active,inactive',
             'vendor'    => 'nullable|exists:vendors,public_id',
             'job'       => 'nullable|exists:orders,public_id',

--- a/server/src/Http/Requests/Internal/CreateDriverRequest.php
+++ b/server/src/Http/Requests/Internal/CreateDriverRequest.php
@@ -4,6 +4,7 @@ namespace Fleetbase\FleetOps\Http\Requests\Internal;
 
 use Fleetbase\FleetOps\Http\Requests\CreateDriverRequest as CreateDriverApiRequest;
 use Fleetbase\FleetOps\Rules\ResolvablePoint;
+use Fleetbase\FleetOps\Rules\ResolvableVehicle;
 use Fleetbase\Support\Auth;
 use Illuminate\Validation\Rule;
 
@@ -49,7 +50,7 @@ class CreateDriverRequest extends CreateDriverApiRequest
             'internal_id'            => 'nullable|string|max:255',
             'country'                => 'nullable|string|size:2',
             'city'                   => 'nullable|string|max:255',
-            'vehicle'                => 'nullable|string|starts_with:vehicle_|exists:vehicles,public_id',
+            'vehicle'                => ['nullable', new ResolvableVehicle()],
             'status'                 => 'nullable|string|in:active,inactive',
             'vendor'                 => 'nullable|exists:vendors,public_id',
             'job'                    => 'nullable|exists:orders,public_id',

--- a/server/src/Rules/ResolvableVehicle.php
+++ b/server/src/Rules/ResolvableVehicle.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace Fleetbase\FleetOps\Rules;
+
+use Fleetbase\FleetOps\Models\Vehicle;
+use Illuminate\Contracts\Validation\Rule;
+use Illuminate\Support\Str;
+
+class ResolvableVehicle implements Rule
+{
+    /**
+     * The resolved vehicle instance, if found.
+     *
+     * @var Vehicle|null
+     */
+    protected ?Vehicle $resolved = null;
+
+    /**
+     * Determine if the validation rule passes.
+     *
+     * Accepts:
+     *  - A public_id string (e.g. "vehicle_abc123")
+     *  - A UUID string (e.g. "550e8400-e29b-41d4-a716-446655440000")
+     *  - An array/object containing an "id", "public_id", or "uuid" key
+     *
+     * @param string $attribute
+     * @param mixed  $value
+     *
+     * @return bool
+     */
+    public function passes($attribute, $value)
+    {
+        $identifier = $this->extractIdentifier($value);
+
+        if (empty($identifier)) {
+            return true; // nullable — let the nullable rule handle empty values
+        }
+
+        if (Str::isUuid($identifier)) {
+            $this->resolved = Vehicle::where('uuid', $identifier)->first();
+        } else {
+            $this->resolved = Vehicle::where('public_id', $identifier)->first();
+        }
+
+        return $this->resolved !== null;
+    }
+
+    /**
+     * Get the validation error message.
+     *
+     * @return string
+     */
+    public function message()
+    {
+        return 'The :attribute must be a valid vehicle public ID, UUID, or vehicle object.';
+    }
+
+    /**
+     * Extract a string identifier from the given value.
+     *
+     * Handles a plain string, an associative array, or a stdClass object.
+     *
+     * @param mixed $value
+     *
+     * @return string|null
+     */
+    protected function extractIdentifier($value): ?string
+    {
+        if (is_string($value)) {
+            return $value;
+        }
+
+        if (is_array($value)) {
+            return data_get($value, 'id')
+                ?? data_get($value, 'public_id')
+                ?? data_get($value, 'uuid')
+                ?? null;
+        }
+
+        if (is_object($value)) {
+            return data_get($value, 'id')
+                ?? data_get($value, 'public_id')
+                ?? data_get($value, 'uuid')
+                ?? null;
+        }
+
+        return null;
+    }
+
+    /**
+     * Get the resolved Vehicle model instance after validation passes.
+     *
+     * @return Vehicle|null
+     */
+    public function getResolved(): ?Vehicle
+    {
+        return $this->resolved;
+    }
+}

--- a/server/src/Rules/ResolvableVehicle.php
+++ b/server/src/Rules/ResolvableVehicle.php
@@ -10,8 +10,6 @@ class ResolvableVehicle implements Rule
 {
     /**
      * The resolved vehicle instance, if found.
-     *
-     * @var Vehicle|null
      */
     protected ?Vehicle $resolved = null;
 
@@ -24,7 +22,6 @@ class ResolvableVehicle implements Rule
      *  - An array/object containing an "id", "public_id", or "uuid" key
      *
      * @param string $attribute
-     * @param mixed  $value
      *
      * @return bool
      */
@@ -59,10 +56,6 @@ class ResolvableVehicle implements Rule
      * Extract a string identifier from the given value.
      *
      * Handles a plain string, an associative array, or a stdClass object.
-     *
-     * @param mixed $value
-     *
-     * @return string|null
      */
     protected function extractIdentifier($value): ?string
     {
@@ -89,8 +82,6 @@ class ResolvableVehicle implements Rule
 
     /**
      * Get the resolved Vehicle model instance after validation passes.
-     *
-     * @return Vehicle|null
      */
     public function getResolved(): ?Vehicle
     {


### PR DESCRIPTION
## Problem

Reported in issue: https://github.com/fleetbase/fleetbase/issues/507

When creating or updating a driver with a vehicle assigned, the frontend sends the vehicle as a full object payload (e.g. `{id: "vehicle_abc", name: "...", make: "..."}`) rather than a plain string public ID.

The existing validation rule:
```php
'vehicle' => 'nullable|string|starts_with:vehicle_|exists:vehicles,public_id'
```

Passes the raw array to PHP's `str_starts_with()`, which throws:
```
TypeError: str_starts_with(): Argument #1 ($haystack) must be of type string, array given
```

## Solution

### 1. New `ResolvableVehicle` Rule
Added `server/src/Rules/ResolvableVehicle.php` that accepts:
- A `public_id` string (e.g. `vehicle_abc123`)
- A UUID string
- An array/object containing an `id`, `public_id`, or `uuid` key

### 2. Updated `CreateDriverRequest`
Replaced the brittle string-only rule with the new `ResolvableVehicle` rule.

### 3. Normalized input in `DriverController`
Added normalization in both `createRecord` and `updateRecord` — if the vehicle field is an array, it extracts the identifier before validation runs.

## Files Changed
- `server/src/Rules/ResolvableVehicle.php` *(new)*
- `server/src/Http/Requests/CreateDriverRequest.php`
- `server/src/Http/Controllers/Internal/v1/DriverController.php`