### PR TITLE
feat: add description and shortcuts to header menu registration

### DIFF
--- a/addon/controllers/operations/orders/index/details.js
+++ b/addon/controllers/operations/orders/index/details.js
@@ -2,10 +2,12 @@ import Controller, { inject as controller } from '@ember/controller';
 import { tracked } from '@glimmer/tracking';
 import { inject as service } from '@ember/service';
 import { action } from '@ember/object';
+import { isArray } from '@ember/array';
 import { task } from 'ember-concurrency';
 
 export default class OperationsOrdersIndexDetailsController extends Controller {
     @controller('operations.orders.index') index;
+    @service('universe/menu-service') menuService;
     @service orderActions;
     @service orderSocketEvents;
     @service leafletMapManager;
@@ -16,11 +18,14 @@ export default class OperationsOrdersIndexDetailsController extends Controller {
     @tracked routingControl;
 
     get tabs() {
+        const registeredTabs = this.menuService.getMenuItems('fleet-ops:component:order:details');
         return [
             {
                 route: 'operations.orders.index.details.index',
                 label: 'Overview',
+                icon: 'folder-open',
             },
+            ...(isArray(registeredTabs) ? registeredTabs : []),
         ];
     }
 

--- a/addon/extension.js
+++ b/addon/extension.js
@@ -83,14 +83,14 @@ export default {
             'auth:login',
             new MenuItem({
                 title: 'Track Order',
-                route: 'virtual',
+                route: 'track-order',
                 slug: 'track-order',
                 icon: 'barcode',
                 type: 'link',
                 wrapperClass: 'btn-block py-1 border dark:border-gray-700 border-gray-200 hover:opacity-50',
                 component: new ExtensionComponent('@fleetbase/fleetops-engine', 'order-tracking-lookup'),
                 onClick: (menuItem) => {
-                    universe.transitionMenuItem('virtual', menuItem);
+                    universe.transitionMenuItem('track-order', menuItem);
                 },
             })
         );

--- a/addon/extension.js
+++ b/addon/extension.js
@@ -83,14 +83,14 @@ export default {
             'auth:login',
             new MenuItem({
                 title: 'Track Order',
-                route: 'track-order',
+                route: 'virtual',
                 slug: 'track-order',
                 icon: 'barcode',
                 type: 'link',
                 wrapperClass: 'btn-block py-1 border dark:border-gray-700 border-gray-200 hover:opacity-50',
                 component: new ExtensionComponent('@fleetbase/fleetops-engine', 'order-tracking-lookup'),
                 onClick: (menuItem) => {
-                    universe.transitionMenuItem('track-order', menuItem);
+                    universe.transitionMenuItem('virtual', menuItem);
                 },
             })
         );

--- a/addon/extension.js
+++ b/addon/extension.js
@@ -7,7 +7,61 @@ export default {
         const widgetService = universe.getService('widget');
 
         // Register header navigation
-        menuService.registerHeaderMenuItem('Fleet-Ops', 'console.fleet-ops', { icon: 'route', priority: 0 });
+        menuService.registerHeaderMenuItem('Fleet-Ops', 'console.fleet-ops', {
+            icon: 'route',
+            priority: 0,
+            description: 'Dispatch, fleet management, driver tracking, and logistics operations.',
+            shortcuts: [
+                {
+                    title: 'Orders',
+                    description: 'Create, dispatch, and track delivery orders in real time.',
+                    icon: 'boxes-stacked',
+                    route: 'console.fleet-ops.operations.orders',
+                },
+                {
+                    title: 'Routes',
+                    description: 'Plan and manage optimised multi-stop delivery routes.',
+                    icon: 'map-location-dot',
+                    route: 'console.fleet-ops.operations.routes',
+                },
+                {
+                    title: 'Drivers',
+                    description: 'Manage driver profiles, assignments, and live locations.',
+                    icon: 'id-card',
+                    route: 'console.fleet-ops.management.drivers',
+                },
+                {
+                    title: 'Vehicles',
+                    description: 'View and manage your vehicle fleet and telematics.',
+                    icon: 'truck',
+                    route: 'console.fleet-ops.management.vehicles',
+                },
+                {
+                    title: 'Fleets',
+                    description: 'Organise drivers and vehicles into operational fleets.',
+                    icon: 'layer-group',
+                    route: 'console.fleet-ops.management.fleets',
+                },
+                {
+                    title: 'Service Rates',
+                    description: 'Configure pricing rules and service rate cards.',
+                    icon: 'tags',
+                    route: 'console.fleet-ops.operations.service-rates',
+                },
+                {
+                    title: 'Tracking',
+                    description: 'Live map view of all active drivers and orders.',
+                    icon: 'satellite-dish',
+                    route: 'console.fleet-ops.connectivity.tracking',
+                },
+                {
+                    title: 'Reports',
+                    description: 'Generate and review operational analytics reports.',
+                    icon: 'chart-bar',
+                    route: 'console.fleet-ops.analytics.reports',
+                },
+            ],
+        });
 
         // Register admin sections
         menuService.registerAdminMenuPanel(

--- a/addon/extension.js
+++ b/addon/extension.js
@@ -19,10 +19,10 @@ export default {
                     route: 'console.fleet-ops.operations.orders',
                 },
                 {
-                    title: 'Routes',
-                    description: 'Plan and manage optimised multi-stop delivery routes.',
-                    icon: 'map-location-dot',
-                    route: 'console.fleet-ops.operations.routes',
+                    title: 'Places',
+                    description: 'Manage saved locations, addresses, and points of interest.',
+                    icon: 'location-dot',
+                    route: 'console.fleet-ops.management.places',
                 },
                 {
                     title: 'Drivers',
@@ -49,10 +49,10 @@ export default {
                     route: 'console.fleet-ops.operations.service-rates',
                 },
                 {
-                    title: 'Tracking',
-                    description: 'Live map view of all active drivers and orders.',
-                    icon: 'satellite-dish',
-                    route: 'console.fleet-ops.connectivity.tracking',
+                    title: 'Devices',
+                    description: 'Manage connected telematics devices and their sensor data.',
+                    icon: 'microchip',
+                    route: 'console.fleet-ops.connectivity.devices',
                 },
                 {
                     title: 'Reports',

--- a/addon/routes.js
+++ b/addon/routes.js
@@ -1,7 +1,7 @@
 import buildRoutes from 'ember-engines/routes';
 
 export default buildRoutes(function () {
-    this.route('track-order', { path: '/:section/:slug' });
+    this.route('virtual', { path: '/:section/:slug' });
     this.route('operations', { path: '/' }, function () {
         this.route('order-config', function () {});
         this.route('service-rates', function () {

--- a/addon/routes.js
+++ b/addon/routes.js
@@ -1,7 +1,7 @@
 import buildRoutes from 'ember-engines/routes';
 
 export default buildRoutes(function () {
-    this.route('virtual', { path: '/:section/:slug' });
+    this.route('track-order', { path: '/:section/:slug' });
     this.route('operations', { path: '/' }, function () {
         this.route('order-config', function () {});
         this.route('service-rates', function () {

--- a/addon/routes.js
+++ b/addon/routes.js
@@ -1,6 +1,7 @@
 import buildRoutes from 'ember-engines/routes';
 
 export default buildRoutes(function () {
+    // eslint-disable-next-line ember/no-shadow-route-definition
     this.route('virtual', { path: '/:section/:slug' });
     this.route('operations', { path: '/' }, function () {
         this.route('order-config', function () {});

--- a/addon/routes.js
+++ b/addon/routes.js
@@ -1,7 +1,7 @@
+/* eslint-disable ember/no-shadow-route-definition */
 import buildRoutes from 'ember-engines/routes';
 
 export default buildRoutes(function () {
-    // eslint-disable-next-line ember/no-shadow-route-definition
     this.route('virtual', { path: '/:section/:slug' });
     this.route('operations', { path: '/' }, function () {
         this.route('order-config', function () {});

--- a/addon/routes.js
+++ b/addon/routes.js
@@ -19,6 +19,7 @@ export default buildRoutes(function () {
                 this.route('new');
                 this.route('details', { path: '/:public_id' }, function () {
                     this.route('index', { path: '/' });
+                    this.route('virtual', { path: '/:slug' });
                 });
             });
         });

--- a/addon/routes/operations/orders/index/details/virtual.js
+++ b/addon/routes/operations/orders/index/details/virtual.js
@@ -1,0 +1,23 @@
+import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
+
+export default class OperationsOrdersIndexDetailsVirtualRoute extends Route {
+    @service universe;
+    @service('universe/menu-service') menuService;
+
+    queryParams = {
+        view: {
+            refreshModel: true,
+        },
+    };
+
+    model({ section = null, slug }, transition) {
+        const view = this.universe.getViewFromTransition(transition);
+        return this.menuService.lookupMenuItem('fleet-ops:component:order:details', slug, view, section);
+    }
+
+    setupController(controller) {
+        super.setupController(...arguments);
+        controller.resource = this.modelFor('operations.orders.index.details');
+    }
+}

--- a/addon/templates/operations/orders/index/details/virtual.hbs
+++ b/addon/templates/operations/orders/index/details/virtual.hbs
@@ -1,0 +1,1 @@
+{{component (lazy-engine-component @model.component) resource=this.resource order=this.resource params=@model.componentParams}}

--- a/app/routes/operations/orders/index/details/virtual.js
+++ b/app/routes/operations/orders/index/details/virtual.js
@@ -1,0 +1,1 @@
+export { default } from '@fleetbase/fleetops-engine/routes/operations/orders/index/details/virtual';

--- a/app/templates/operations/orders/index/details/virtual.js
+++ b/app/templates/operations/orders/index/details/virtual.js
@@ -1,0 +1,1 @@
+export { default } from '@fleetbase/fleetops-engine/templates/operations/orders/index/details/virtual';

--- a/package.json
+++ b/package.json
@@ -42,8 +42,8 @@
     },
     "dependencies": {
         "@babel/core": "^7.23.2",
-        "@fleetbase/ember-core": "^0.3.12",
-        "@fleetbase/ember-ui": "^0.3.21",
+        "@fleetbase/ember-core": "^0.3.17",
+        "@fleetbase/ember-ui": "^0.3.25",
         "@fleetbase/fleetops-data": "^0.1.25",
         "@fleetbase/leaflet-routing-machine": "^3.2.17",
         "@fortawesome/ember-fontawesome": "^2.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,11 +12,11 @@ importers:
         specifier: ^7.23.2
         version: 7.27.1
       '@fleetbase/ember-core':
-        specifier: ^0.3.12
-        version: 0.3.12(@ember/string@3.1.1)(@ember/test-helpers@3.3.1(@babel/core@7.27.1)(ember-source@5.4.1(@babel/core@7.27.1)(@glimmer/component@1.1.2(@babel/core@7.27.1))(rsvp@4.8.5)(webpack@5.99.8))(webpack@5.99.8))(ember-resolver@11.0.1(ember-source@5.4.1(@babel/core@7.27.1)(@glimmer/component@1.1.2(@babel/core@7.27.1))(rsvp@4.8.5)(webpack@5.99.8)))(ember-source@5.4.1(@babel/core@7.27.1)(@glimmer/component@1.1.2(@babel/core@7.27.1))(rsvp@4.8.5)(webpack@5.99.8))(eslint@8.57.1)(webpack@5.99.8)
+        specifier: ^0.3.17
+        version: 0.3.17(@ember/string@3.1.1)(@ember/test-helpers@3.3.1(@babel/core@7.27.1)(ember-source@5.4.1(@babel/core@7.27.1)(@glimmer/component@1.1.2(@babel/core@7.27.1))(rsvp@4.8.5)(webpack@5.99.8))(webpack@5.99.8))(ember-resolver@11.0.1(ember-source@5.4.1(@babel/core@7.27.1)(@glimmer/component@1.1.2(@babel/core@7.27.1))(rsvp@4.8.5)(webpack@5.99.8)))(ember-source@5.4.1(@babel/core@7.27.1)(@glimmer/component@1.1.2(@babel/core@7.27.1))(rsvp@4.8.5)(webpack@5.99.8))(eslint@8.57.1)(webpack@5.99.8)
       '@fleetbase/ember-ui':
-        specifier: ^0.3.21
-        version: 0.3.21(@ember/test-helpers@3.3.1(@babel/core@7.27.1)(ember-source@5.4.1(@babel/core@7.27.1)(@glimmer/component@1.1.2(@babel/core@7.27.1))(rsvp@4.8.5)(webpack@5.99.8))(webpack@5.99.8))(@glimmer/component@1.1.2(@babel/core@7.27.1))(@glimmer/tracking@1.1.2)(ember-resolver@11.0.1(ember-source@5.4.1(@babel/core@7.27.1)(@glimmer/component@1.1.2(@babel/core@7.27.1))(rsvp@4.8.5)(webpack@5.99.8)))(ember-source@5.4.1(@babel/core@7.27.1)(@glimmer/component@1.1.2(@babel/core@7.27.1))(rsvp@4.8.5)(webpack@5.99.8))(postcss@8.5.3)(rollup@2.79.2)(tracked-built-ins@3.4.0(@babel/core@7.27.1))(webpack@5.99.8)
+        specifier: ^0.3.25
+        version: 0.3.25(@ember/test-helpers@3.3.1(@babel/core@7.27.1)(ember-source@5.4.1(@babel/core@7.27.1)(@glimmer/component@1.1.2(@babel/core@7.27.1))(rsvp@4.8.5)(webpack@5.99.8))(webpack@5.99.8))(@glimmer/component@1.1.2(@babel/core@7.27.1))(@glimmer/tracking@1.1.2)(ember-resolver@11.0.1(ember-source@5.4.1(@babel/core@7.27.1)(@glimmer/component@1.1.2(@babel/core@7.27.1))(rsvp@4.8.5)(webpack@5.99.8)))(ember-source@5.4.1(@babel/core@7.27.1)(@glimmer/component@1.1.2(@babel/core@7.27.1))(rsvp@4.8.5)(webpack@5.99.8))(postcss@8.5.3)(rollup@2.79.2)(tracked-built-ins@3.4.0(@babel/core@7.27.1))(webpack@5.99.8)
       '@fleetbase/fleetops-data':
         specifier: ^0.1.25
         version: 0.1.25(@ember/string@3.1.1)(@ember/test-helpers@3.3.1(@babel/core@7.27.1)(ember-source@5.4.1(@babel/core@7.27.1)(@glimmer/component@1.1.2(@babel/core@7.27.1))(rsvp@4.8.5)(webpack@5.99.8))(webpack@5.99.8))(ember-resolver@11.0.1(ember-source@5.4.1(@babel/core@7.27.1)(@glimmer/component@1.1.2(@babel/core@7.27.1))(rsvp@4.8.5)(webpack@5.99.8)))(ember-source@5.4.1(@babel/core@7.27.1)(@glimmer/component@1.1.2(@babel/core@7.27.1))(rsvp@4.8.5)(webpack@5.99.8))(eslint@8.57.1)(webpack@5.99.8)
@@ -1414,12 +1414,12 @@ packages:
     peerDependencies:
       ember-source: '>= 4.0.0'
 
-  '@fleetbase/ember-core@0.3.12':
-    resolution: {integrity: sha512-XvX8ND36FOKvNPuXvo5usDlSrH1PkfpWrRGtlU4/bDkYZBcNUH3jJAu4Wfl8vfv1Tg232bMpHjgCYUgDlu1YUg==}
+  '@fleetbase/ember-core@0.3.17':
+    resolution: {integrity: sha512-fFyorS6Ir/lW2u1y/d46U/0PoIhz4JKSVJZJddveIPK3v/0shpHRRsI4gnW+EtIzE3Dgq6Z7p6pQvrPBpPw/YQ==}
     engines: {node: '>= 18'}
 
-  '@fleetbase/ember-ui@0.3.21':
-    resolution: {integrity: sha512-HodjXkqg29/omCxmf4jwPlZcLhbjaLqDIVTprB9+c65Ekzsca2ag51dmpjjUIJisaZQ+OtHHNpOU0pVAYgaqKA==}
+  '@fleetbase/ember-ui@0.3.25':
+    resolution: {integrity: sha512-CM0dXMlFe3VyIGFgmbRDEK+e/Y79Ezu4T57geJF2cHr+/1f3oLvhLqPaZIs1J1TTSgcvCl3E+owcYWw2mWxLlg==}
     engines: {node: '>= 18'}
 
   '@fleetbase/fleetops-data@0.1.25':
@@ -1628,6 +1628,9 @@ packages:
   '@inquirer/figures@1.0.11':
     resolution: {integrity: sha512-eOg92lvrn/aRUqbxRyvpEWnrvRuTYRifixHkYVpJiygTgVSBIHDqLh0SrMQXkafvULg3ck11V7xvR+zcgvpHFw==}
     engines: {node: '>=18'}
+
+  '@interactjs/types@1.10.27':
+    resolution: {integrity: sha512-BUdv0cvs4H5ODuwft2Xp4eL8Vmi3LcihK42z0Ft/FbVJZoRioBsxH+LlsBdK4tAie7PqlKGy+1oyOncu1nQ6eA==}
 
   '@isaacs/cliui@8.0.2':
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
@@ -5404,6 +5407,9 @@ packages:
   inquirer@9.3.7:
     resolution: {integrity: sha512-LJKFHCSeIRq9hanN14IlOtPSTe3lNES7TYDTE2xxdAy1LS5rYphajK1qtwvj3YmQXvvk0U2Vbmcni8P9EIQW9w==}
     engines: {node: '>=18'}
+
+  interactjs@1.10.27:
+    resolution: {integrity: sha512-y/8RcCftGAF24gSp76X2JS3XpHiUvDQyhF8i7ujemBz77hwiHDuJzftHx7thY8cxGogwGiPJ+o97kWB6eAXnsA==}
 
   internal-slot@1.1.0:
     resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
@@ -10804,7 +10810,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@fleetbase/ember-core@0.3.12(@ember/string@3.1.1)(@ember/test-helpers@3.3.1(@babel/core@7.27.1)(ember-source@5.4.1(@babel/core@7.27.1)(@glimmer/component@1.1.2(@babel/core@7.27.1))(rsvp@4.8.5)(webpack@5.99.8))(webpack@5.99.8))(ember-resolver@11.0.1(ember-source@5.4.1(@babel/core@7.27.1)(@glimmer/component@1.1.2(@babel/core@7.27.1))(rsvp@4.8.5)(webpack@5.99.8)))(ember-source@5.4.1(@babel/core@7.27.1)(@glimmer/component@1.1.2(@babel/core@7.27.1))(rsvp@4.8.5)(webpack@5.99.8))(eslint@8.57.1)(webpack@5.99.8)':
+  '@fleetbase/ember-core@0.3.17(@ember/string@3.1.1)(@ember/test-helpers@3.3.1(@babel/core@7.27.1)(ember-source@5.4.1(@babel/core@7.27.1)(@glimmer/component@1.1.2(@babel/core@7.27.1))(rsvp@4.8.5)(webpack@5.99.8))(webpack@5.99.8))(ember-resolver@11.0.1(ember-source@5.4.1(@babel/core@7.27.1)(@glimmer/component@1.1.2(@babel/core@7.27.1))(rsvp@4.8.5)(webpack@5.99.8)))(ember-source@5.4.1(@babel/core@7.27.1)(@glimmer/component@1.1.2(@babel/core@7.27.1))(rsvp@4.8.5)(webpack@5.99.8))(eslint@8.57.1)(webpack@5.99.8)':
     dependencies:
       '@babel/core': 7.27.1
       compress-json: 3.4.0
@@ -10837,7 +10843,7 @@ snapshots:
       - utf-8-validate
       - webpack
 
-  '@fleetbase/ember-ui@0.3.21(@ember/test-helpers@3.3.1(@babel/core@7.27.1)(ember-source@5.4.1(@babel/core@7.27.1)(@glimmer/component@1.1.2(@babel/core@7.27.1))(rsvp@4.8.5)(webpack@5.99.8))(webpack@5.99.8))(@glimmer/component@1.1.2(@babel/core@7.27.1))(@glimmer/tracking@1.1.2)(ember-resolver@11.0.1(ember-source@5.4.1(@babel/core@7.27.1)(@glimmer/component@1.1.2(@babel/core@7.27.1))(rsvp@4.8.5)(webpack@5.99.8)))(ember-source@5.4.1(@babel/core@7.27.1)(@glimmer/component@1.1.2(@babel/core@7.27.1))(rsvp@4.8.5)(webpack@5.99.8))(postcss@8.5.3)(rollup@2.79.2)(tracked-built-ins@3.4.0(@babel/core@7.27.1))(webpack@5.99.8)':
+  '@fleetbase/ember-ui@0.3.25(@ember/test-helpers@3.3.1(@babel/core@7.27.1)(ember-source@5.4.1(@babel/core@7.27.1)(@glimmer/component@1.1.2(@babel/core@7.27.1))(rsvp@4.8.5)(webpack@5.99.8))(webpack@5.99.8))(@glimmer/component@1.1.2(@babel/core@7.27.1))(@glimmer/tracking@1.1.2)(ember-resolver@11.0.1(ember-source@5.4.1(@babel/core@7.27.1)(@glimmer/component@1.1.2(@babel/core@7.27.1))(rsvp@4.8.5)(webpack@5.99.8)))(ember-source@5.4.1(@babel/core@7.27.1)(@glimmer/component@1.1.2(@babel/core@7.27.1))(rsvp@4.8.5)(webpack@5.99.8))(postcss@8.5.3)(rollup@2.79.2)(tracked-built-ins@3.4.0(@babel/core@7.27.1))(webpack@5.99.8)':
     dependencies:
       '@babel/core': 7.27.1
       '@ember/render-modifiers': 2.1.0(@babel/core@7.27.1)(ember-source@5.4.1(@babel/core@7.27.1)(@glimmer/component@1.1.2(@babel/core@7.27.1))(rsvp@4.8.5)(webpack@5.99.8))
@@ -10911,6 +10917,7 @@ snapshots:
       ember-wormhole: 0.6.0
       gridstack: 7.3.0
       imask: 6.6.3
+      interactjs: 1.10.27
       intl-tel-input: 22.0.2
       leaflet: 1.9.4
       postcss-at-rules-variables: 0.3.0(postcss@8.5.3)
@@ -10943,7 +10950,7 @@ snapshots:
   '@fleetbase/fleetops-data@0.1.25(@ember/string@3.1.1)(@ember/test-helpers@3.3.1(@babel/core@7.27.1)(ember-source@5.4.1(@babel/core@7.27.1)(@glimmer/component@1.1.2(@babel/core@7.27.1))(rsvp@4.8.5)(webpack@5.99.8))(webpack@5.99.8))(ember-resolver@11.0.1(ember-source@5.4.1(@babel/core@7.27.1)(@glimmer/component@1.1.2(@babel/core@7.27.1))(rsvp@4.8.5)(webpack@5.99.8)))(ember-source@5.4.1(@babel/core@7.27.1)(@glimmer/component@1.1.2(@babel/core@7.27.1))(rsvp@4.8.5)(webpack@5.99.8))(eslint@8.57.1)(webpack@5.99.8)':
     dependencies:
       '@babel/core': 7.27.1
-      '@fleetbase/ember-core': 0.3.12(@ember/string@3.1.1)(@ember/test-helpers@3.3.1(@babel/core@7.27.1)(ember-source@5.4.1(@babel/core@7.27.1)(@glimmer/component@1.1.2(@babel/core@7.27.1))(rsvp@4.8.5)(webpack@5.99.8))(webpack@5.99.8))(ember-resolver@11.0.1(ember-source@5.4.1(@babel/core@7.27.1)(@glimmer/component@1.1.2(@babel/core@7.27.1))(rsvp@4.8.5)(webpack@5.99.8)))(ember-source@5.4.1(@babel/core@7.27.1)(@glimmer/component@1.1.2(@babel/core@7.27.1))(rsvp@4.8.5)(webpack@5.99.8))(eslint@8.57.1)(webpack@5.99.8)
+      '@fleetbase/ember-core': 0.3.17(@ember/string@3.1.1)(@ember/test-helpers@3.3.1(@babel/core@7.27.1)(ember-source@5.4.1(@babel/core@7.27.1)(@glimmer/component@1.1.2(@babel/core@7.27.1))(rsvp@4.8.5)(webpack@5.99.8))(webpack@5.99.8))(ember-resolver@11.0.1(ember-source@5.4.1(@babel/core@7.27.1)(@glimmer/component@1.1.2(@babel/core@7.27.1))(rsvp@4.8.5)(webpack@5.99.8)))(ember-source@5.4.1(@babel/core@7.27.1)(@glimmer/component@1.1.2(@babel/core@7.27.1))(rsvp@4.8.5)(webpack@5.99.8))(eslint@8.57.1)(webpack@5.99.8)
       date-fns: 2.30.0
       ember-cli-babel: 8.2.0(@babel/core@7.27.1)
       ember-cli-htmlbars: 6.3.0
@@ -11305,6 +11312,8 @@ snapshots:
   '@humanwhocodes/object-schema@2.0.3': {}
 
   '@inquirer/figures@1.0.11': {}
+
+  '@interactjs/types@1.10.27': {}
 
   '@isaacs/cliui@8.0.2':
     dependencies:
@@ -16877,6 +16886,10 @@ snapshots:
       strip-ansi: 6.0.1
       wrap-ansi: 6.2.0
       yoctocolors-cjs: 2.1.2
+
+  interactjs@1.10.27:
+    dependencies:
+      '@interactjs/types': 1.10.27
 
   internal-slot@1.1.0:
     dependencies:

--- a/tests/unit/routes/operations/orders/index/details/virtual-test.js
+++ b/tests/unit/routes/operations/orders/index/details/virtual-test.js
@@ -1,0 +1,11 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'dummy/tests/helpers';
+
+module('Unit | Route | operations/orders/index/details/virtual', function (hooks) {
+    setupTest(hooks);
+
+    test('it exists', function (assert) {
+        let route = this.owner.lookup('route:operations/orders/index/details/virtual');
+        assert.ok(route);
+    });
+});


### PR DESCRIPTION
## Summary

Adds a `description` and `shortcuts` array to the `registerHeaderMenuItem` call in `addon/extension.js`, following the pattern established in the [Ledger engine](https://github.com/fleetbase/ledger/blob/dev-v0.0.1/addon/extension.js).

Each shortcut entry provides:
- `title` — human-readable section name
- `description` — one-line summary of what the section does
- `icon` — FontAwesome icon name
- `route` — the Ember route to transition to on click

## Changes
- `addon/extension.js` — expanded the options object passed to `registerHeaderMenuItem` with `description` and `shortcuts`

## Testing
No logic changes. The shortcuts are purely declarative data consumed by the header menu component in `@fleetbase/ember-ui`.