### PR TITLE
fix: correct orchestrator capacity column naming and remove redundant payload capacity columns

### DIFF
--- a/addon/components/vehicle/details.hbs
+++ b/addon/components/vehicle/details.hbs
@@ -408,6 +408,28 @@
             </div>
 
             <div class="field-info-container">
+                <div class="field-name">Payload Volume</div>
+                <div class="field-value">
+                    {{#if @resource.payload_capacity_volume}}
+                        {{@resource.payload_capacity_volume}}
+                        m³
+                    {{else}}
+                        {{n-a @resource.payload_capacity_volume}}
+                    {{/if}}
+                </div>
+            </div>
+
+            <div class="field-info-container">
+                <div class="field-name">Pallet Capacity</div>
+                <div class="field-value">{{n-a @resource.payload_capacity_pallets}}</div>
+            </div>
+
+            <div class="field-info-container">
+                <div class="field-name">Parcel Capacity</div>
+                <div class="field-value">{{n-a @resource.payload_capacity_parcels}}</div>
+            </div>
+
+            <div class="field-info-container">
                 <div class="field-name">Passenger Volume</div>
                 <div class="field-value">
                     {{#if @resource.passenger_volume}}
@@ -614,7 +636,7 @@
     <CustomField::Yield @subject={{@resource}} @viewMode={{true}} @wrapperClass="bordered-top" />
 
     {{! ORCHESTRATOR CONSTRAINTS (read-only view) }}
-    {{#if (or @resource.skills.length @resource.time_window_start @resource.time_window_end @resource.max_tasks @resource.payload_capacity_volume @resource.payload_capacity_pallets @resource.payload_capacity_parcels)}}
+    {{#if (or @resource.skills.length @resource.time_window_start @resource.time_window_end @resource.max_tasks)}}
         <ContentPanel @title="Orchestrator Constraints" @open={{true}} @wrapperClass="bordered-top">
             <div class="grid grid-cols-2 gap-2 text-xs dark:text-gray-100">
                 {{#if @resource.skills.length}}
@@ -637,24 +659,6 @@
                     <div class="field-info-container">
                         <div class="field-name">Max Tasks</div>
                         <div class="field-value">{{@resource.max_tasks}}</div>
-                    </div>
-                {{/if}}
-                {{#if @resource.payload_capacity_volume}}
-                    <div class="field-info-container">
-                        <div class="field-name">Payload Volume</div>
-                        <div class="field-value">{{@resource.payload_capacity_volume}} m³</div>
-                    </div>
-                {{/if}}
-                {{#if @resource.payload_capacity_pallets}}
-                    <div class="field-info-container">
-                        <div class="field-name">Pallet Capacity</div>
-                        <div class="field-value">{{@resource.payload_capacity_pallets}}</div>
-                    </div>
-                {{/if}}
-                {{#if @resource.payload_capacity_parcels}}
-                    <div class="field-info-container">
-                        <div class="field-name">Parcel Capacity</div>
-                        <div class="field-value">{{@resource.payload_capacity_parcels}}</div>
                     </div>
                 {{/if}}
             </div>

--- a/addon/components/vehicle/details.hbs
+++ b/addon/components/vehicle/details.hbs
@@ -614,7 +614,7 @@
     <CustomField::Yield @subject={{@resource}} @viewMode={{true}} @wrapperClass="bordered-top" />
 
     {{! ORCHESTRATOR CONSTRAINTS (read-only view) }}
-    {{#if (or @resource.skills.length @resource.time_window_start @resource.time_window_end @resource.max_tasks)}}
+    {{#if (or @resource.skills.length @resource.time_window_start @resource.time_window_end @resource.max_tasks @resource.payload_capacity_volume @resource.payload_capacity_pallets @resource.payload_capacity_parcels)}}
         <ContentPanel @title="Orchestrator Constraints" @open={{true}} @wrapperClass="bordered-top">
             <div class="grid grid-cols-2 gap-2 text-xs dark:text-gray-100">
                 {{#if @resource.skills.length}}
@@ -637,6 +637,24 @@
                     <div class="field-info-container">
                         <div class="field-name">Max Tasks</div>
                         <div class="field-value">{{@resource.max_tasks}}</div>
+                    </div>
+                {{/if}}
+                {{#if @resource.payload_capacity_volume}}
+                    <div class="field-info-container">
+                        <div class="field-name">Payload Volume</div>
+                        <div class="field-value">{{@resource.payload_capacity_volume}} m³</div>
+                    </div>
+                {{/if}}
+                {{#if @resource.payload_capacity_pallets}}
+                    <div class="field-info-container">
+                        <div class="field-name">Pallet Capacity</div>
+                        <div class="field-value">{{@resource.payload_capacity_pallets}}</div>
+                    </div>
+                {{/if}}
+                {{#if @resource.payload_capacity_parcels}}
+                    <div class="field-info-container">
+                        <div class="field-name">Parcel Capacity</div>
+                        <div class="field-value">{{@resource.payload_capacity_parcels}}</div>
                     </div>
                 {{/if}}
             </div>

--- a/addon/components/vehicle/form.hbs
+++ b/addon/components/vehicle/form.hbs
@@ -403,15 +403,15 @@
                     <UnitInput class="w-full" @value={{@resource.cargo_volume}} @unit="L" @placeholder="Cargo Volume" />
                 </InputGroup>
 
-                <InputGroup @name="Payload Volume (m³)" @helpText="Maximum cargo volume capacity for Orchestrator allocation.">
+                <InputGroup @name="Payload Volume (m³)" @helpText="The maximum cargo volume this vehicle can carry, in cubic metres.">
                     <Input @value={{@resource.payload_capacity_volume}} @type="number" class="form-input w-full" placeholder="e.g. 40" disabled={{cannot-write @resource}} />
                 </InputGroup>
 
-                <InputGroup @name="Pallet Capacity" @helpText="Maximum number of pallets for Orchestrator allocation.">
+                <InputGroup @name="Pallet Capacity" @helpText="The maximum number of standard pallets this vehicle can carry.">
                     <Input @value={{@resource.payload_capacity_pallets}} @type="number" class="form-input w-full" placeholder="e.g. 20" disabled={{cannot-write @resource}} />
                 </InputGroup>
 
-                <InputGroup @name="Parcel Capacity" @helpText="Maximum number of parcels for Orchestrator allocation.">
+                <InputGroup @name="Parcel Capacity" @helpText="The maximum number of parcels or packages this vehicle can carry.">
                     <Input @value={{@resource.payload_capacity_parcels}} @type="number" class="form-input w-full" placeholder="e.g. 200" disabled={{cannot-write @resource}} />
                 </InputGroup>
 

--- a/addon/components/vehicle/form.hbs
+++ b/addon/components/vehicle/form.hbs
@@ -403,6 +403,18 @@
                     <UnitInput class="w-full" @value={{@resource.cargo_volume}} @unit="L" @placeholder="Cargo Volume" />
                 </InputGroup>
 
+                <InputGroup @name="Payload Volume (m³)" @helpText="Maximum cargo volume capacity for Orchestrator allocation.">
+                    <Input @value={{@resource.payload_capacity_volume}} @type="number" class="form-input w-full" placeholder="e.g. 40" disabled={{cannot-write @resource}} />
+                </InputGroup>
+
+                <InputGroup @name="Pallet Capacity" @helpText="Maximum number of pallets for Orchestrator allocation.">
+                    <Input @value={{@resource.payload_capacity_pallets}} @type="number" class="form-input w-full" placeholder="e.g. 20" disabled={{cannot-write @resource}} />
+                </InputGroup>
+
+                <InputGroup @name="Parcel Capacity" @helpText="Maximum number of parcels for Orchestrator allocation.">
+                    <Input @value={{@resource.payload_capacity_parcels}} @type="number" class="form-input w-full" placeholder="e.g. 200" disabled={{cannot-write @resource}} />
+                </InputGroup>
+
                 <InputGroup @name="Passenger Volume">
                     <UnitInput class="w-full" @value={{@resource.passenger_volume}} @unit="L" @placeholder="Passenger Volume" />
                 </InputGroup>

--- a/server/migrations/2026_04_08_000001_add_orchestrator_columns_to_vehicles_table.php
+++ b/server/migrations/2026_04_08_000001_add_orchestrator_columns_to_vehicles_table.php
@@ -1,24 +1,20 @@
 <?php
-
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
-
 /**
  * Add Orchestrator constraint columns to the vehicles table.
  *
- * Note: payload weight capacity is already covered by the existing
- * `payload_capacity` column on the vehicles table and is NOT duplicated here.
- *
  * New columns:
- *   - skills                      JSON array of vehicle capability flags (e.g. ["tail_lift","refrigerated"])
- *   - payload_capacity_volume     Maximum cargo volume in cubic metres
- *   - payload_capacity_pallets    Maximum pallet count
- *   - payload_capacity_parcels    Maximum parcel/package count
- *   - max_tasks                   Maximum number of stops per route
- *   - time_window_start           Default availability start time (HH:MM)
- *   - time_window_end             Default availability end time (HH:MM)
- *   - return_to_depot             Whether the vehicle must return to its start depot after a route
+ *   - skills              JSON array of vehicle capability flags (e.g. ["tail_lift","refrigerated"])
+ *   - capacity_weight_kg  Maximum payload weight in kilograms
+ *   - capacity_volume_m3  Maximum cargo volume in cubic metres
+ *   - capacity_pallets    Maximum pallet count
+ *   - capacity_parcels    Maximum parcel/package count
+ *   - max_tasks           Maximum number of stops per route
+ *   - time_window_start   Default shift start time (HH:MM)
+ *   - time_window_end     Default shift end time (HH:MM)
+ *   - return_to_depot     Whether the vehicle must return to its start depot
  */
 return new class extends Migration {
     public function up(): void
@@ -26,28 +22,27 @@ return new class extends Migration {
         Schema::table('vehicles', function (Blueprint $table) {
             // Skills / capabilities
             $table->json('skills')->nullable()->after('status');
-
-            // Additional capacity dimensions (weight is already payload_capacity)
-            $table->unsignedDecimal('payload_capacity_volume', 10, 3)->nullable()->comment('Maximum cargo volume in cubic metres')->after('skills');
-            $table->unsignedInteger('payload_capacity_pallets')->nullable()->comment('Maximum pallet count')->after('payload_capacity_volume');
-            $table->unsignedInteger('payload_capacity_parcels')->nullable()->comment('Maximum parcel/package count')->after('payload_capacity_pallets');
-
+            // Multi-dimensional capacity
+            $table->unsignedDecimal('capacity_weight_kg', 10, 2)->nullable()->after('skills');
+            $table->unsignedDecimal('capacity_volume_m3', 10, 3)->nullable()->after('capacity_weight_kg');
+            $table->unsignedInteger('capacity_pallets')->nullable()->after('capacity_volume_m3');
+            $table->unsignedInteger('capacity_parcels')->nullable()->after('capacity_pallets');
             // Route constraints
-            $table->unsignedInteger('max_tasks')->nullable()->after('payload_capacity_parcels');
+            $table->unsignedInteger('max_tasks')->nullable()->after('capacity_parcels');
             $table->time('time_window_start')->nullable()->after('max_tasks');
             $table->time('time_window_end')->nullable()->after('time_window_start');
             $table->boolean('return_to_depot')->default(true)->after('time_window_end');
         });
     }
-
     public function down(): void
     {
         Schema::table('vehicles', function (Blueprint $table) {
             $table->dropColumn([
                 'skills',
-                'payload_capacity_volume',
-                'payload_capacity_pallets',
-                'payload_capacity_parcels',
+                'capacity_weight_kg',
+                'capacity_volume_m3',
+                'capacity_pallets',
+                'capacity_parcels',
                 'max_tasks',
                 'time_window_start',
                 'time_window_end',

--- a/server/migrations/2026_04_08_000001_add_orchestrator_columns_to_vehicles_table.php
+++ b/server/migrations/2026_04_08_000001_add_orchestrator_columns_to_vehicles_table.php
@@ -7,16 +7,18 @@ use Illuminate\Support\Facades\Schema;
 /**
  * Add Orchestrator constraint columns to the vehicles table.
  *
+ * Note: payload weight capacity is already covered by the existing
+ * `payload_capacity` column on the vehicles table and is NOT duplicated here.
+ *
  * New columns:
- *   - skills              JSON array of vehicle capability flags (e.g. ["tail_lift","refrigerated"])
- *   - capacity_weight_kg  Maximum payload weight in kilograms
- *   - capacity_volume_m3  Maximum cargo volume in cubic metres
- *   - capacity_pallets    Maximum pallet count
- *   - capacity_parcels    Maximum parcel/package count
- *   - max_tasks           Maximum number of stops per route
- *   - time_window_start   Default shift start time (HH:MM)
- *   - time_window_end     Default shift end time (HH:MM)
- *   - return_to_depot     Whether the vehicle must return to its start depot
+ *   - skills                      JSON array of vehicle capability flags (e.g. ["tail_lift","refrigerated"])
+ *   - payload_capacity_volume     Maximum cargo volume in cubic metres
+ *   - payload_capacity_pallets    Maximum pallet count
+ *   - payload_capacity_parcels    Maximum parcel/package count
+ *   - max_tasks                   Maximum number of stops per route
+ *   - time_window_start           Default availability start time (HH:MM)
+ *   - time_window_end             Default availability end time (HH:MM)
+ *   - return_to_depot             Whether the vehicle must return to its start depot after a route
  */
 return new class extends Migration {
     public function up(): void
@@ -25,14 +27,13 @@ return new class extends Migration {
             // Skills / capabilities
             $table->json('skills')->nullable()->after('status');
 
-            // Multi-dimensional capacity
-            $table->unsignedDecimal('capacity_weight_kg', 10, 2)->nullable()->after('skills');
-            $table->unsignedDecimal('capacity_volume_m3', 10, 3)->nullable()->after('capacity_weight_kg');
-            $table->unsignedInteger('capacity_pallets')->nullable()->after('capacity_volume_m3');
-            $table->unsignedInteger('capacity_parcels')->nullable()->after('capacity_pallets');
+            // Additional capacity dimensions (weight is already payload_capacity)
+            $table->unsignedDecimal('payload_capacity_volume', 10, 3)->nullable()->comment('Maximum cargo volume in cubic metres')->after('skills');
+            $table->unsignedInteger('payload_capacity_pallets')->nullable()->comment('Maximum pallet count')->after('payload_capacity_volume');
+            $table->unsignedInteger('payload_capacity_parcels')->nullable()->comment('Maximum parcel/package count')->after('payload_capacity_pallets');
 
             // Route constraints
-            $table->unsignedInteger('max_tasks')->nullable()->after('capacity_parcels');
+            $table->unsignedInteger('max_tasks')->nullable()->after('payload_capacity_parcels');
             $table->time('time_window_start')->nullable()->after('max_tasks');
             $table->time('time_window_end')->nullable()->after('time_window_start');
             $table->boolean('return_to_depot')->default(true)->after('time_window_end');
@@ -44,10 +45,9 @@ return new class extends Migration {
         Schema::table('vehicles', function (Blueprint $table) {
             $table->dropColumn([
                 'skills',
-                'capacity_weight_kg',
-                'capacity_volume_m3',
-                'capacity_pallets',
-                'capacity_parcels',
+                'payload_capacity_volume',
+                'payload_capacity_pallets',
+                'payload_capacity_parcels',
                 'max_tasks',
                 'time_window_start',
                 'time_window_end',

--- a/server/migrations/2026_04_08_000004_add_orchestrator_columns_to_payloads_table.php
+++ b/server/migrations/2026_04_08_000004_add_orchestrator_columns_to_payloads_table.php
@@ -5,37 +5,28 @@ use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
 /**
- * Add Orchestrator capacity columns to the payloads table.
+ * Orchestrator payload migration — intentionally empty.
  *
- * New columns:
- *   - capacity_weight_kg  Total payload weight in kilograms (aggregated from entities)
- *   - capacity_volume_m3  Total payload volume in cubic metres
- *   - capacity_pallets    Total pallet count
- *   - capacity_parcels    Total parcel/package count
+ * Payload capacity (weight, volume, pallets, parcels) is computed dynamically
+ * from the payload's entities at orchestration time and does not need to be
+ * stored as denormalised columns on the payloads table. Storing them would
+ * create a synchronisation problem: any entity add/update/remove would require
+ * explicit cache invalidation.
  *
- * These columns allow the Orchestrator to quickly compare payload requirements
- * against vehicle capacity without re-aggregating entity dimensions on every run.
+ * The OrchestrationPayloadBuilder aggregates entity.weight and entity dimensions
+ * directly from the payload->entities relationship instead.
+ *
+ * This migration is kept as a no-op so the migration history remains intact
+ * and the file can be referenced if the decision is ever revisited.
  */
 return new class extends Migration {
     public function up(): void
     {
-        Schema::table('payloads', function (Blueprint $table) {
-            $table->unsignedDecimal('capacity_weight_kg', 10, 2)->nullable()->after('cod_currency');
-            $table->unsignedDecimal('capacity_volume_m3', 10, 3)->nullable()->after('capacity_weight_kg');
-            $table->unsignedInteger('capacity_pallets')->nullable()->after('capacity_volume_m3');
-            $table->unsignedInteger('capacity_parcels')->nullable()->after('capacity_pallets');
-        });
+        // No schema changes — see docblock above.
     }
 
     public function down(): void
     {
-        Schema::table('payloads', function (Blueprint $table) {
-            $table->dropColumn([
-                'capacity_weight_kg',
-                'capacity_volume_m3',
-                'capacity_pallets',
-                'capacity_parcels',
-            ]);
-        });
+        // No schema changes to reverse.
     }
 };

--- a/server/migrations/2026_04_08_000004_add_orchestrator_columns_to_payloads_table.php
+++ b/server/migrations/2026_04_08_000004_add_orchestrator_columns_to_payloads_table.php
@@ -1,32 +1,38 @@
 <?php
-
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
-
 /**
- * Orchestrator payload migration — intentionally empty.
+ * Add Orchestrator capacity columns to the payloads table.
  *
- * Payload capacity (weight, volume, pallets, parcels) is computed dynamically
- * from the payload's entities at orchestration time and does not need to be
- * stored as denormalised columns on the payloads table. Storing them would
- * create a synchronisation problem: any entity add/update/remove would require
- * explicit cache invalidation.
+ * New columns:
+ *   - capacity_weight_kg  Total payload weight in kilograms (aggregated from entities)
+ *   - capacity_volume_m3  Total payload volume in cubic metres
+ *   - capacity_pallets    Total pallet count
+ *   - capacity_parcels    Total parcel/package count
  *
- * The OrchestrationPayloadBuilder aggregates entity.weight and entity dimensions
- * directly from the payload->entities relationship instead.
- *
- * This migration is kept as a no-op so the migration history remains intact
- * and the file can be referenced if the decision is ever revisited.
+ * These columns allow the Orchestrator to quickly compare payload requirements
+ * against vehicle capacity without re-aggregating entity dimensions on every run.
  */
 return new class extends Migration {
     public function up(): void
     {
-        // No schema changes — see docblock above.
+        Schema::table('payloads', function (Blueprint $table) {
+            $table->unsignedDecimal('capacity_weight_kg', 10, 2)->nullable()->after('cod_currency');
+            $table->unsignedDecimal('capacity_volume_m3', 10, 3)->nullable()->after('capacity_weight_kg');
+            $table->unsignedInteger('capacity_pallets')->nullable()->after('capacity_volume_m3');
+            $table->unsignedInteger('capacity_parcels')->nullable()->after('capacity_pallets');
+        });
     }
-
     public function down(): void
     {
-        // No schema changes to reverse.
+        Schema::table('payloads', function (Blueprint $table) {
+            $table->dropColumn([
+                'capacity_weight_kg',
+                'capacity_volume_m3',
+                'capacity_pallets',
+                'capacity_parcels',
+            ]);
+        });
     }
 };

--- a/server/migrations/2026_04_14_000001_drop_redundant_capacity_columns_from_payloads_table.php
+++ b/server/migrations/2026_04_14_000001_drop_redundant_capacity_columns_from_payloads_table.php
@@ -1,0 +1,42 @@
+<?php
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+/**
+ * Drop redundant denormalised capacity columns from the payloads table.
+ *
+ * The columns capacity_weight_kg, capacity_volume_m3, capacity_pallets, and
+ * capacity_parcels were added in migration 2026_04_08_000004 as a cache of
+ * aggregated entity dimensions. Storing them creates a synchronisation problem:
+ * any entity add, update, or removal requires explicit cache invalidation.
+ *
+ * The OrchestrationPayloadBuilder now computes these values dynamically from
+ * the payload->entities relationship at orchestration time, so the columns are
+ * no longer needed.
+ *
+ * Rollback restores the columns as nullable so existing data is not lost if
+ * this migration is reversed.
+ */
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::table('payloads', function (Blueprint $table) {
+            $table->dropColumn([
+                'capacity_weight_kg',
+                'capacity_volume_m3',
+                'capacity_pallets',
+                'capacity_parcels',
+            ]);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('payloads', function (Blueprint $table) {
+            $table->unsignedDecimal('capacity_weight_kg', 10, 2)->nullable()->after('cod_currency');
+            $table->unsignedDecimal('capacity_volume_m3', 10, 3)->nullable()->after('capacity_weight_kg');
+            $table->unsignedInteger('capacity_pallets')->nullable()->after('capacity_volume_m3');
+            $table->unsignedInteger('capacity_parcels')->nullable()->after('capacity_pallets');
+        });
+    }
+};

--- a/server/migrations/2026_04_14_000002_rename_capacity_columns_on_vehicles_table.php
+++ b/server/migrations/2026_04_14_000002_rename_capacity_columns_on_vehicles_table.php
@@ -1,0 +1,48 @@
+<?php
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+/**
+ * Correct orchestrator capacity column names on the vehicles table.
+ *
+ * The columns added in migration 2026_04_08_000001 did not follow the Fleetbase
+ * naming convention for capacity fields. This migration:
+ *
+ *   1. Drops capacity_weight_kg — this is a duplicate of the pre-existing
+ *      payload_capacity column which already represents maximum payload weight.
+ *
+ *   2. Renames the remaining capacity columns to follow the payload_capacity_*
+ *      convention used by the existing payload_capacity column:
+ *        capacity_volume_m3  → payload_capacity_volume
+ *        capacity_pallets    → payload_capacity_pallets
+ *        capacity_parcels    → payload_capacity_parcels
+ *
+ * Rollback reverses the renames and restores capacity_weight_kg as nullable.
+ */
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::table('vehicles', function (Blueprint $table) {
+            // Drop the redundant weight capacity column (payload_capacity already exists)
+            $table->dropColumn('capacity_weight_kg');
+
+            // Rename remaining columns to follow payload_capacity_* convention
+            $table->renameColumn('capacity_volume_m3', 'payload_capacity_volume');
+            $table->renameColumn('capacity_pallets', 'payload_capacity_pallets');
+            $table->renameColumn('capacity_parcels', 'payload_capacity_parcels');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('vehicles', function (Blueprint $table) {
+            // Restore the dropped column
+            $table->unsignedDecimal('capacity_weight_kg', 10, 2)->nullable()->after('skills');
+
+            // Reverse the renames
+            $table->renameColumn('payload_capacity_volume', 'capacity_volume_m3');
+            $table->renameColumn('payload_capacity_pallets', 'capacity_pallets');
+            $table->renameColumn('payload_capacity_parcels', 'capacity_parcels');
+        });
+    }
+};

--- a/server/src/Http/Controllers/Api/v1/OrderController.php
+++ b/server/src/Http/Controllers/Api/v1/OrderController.php
@@ -55,7 +55,14 @@ class OrderController extends Controller
         set_time_limit(180);
 
         // get request input
-        $input = $request->only(['internal_id', 'payload', 'service_quote', 'purchase_rate', 'adhoc', 'adhoc_distance', 'pod_method', 'pod_required', 'scheduled_at', 'status', 'meta', 'notes']);
+        $input = $request->only([
+            'internal_id', 'payload', 'service_quote', 'purchase_rate',
+            'adhoc', 'adhoc_distance', 'pod_method', 'pod_required',
+            'scheduled_at', 'status', 'meta', 'notes',
+            // Orchestrator constraints
+            'time_window_start', 'time_window_end',
+            'required_skills', 'orchestrator_priority',
+        ]);
 
         // Get order config
         $orderConfig = OrderConfig::resolveFromIdentifier($request->only(['type', 'order_config']));
@@ -363,7 +370,13 @@ class OrderController extends Controller
         }
 
         // get request input
-        $input = $request->only(['internal_id', 'payload', 'adhoc', 'adhoc_distance', 'pod_method', 'pod_required', 'scheduled_at', 'meta', 'type', 'status', 'notes']);
+        $input = $request->only([
+            'internal_id', 'payload', 'adhoc', 'adhoc_distance',
+            'pod_method', 'pod_required', 'scheduled_at', 'meta', 'type', 'status', 'notes',
+            // Orchestrator constraints
+            'time_window_start', 'time_window_end',
+            'required_skills', 'orchestrator_priority',
+        ]);
 
         // update payload if new input or change payload by id
         if ($request->isArray('payload')) {

--- a/server/src/Http/Controllers/Api/v1/VehicleController.php
+++ b/server/src/Http/Controllers/Api/v1/VehicleController.php
@@ -26,7 +26,15 @@ class VehicleController extends Controller
     public function create(CreateVehicleRequest $request)
     {
         // get request input
-        $input = $request->only(['status', 'make', 'model', 'year', 'trim', 'type', 'plate_number', 'vin', 'meta', 'online', 'location', 'altitude', 'heading', 'speed']);
+        $input = $request->only([
+            'status', 'make', 'model', 'year', 'trim', 'type', 'plate_number', 'vin',
+            'meta', 'online', 'location', 'altitude', 'heading', 'speed',
+            // Capacity
+            'payload_capacity', 'payload_capacity_volume',
+            'payload_capacity_pallets', 'payload_capacity_parcels',
+            // Orchestrator constraints
+            'skills', 'max_tasks', 'time_window_start', 'time_window_end', 'return_to_depot',
+        ]);
 
         // make sure company is set
         $input['company_uuid'] = session('company');
@@ -97,7 +105,15 @@ class VehicleController extends Controller
         }
 
         // get request input
-        $input = $request->only(['status', 'make', 'model', 'year', 'trim', 'type', 'plate_number', 'vin', 'meta', 'location', 'online', 'altitude', 'heading', 'speed']);
+        $input = $request->only([
+            'status', 'make', 'model', 'year', 'trim', 'type', 'plate_number', 'vin',
+            'meta', 'location', 'online', 'altitude', 'heading', 'speed',
+            // Capacity
+            'payload_capacity', 'payload_capacity_volume',
+            'payload_capacity_pallets', 'payload_capacity_parcels',
+            // Orchestrator constraints
+            'skills', 'max_tasks', 'time_window_start', 'time_window_end', 'return_to_depot',
+        ]);
 
         // vendor assignment
         if ($request->has('vendor')) {

--- a/server/src/Models/Payload.php
+++ b/server/src/Models/Payload.php
@@ -61,7 +61,7 @@ class Payload extends Model
      *
      * @var array
      */
-    protected $fillable = ['_key', 'company_uuid', 'pickup_uuid', 'dropoff_uuid', 'return_uuid', 'current_waypoint_uuid', 'meta', 'payment_method', 'cod_amount', 'cod_currency', 'cod_payment_method', 'type', 'capacity_weight_kg', 'capacity_volume_m3', 'capacity_pallets', 'capacity_parcels'];
+    protected $fillable = ['_key', 'company_uuid', 'pickup_uuid', 'dropoff_uuid', 'return_uuid', 'current_waypoint_uuid', 'meta', 'payment_method', 'cod_amount', 'cod_currency', 'cod_payment_method', 'type'];
 
     /**
      * The attributes that should be cast to native types.
@@ -69,12 +69,7 @@ class Payload extends Model
      * @var array
      */
     protected $casts = [
-        'meta'               => Json::class,
-        // Orchestrator
-        'capacity_weight_kg' => 'decimal:2',
-        'capacity_volume_m3' => 'decimal:3',
-        'capacity_pallets'   => 'integer',
-        'capacity_parcels'   => 'integer',
+        'meta' => Json::class,
     ];
 
     /**

--- a/server/src/Models/Vehicle.php
+++ b/server/src/Models/Vehicle.php
@@ -207,10 +207,9 @@ class Vehicle extends Model
         'lease_expires_at',
         // Orchestrator
         'skills',
-        'capacity_weight_kg',
-        'capacity_volume_m3',
-        'capacity_pallets',
-        'capacity_parcels',
+        'payload_capacity_volume',
+        'payload_capacity_pallets',
+        'payload_capacity_parcels',
         'max_tasks',
         'time_window_start',
         'time_window_end',
@@ -307,13 +306,12 @@ class Vehicle extends Model
         'gvwr'                => 'decimal:2',
         'gcwr'                => 'decimal:2',
         // Orchestrator
-        'skills'              => Json::class,
-        'capacity_weight_kg'  => 'decimal:2',
-        'capacity_volume_m3'  => 'decimal:3',
-        'capacity_pallets'    => 'integer',
-        'capacity_parcels'    => 'integer',
-        'max_tasks'           => 'integer',
-        'return_to_depot'     => 'boolean',
+        'skills'                    => Json::class,
+        'payload_capacity_volume'   => 'decimal:3',
+        'payload_capacity_pallets'  => 'integer',
+        'payload_capacity_parcels'  => 'integer',
+        'max_tasks'                 => 'integer',
+        'return_to_depot'           => 'boolean',
     ];
 
     public function photo(): BelongsTo

--- a/server/src/Orchestration/Support/OrchestrationPayloadBuilder.php
+++ b/server/src/Orchestration/Support/OrchestrationPayloadBuilder.php
@@ -16,9 +16,12 @@ use Illuminate\Support\Collection;
  * adapter (e.g. VroomOrchestrationEngine) calls the builder and then maps the
  * normalized output to its own wire format.
  *
- * The builder now reads first-class orchestrator columns (skills, capacity_*,
- * time_window_*, service_time, orchestrator_priority) added by the 2026-04-08
- * migrations, falling back to custom fields and meta for backwards compatibility.
+ * Vehicle capacity is read from the existing first-class columns on the
+ * vehicles table (payload_capacity, payload_capacity_volume, etc.).
+ *
+ * Order/payload capacity demand is computed dynamically by aggregating the
+ * weight and dimensions of the payload's entities — no denormalised cache
+ * columns are needed or used on the payloads table.
  */
 class OrchestrationPayloadBuilder
 {
@@ -42,6 +45,102 @@ class OrchestrationPayloadBuilder
     }
 
     /**
+     * Compute the multi-dimensional capacity demand for a payload by aggregating
+     * its entities' weight and volume values.
+     *
+     * Returns a 4-element integer array matching the vehicle capacity array:
+     *   [weight_kg, volume_litres, pallets, parcels]
+     *
+     * Weight is normalised to kg from entity.weight_unit.
+     * Volume is derived from entity length × width × height (dimensions_unit normalised to metres)
+     * and expressed in litres (×1000) so it can be stored as an integer for VROOM.
+     *
+     * Falls back to order meta keys (weight_kg, volume_m3, pallets, parcels) for
+     * backwards compatibility with orders that were created before entity-level
+     * dimension data was captured.
+     */
+    protected static function computePayloadDemand(Order $order): array
+    {
+        $payload = $order->payload;
+
+        if ($payload && $payload->entities && $payload->entities->isNotEmpty()) {
+            $totalWeightKg  = 0.0;
+            $totalVolumeLit = 0.0;
+            $totalParcels   = 0;
+
+            foreach ($payload->entities as $entity) {
+                // --- Weight ---
+                $rawWeight = (float) ($entity->weight ?? 0);
+                $weightUnit = strtolower($entity->weight_unit ?? 'kg');
+                $weightKg = match ($weightUnit) {
+                    'g', 'gram', 'grams'              => $rawWeight / 1000,
+                    'lb', 'lbs', 'pound', 'pounds'    => $rawWeight * 0.453592,
+                    'oz', 'ounce', 'ounces'            => $rawWeight * 0.0283495,
+                    't', 'ton', 'tonne', 'tonnes'      => $rawWeight * 1000,
+                    default                            => $rawWeight, // kg assumed
+                };
+                $totalWeightKg += $weightKg;
+
+                // --- Volume (L × W × H → m³ → litres) ---
+                $l    = (float) ($entity->length ?? 0);
+                $w    = (float) ($entity->width ?? 0);
+                $h    = (float) ($entity->height ?? 0);
+                $unit = strtolower($entity->dimensions_unit ?? 'm');
+
+                if ($l > 0 && $w > 0 && $h > 0) {
+                    // Normalise to metres
+                    $factor = match ($unit) {
+                        'cm', 'centimeter', 'centimetre'   => 0.01,
+                        'mm', 'millimeter', 'millimetre'   => 0.001,
+                        'in', 'inch', 'inches'             => 0.0254,
+                        'ft', 'foot', 'feet'               => 0.3048,
+                        default                            => 1.0, // metres assumed
+                    };
+                    $volumeM3    = ($l * $factor) * ($w * $factor) * ($h * $factor);
+                    $totalVolumeLit += $volumeM3 * 1000; // m³ → litres
+                }
+
+                $totalParcels++;
+            }
+
+            return [
+                (int) round($totalWeightKg),
+                (int) round($totalVolumeLit),
+                0, // pallet count not tracked at entity level
+                $totalParcels,
+            ];
+        }
+
+        // Fallback: order meta keys for backwards compatibility
+        return [
+            (int) round((float) ($order->getMeta('weight_kg') ?? 0)),
+            (int) round((float) ($order->getMeta('volume_m3') ?? 0) * 1000),
+            (int) ($order->getMeta('pallets') ?? 0),
+            (int) ($order->getMeta('parcels') ?? 1),
+        ];
+    }
+
+    /**
+     * Build the vehicle capacity array from the vehicle's first-class columns.
+     *
+     * Returns a 4-element integer array:
+     *   [weight_kg, volume_litres, pallets, parcels]
+     *
+     * payload_capacity        — existing column, weight in kg
+     * payload_capacity_volume — new column, volume in m³ (stored as litres for VROOM)
+     * payload_capacity_pallets / payload_capacity_parcels — new columns
+     */
+    protected static function buildVehicleCapacity(Vehicle $vehicle): array
+    {
+        return [
+            (int) round((float) ($vehicle->payload_capacity ?? static::safeMeta($vehicle, 'max_weight_kg', 0))),
+            (int) round((float) ($vehicle->payload_capacity_volume ?? static::safeMeta($vehicle, 'max_volume_m3', 0)) * 1000),
+            (int) ($vehicle->payload_capacity_pallets ?? static::safeMeta($vehicle, 'max_pallets', 0)),
+            (int) ($vehicle->payload_capacity_parcels ?? static::safeMeta($vehicle, 'max_parcels', 100)),
+        ];
+    }
+
+    /**
      * Build the normalized job list from a collection of Orders.
      *
      * Each job contains:
@@ -51,7 +150,7 @@ class OrchestrationPayloadBuilder
      *   - service:       service time in seconds (waypoint.service_time → order meta → default 300)
      *   - time_windows:  [[earliest_unix, latest_unix]] from order.time_window_start/end or scheduled_at
      *   - skills:        integer skill codes from order.required_skills or custom fields
-     *   - amount:        multi-dimensional capacity demand [weight_kg, volume_m3, pallets, parcels]
+     *   - amount:        multi-dimensional capacity demand [weight_kg, volume_litres, pallets, parcels]
      *   - priority:      orchestrator_priority (0–100, higher = more important)
      *   - description:   human-readable label for debugging
      */
@@ -87,14 +186,9 @@ class OrchestrationPayloadBuilder
                 ?? 300
             );
 
-            // --- Capacity demand (multi-dimensional) ---
-            // [weight_kg, volume_m3, pallets, parcels] — must match vehicle capacity array
-            $job['amount'] = [
-                (int) round((float) ($payload?->capacity_weight_kg ?? $order->getMeta('weight_kg') ?? 0)),
-                (int) round((float) ($payload?->capacity_volume_m3 ?? $order->getMeta('volume_m3') ?? 0) * 1000), // store as litres for integer
-                (int) ($payload?->capacity_pallets ?? $order->getMeta('pallets') ?? 0),
-                (int) ($payload?->capacity_parcels ?? $order->getMeta('parcels') ?? 1),
-            ];
+            // --- Capacity demand ---
+            // Aggregated dynamically from payload entities; falls back to order meta.
+            $job['amount'] = static::computePayloadDemand($order);
 
             // --- Time windows ---
             // Prefer explicit orchestrator time_window columns, fall back to scheduled_at
@@ -148,12 +242,7 @@ class OrchestrationPayloadBuilder
             if ($vehicle->return_to_depot && $vehicle->location) {
                 $entry['end'] = [$vehicle->location->getLng(), $vehicle->location->getLat()];
             }
-            $entry['capacity'] = [
-                (int) round((float) ($vehicle->capacity_weight_kg ?? static::safeMeta($vehicle, 'max_weight_kg', 0))),
-                (int) round((float) ($vehicle->capacity_volume_m3 ?? static::safeMeta($vehicle, 'max_volume_m3', 0)) * 1000),
-                (int) ($vehicle->capacity_pallets ?? static::safeMeta($vehicle, 'max_pallets', 0)),
-                (int) ($vehicle->capacity_parcels ?? static::safeMeta($vehicle, 'max_parcels', 100)),
-            ];
+            $entry['capacity'] = static::buildVehicleCapacity($vehicle);
             if ($vehicle->max_tasks !== null && $vehicle->max_tasks > 0) {
                 $entry['max_tasks'] = (int) $vehicle->max_tasks;
             }
@@ -172,6 +261,13 @@ class OrchestrationPayloadBuilder
         })->filter()->values()->toArray();
     }
 
+    /**
+     * Build vehicles for driver+vehicle allocation mode.
+     *
+     * Uses driver.location as the start position, falling back to vehicle.location.
+     * Capacity is read from the vehicle. Time windows prefer the driver's explicit
+     * window, then the driver's active shift, then the vehicle's window.
+     */
     public static function buildVehicles(Collection $vehicles): array
     {
         return $vehicles->map(function (Vehicle $vehicle) {
@@ -193,13 +289,7 @@ class OrchestrationPayloadBuilder
             }
 
             // --- Multi-dimensional capacity ---
-            // [weight_kg, volume_l (×1000 from m3), pallets, parcels]
-            $entry['capacity'] = [
-                (int) round((float) ($vehicle->capacity_weight_kg ?? static::safeMeta($vehicle, 'max_weight_kg', 0))),
-                (int) round((float) ($vehicle->capacity_volume_m3 ?? static::safeMeta($vehicle, 'max_volume_m3', 0)) * 1000),
-                (int) ($vehicle->capacity_pallets ?? static::safeMeta($vehicle, 'max_pallets', 0)),
-                (int) ($vehicle->capacity_parcels ?? static::safeMeta($vehicle, 'max_parcels', 100)),
-            ];
+            $entry['capacity'] = static::buildVehicleCapacity($vehicle);
 
             // --- Max tasks ---
             if ($vehicle->max_tasks !== null && $vehicle->max_tasks > 0) {


### PR DESCRIPTION
## Summary

This PR fixes critical naming inconsistencies and redundant columns introduced with the orchestrator feature in the previous release.

### Problems fixed

**1. Redundant `capacity_weight_kg` on vehicles** — duplicates the existing `payload_capacity` column. Removed; `OrchestrationPayloadBuilder` now reads `payload_capacity` directly.

**2. Non-standard column names on vehicles** — `capacity_volume_m3`, `capacity_pallets`, `capacity_parcels` renamed to `payload_capacity_volume`, `payload_capacity_pallets`, `payload_capacity_parcels` to follow Fleetbase naming convention.

**3. Redundant capacity columns on payloads** — all four payload capacity columns removed entirely; `OrchestrationPayloadBuilder` now computes the VROOM job `amount` array dynamically by aggregating entity `weight`/`dimensions` with full unit normalisation (kg, g, lb, oz, t; m, cm, mm, in, ft).

**4. API controllers did not accept orchestrator fields** — `VehicleController` and `OrderController` `create`/`update` whitelists now include all orchestrator constraint and capacity fields.

### Migration note
Users upgrading from the previous release need to run `php artisan migrate` to apply the column renames.