### PR TITLE
Add orchestrator consumable API and capacity allocation

### DIFF
--- a/addon/components/orchestrator-workbench.js
+++ b/addon/components/orchestrator-workbench.js
@@ -68,7 +68,7 @@ export default class OrchestratorWorkbenchComponent extends Component {
 
     /**
      * User-composed list of phases to execute in sequence.
-     * Each phase: { id, mode, label, engine, orderStatuses, balanceWorkload,
+     * Each phase: { id, mode, label, engine, allocationStrategy, orderStatuses, balanceWorkload,
      *               respectSkills, respectCapacity, returnToDepot, autoCommit }
      */
     @tracked phases = [];
@@ -270,6 +270,7 @@ export default class OrchestratorWorkbenchComponent extends Component {
                 order_statuses: phase.orderStatuses ?? ['created'],
                 options: {
                     engine: phase.engine ?? 'greedy',
+                    allocation_strategy: phase.allocationStrategy ?? 'route_aware',
                     balance_workload: phase.balanceWorkload ?? false,
                     respect_skills: phase.respectSkills ?? true,
                     respect_capacity: phase.respectCapacity ?? true,
@@ -399,6 +400,7 @@ export default class OrchestratorWorkbenchComponent extends Component {
             mode: 'allocate',
             label: 'Allocate',
             engine: 'greedy',
+            allocationStrategy: 'route_aware',
             orderStatuses: ['created'],
             balanceWorkload: false,
             respectSkills: true,

--- a/addon/components/orchestrator/phase-builder.hbs
+++ b/addon/components/orchestrator/phase-builder.hbs
@@ -109,6 +109,27 @@
                         />
                     </InputGroup>
 
+                    {{#if this.shouldShowAllocationStrategy}}
+                        <InputGroup @name={{t "orchestrator.allocation-strategy"}}>
+                            <div class="grid grid-cols-2 gap-1">
+                                {{#each this.allocationStrategyOptions as |opt|}}
+                                    <button
+                                        type="button"
+                                        class="flex items-center justify-center gap-1.5 px-2 py-1.5 rounded border text-xs transition-colors
+                                            {{if
+                                                (eq this.draftPhase.allocationStrategy opt.value)
+                                                'bg-indigo-50 dark:bg-indigo-900/30 border-indigo-400 dark:border-indigo-600 text-indigo-700 dark:text-indigo-300'
+                                                'border-gray-200 dark:border-gray-600 text-gray-600 dark:text-gray-400 hover:border-gray-300 dark:hover:border-gray-500'
+                                            }}"
+                                        {{on "click" (fn this.setDraftOption "allocationStrategy" opt.value)}}
+                                    >
+                                        {{opt.label}}
+                                    </button>
+                                {{/each}}
+                            </div>
+                        </InputGroup>
+                    {{/if}}
+
                     {{! Constraint toggles }}
                     <InputGroup @name={{t "orchestrator.constraints"}}>
                         <div class="space-y-1.5">
@@ -124,10 +145,12 @@
                                 <span class="text-xs text-gray-600 dark:text-gray-400">{{t "orchestrator.balance-workload"}}</span>
                                 <Toggle @isToggled={{this.draftPhase.balanceWorkload}} @onToggle={{fn this.setDraftOption "balanceWorkload"}} />
                             </div>
-                            <div class="flex items-center justify-between">
-                                <span class="text-xs text-gray-600 dark:text-gray-400">{{t "orchestrator.return-to-depot"}}</span>
-                                <Toggle @isToggled={{this.draftPhase.returnToDepot}} @onToggle={{fn this.setDraftOption "returnToDepot"}} />
-                            </div>
+                            {{#if this.shouldShowRouteOptions}}
+                                <div class="flex items-center justify-between">
+                                    <span class="text-xs text-gray-600 dark:text-gray-400">{{t "orchestrator.return-to-depot"}}</span>
+                                    <Toggle @isToggled={{this.draftPhase.returnToDepot}} @onToggle={{fn this.setDraftOption "returnToDepot"}} />
+                                </div>
+                            {{/if}}
                             <div class="flex items-center justify-between">
                                 <span class="text-xs text-gray-600 dark:text-gray-400">{{t "orchestrator.auto-commit"}}</span>
                                 <Toggle @isToggled={{this.draftPhase.autoCommit}} @onToggle={{fn this.setDraftOption "autoCommit"}} />

--- a/addon/components/orchestrator/phase-builder.js
+++ b/addon/components/orchestrator/phase-builder.js
@@ -50,6 +50,7 @@ export default class OrchestratorPhaseBuilderComponent extends Component {
             mode,
             label: this.intl.t(`orchestrator.mode-${mode.replace(/_/g, '-')}`),
             engine: 'greedy',
+            allocationStrategy: 'route_aware',
             orderStatuses: ['created'],
             balanceWorkload: false,
             respectSkills: true,
@@ -125,7 +126,11 @@ export default class OrchestratorPhaseBuilderComponent extends Component {
     }
 
     @action setDraftEngine(engine) {
-        this.draftPhase = { ...this.draftPhase, engine };
+        this.draftPhase = {
+            ...this.draftPhase,
+            engine,
+            allocationStrategy: engine === 'capacity' ? 'capacity_only' : (this.draftPhase.allocationStrategy ?? 'route_aware'),
+        };
     }
 
     @action toggleDraftOrderStatus(status) {
@@ -144,6 +149,21 @@ export default class OrchestratorPhaseBuilderComponent extends Component {
 
     get isEditing() {
         return this.editingIndex !== null && this.draftPhase !== null;
+    }
+
+    get allocationStrategyOptions() {
+        return [
+            { value: 'route_aware', label: this.intl.t('orchestrator.allocation-strategy-route-aware') },
+            { value: 'capacity_only', label: this.intl.t('orchestrator.allocation-strategy-capacity-only') },
+        ];
+    }
+
+    get shouldShowAllocationStrategy() {
+        return this.draftPhase?.mode === 'assign_vehicles' && this.draftPhase?.engine === 'vroom';
+    }
+
+    get shouldShowRouteOptions() {
+        return this.draftPhase?.engine !== 'capacity' && this.draftPhase?.allocationStrategy !== 'capacity_only';
     }
 
     modeLabel(mode) {

--- a/addon/components/orchestrator/resource-panel.hbs
+++ b/addon/components/orchestrator/resource-panel.hbs
@@ -187,6 +187,15 @@
                                     <Badge @status={{vehicle.status}}>{{smart-humanize vehicle.status}}</Badge>
                                 {{/if}}
                             </div>
+                            {{! Position }}
+                            <div
+                                class="flex items-center gap-1 text-xs truncate
+                                    {{if (this.hasPosition vehicle) 'text-green-500 dark:text-green-300' 'text-amber-600 dark:text-amber-300'}}"
+                                title={{if (this.hasPosition vehicle) (point-coordinates vehicle.location) (t "orchestrator.no-position")}}
+                            >
+                                <FaIcon @icon="location-dot" @size="xs" class="w-3 flex-shrink-0" />
+                                <span class="truncate">{{#if (this.hasPosition vehicle)}}{{point-coordinates vehicle.location}}{{else}}{{t "orchestrator.no-position"}}{{/if}}</span>
+                            </div>
                             {{! Assigned driver }}
                             <div class="flex items-center gap-1 text-xs text-gray-500 dark:text-gray-400">
                                 <FaIcon @icon="id-card-alt" @size="xs" class="w-3 flex-shrink-0" />
@@ -245,6 +254,15 @@
                         {{! All fields — always shown, "-" when absent }}
                         <div class="flex-1 min-w-0 space-y-0.5">
                             <div class="text-xs font-semibold truncate dark:text-white">{{or driver.name "-"}}</div>
+                            {{! Position }}
+                            <div
+                                class="flex items-center gap-1 text-xs truncate
+                                    {{if (this.hasPosition driver) 'text-green-500 dark:text-green-300' 'text-amber-600 dark:text-amber-300'}}"
+                                title={{if (this.hasPosition driver) (point-coordinates driver.location) (t "orchestrator.no-position")}}
+                            >
+                                <FaIcon @icon="location-dot" @size="xs" class="w-3 flex-shrink-0" />
+                                <span class="truncate">{{#if (this.hasPosition driver)}}{{point-coordinates driver.location}}{{else}}{{t "orchestrator.no-position"}}{{/if}}</span>
+                            </div>
                             {{! Vehicle }}
                             <div class="flex items-center gap-1 text-xs text-gray-500 dark:text-gray-400">
                                 <FaIcon @icon="truck" @size="xs" class="w-3 flex-shrink-0" />

--- a/addon/components/orchestrator/resource-panel.js
+++ b/addon/components/orchestrator/resource-panel.js
@@ -99,6 +99,10 @@ export default class OrchestratorResourcePanelComponent extends Component {
         return [...(this.args.selectedDriverIds ?? new Set())];
     }
 
+    @action hasPosition(resource) {
+        return resource?.hasInvalidCoordinates === false;
+    }
+
     @action clearAllSelections() {
         this.args.onClearVehicles?.();
         this.args.onClearDrivers?.();

--- a/server/seeders/VroomOrchestrationSeeder.php
+++ b/server/seeders/VroomOrchestrationSeeder.php
@@ -1,0 +1,402 @@
+<?php
+
+namespace Fleetbase\FleetOps\Seeders;
+
+use Fleetbase\FleetOps\Models\Entity;
+use Fleetbase\FleetOps\Models\Order;
+use Fleetbase\FleetOps\Models\Payload;
+use Fleetbase\FleetOps\Models\Place;
+use Fleetbase\FleetOps\Models\Vehicle;
+use Fleetbase\FleetOps\Models\Waypoint;
+use Fleetbase\LaravelMysqlSpatial\Types\Point;
+use Fleetbase\Models\Company;
+use Fleetbase\Seeders\Concerns\ResolvesSeedCompany;
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+
+class VroomOrchestrationSeeder extends Seeder
+{
+    use ResolvesSeedCompany;
+
+    protected const SEED_NAME = 'vroom-orchestration';
+
+    public function run(): void
+    {
+        $company = $this->resolveCompany();
+        if (!$company) {
+            $this->command?->error('No company found. Create a Fleetbase company before running the VROOM orchestration seeder.');
+
+            return;
+        }
+
+        session(['company' => $company->uuid]);
+
+        DB::transaction(function () use ($company) {
+            $this->purgePreviousSeedData();
+
+            $places   = $this->seedPlaces($company);
+            $vehicles = $this->seedVehicles($company);
+            $orders   = $this->seedOrders($company, $places);
+
+            $this->command?->info('Seeded VROOM orchestration test data for company: ' . $company->public_id);
+            $this->command?->line('Order IDs: ' . implode(', ', array_map(fn (Order $order) => $order->public_id, $orders)));
+            $this->command?->line('Vehicle IDs: ' . implode(', ', array_map(fn (Vehicle $vehicle) => $vehicle->public_id, $vehicles)));
+        });
+    }
+
+    protected function resolveCompany(): ?Company
+    {
+        return $this->resolveSeedCompany(
+            'FLEETOPS_VROOM_SEED_COMPANY_UUID',
+            'FLEETOPS_VROOM_SEED_COMPANY_PUBLIC_ID'
+        );
+    }
+
+    protected function purgePreviousSeedData(): void
+    {
+        $payloadUuids = $this->seeded(Payload::query())->pluck('uuid');
+
+        $this->seeded(Order::query())->forceDelete();
+        Entity::whereIn('payload_uuid', $payloadUuids)->forceDelete();
+        Waypoint::whereIn('payload_uuid', $payloadUuids)->forceDelete();
+        $this->seeded(Payload::query())->forceDelete();
+        $this->seeded(Vehicle::query())->forceDelete();
+        $this->seeded(Place::query())->forceDelete();
+    }
+
+    protected function seeded($query)
+    {
+        return $query->where('meta->seed', static::SEED_NAME);
+    }
+
+    protected function meta(string $seedId, array $extra = []): array
+    {
+        return array_merge([
+            'seed'    => static::SEED_NAME,
+            'seed_id' => $seedId,
+        ], $extra);
+    }
+
+    protected function seedPlaces(Company $company): array
+    {
+        $places = [
+            'depot' => [
+                'seed_id'   => 'depot_tanjong_pagar',
+                'name'      => 'VROOM Test Depot - Tanjong Pagar',
+                'street1'   => '1 Raffles Quay',
+                'city'      => 'Singapore',
+                'country'   => 'SG',
+                'lat'       => 1.2816,
+                'lng'       => 103.8510,
+            ],
+            'orchard' => [
+                'seed_id'   => 'dropoff_orchard',
+                'name'      => 'VROOM Test Dropoff - Orchard',
+                'street1'   => '2 Orchard Turn',
+                'city'      => 'Singapore',
+                'country'   => 'SG',
+                'lat'       => 1.3048,
+                'lng'       => 103.8318,
+            ],
+            'changi' => [
+                'seed_id'   => 'dropoff_changi',
+                'name'      => 'VROOM Test Dropoff - Changi',
+                'street1'   => '80 Airport Boulevard',
+                'city'      => 'Singapore',
+                'country'   => 'SG',
+                'lat'       => 1.3644,
+                'lng'       => 103.9915,
+            ],
+            'woodlands' => [
+                'seed_id'   => 'dropoff_woodlands',
+                'name'      => 'VROOM Test Dropoff - Woodlands',
+                'street1'   => '1 Woodlands Square',
+                'city'      => 'Singapore',
+                'country'   => 'SG',
+                'lat'       => 1.4360,
+                'lng'       => 103.7860,
+            ],
+            'rochor' => [
+                'seed_id'   => 'waypoint_rochor',
+                'name'      => 'VROOM Test Waypoint - Rochor',
+                'street1'   => '1 Rochor Canal Road',
+                'city'      => 'Singapore',
+                'country'   => 'SG',
+                'lat'       => 1.3039,
+                'lng'       => 103.8520,
+            ],
+            'novena' => [
+                'seed_id'   => 'waypoint_novena',
+                'name'      => 'VROOM Test Waypoint - Novena',
+                'street1'   => '10 Sinaran Drive',
+                'city'      => 'Singapore',
+                'country'   => 'SG',
+                'lat'       => 1.3206,
+                'lng'       => 103.8439,
+            ],
+            'serangoon' => [
+                'seed_id'   => 'waypoint_serangoon',
+                'name'      => 'VROOM Test Waypoint - Serangoon',
+                'street1'   => '23 Serangoon Central',
+                'city'      => 'Singapore',
+                'country'   => 'SG',
+                'lat'       => 1.3508,
+                'lng'       => 103.8723,
+            ],
+            'paya_lebar' => [
+                'seed_id'   => 'waypoint_paya_lebar',
+                'name'      => 'VROOM Test Waypoint - Paya Lebar',
+                'street1'   => '10 Paya Lebar Road',
+                'city'      => 'Singapore',
+                'country'   => 'SG',
+                'lat'       => 1.3174,
+                'lng'       => 103.8927,
+            ],
+            'tampines' => [
+                'seed_id'   => 'waypoint_tampines',
+                'name'      => 'VROOM Test Waypoint - Tampines',
+                'street1'   => '4 Tampines Central 5',
+                'city'      => 'Singapore',
+                'country'   => 'SG',
+                'lat'       => 1.3525,
+                'lng'       => 103.9447,
+            ],
+        ];
+
+        return collect($places)->mapWithKeys(function (array $place, string $key) use ($company) {
+            $model = new Place();
+            $model->forceFill([
+                'uuid'         => (string) Str::uuid(),
+                'company_uuid' => $company->uuid,
+                'name'         => $place['name'],
+                'street1'      => $place['street1'],
+                'city'         => $place['city'],
+                'country'      => $place['country'],
+                'location'     => new Point($place['lat'], $place['lng']),
+                'meta'         => $this->meta($place['seed_id']),
+            ])->save();
+
+            return [$key => $model];
+        })->all();
+    }
+
+    protected function seedVehicles(Company $company): array
+    {
+        $vehicles = [
+            [
+                'seed_id'   => 'central_1',
+                'name'      => 'VROOM Test Van - Central',
+                'make'      => 'Nissan',
+                'model'     => 'NV200',
+                'lat'       => 1.2798,
+                'lng'       => 103.8500,
+                'capacity'  => [120, 4.5, 1, 20],
+            ],
+            [
+                'seed_id'   => 'east_1',
+                'name'      => 'VROOM Test Van - East',
+                'make'      => 'Toyota',
+                'model'     => 'HiAce',
+                'lat'       => 1.3349,
+                'lng'       => 103.9617,
+                'capacity'  => [250, 8, 2, 40],
+            ],
+            [
+                'seed_id'   => 'north_1',
+                'name'      => 'VROOM Test Van - North',
+                'make'      => 'Mercedes-Benz',
+                'model'     => 'Sprinter',
+                'lat'       => 1.4326,
+                'lng'       => 103.7856,
+                'capacity'  => [500, 16, 4, 80],
+            ],
+            [
+                'seed_id'   => 'west_1',
+                'name'      => 'VROOM Test Van - West',
+                'make'      => 'Ford',
+                'model'     => 'Transit',
+                'lat'       => 1.3345,
+                'lng'       => 103.7420,
+                'capacity'  => [90, 3, 0, 12],
+            ],
+            [
+                'seed_id'   => 'capacity_only_heavy_1',
+                'name'      => 'VROOM Test Capacity Truck - No Position',
+                'make'      => 'Isuzu',
+                'model'     => 'NPR',
+                'capacity'  => [900, 24, 8, 160],
+                'skills'    => ['tail_lift'],
+                'max_tasks' => 10,
+            ],
+            [
+                'seed_id'   => 'capacity_only_cold_1',
+                'name'      => 'VROOM Test Cold Chain Van - No Position',
+                'make'      => 'Hyundai',
+                'model'     => 'H350',
+                'capacity'  => [350, 10, 3, 60],
+                'skills'    => ['cold_chain'],
+                'max_tasks' => 8,
+            ],
+        ];
+
+        return collect($vehicles)->mapWithKeys(function (array $vehicle) use ($company) {
+            $model = new Vehicle();
+            $model->forceFill([
+                'uuid'                     => (string) Str::uuid(),
+                'company_uuid'             => $company->uuid,
+                'name'                     => $vehicle['name'],
+                'make'                     => $vehicle['make'],
+                'model'                    => $vehicle['model'],
+                'year'                     => '2024',
+                'type'                     => 'van',
+                'status'                   => 'active',
+                'online'                   => true,
+                'location'                 => isset($vehicle['lat'], $vehicle['lng']) ? new Point($vehicle['lat'], $vehicle['lng']) : null,
+                'skills'                   => $vehicle['skills'] ?? [],
+                'payload_capacity'         => $vehicle['capacity'][0],
+                'payload_capacity_volume'  => $vehicle['capacity'][1],
+                'payload_capacity_pallets' => $vehicle['capacity'][2],
+                'payload_capacity_parcels' => $vehicle['capacity'][3],
+                'max_tasks'                => $vehicle['max_tasks'] ?? 6,
+                'return_to_depot'          => false,
+                'meta'                     => $this->meta($vehicle['seed_id'], [
+                    'location_state' => isset($vehicle['lat'], $vehicle['lng']) ? 'set' : 'not_set',
+                    'capacity'       => [
+                        'weight_kg'     => $vehicle['capacity'][0],
+                        'volume_m3'     => $vehicle['capacity'][1],
+                        'pallets'       => $vehicle['capacity'][2],
+                        'parcels'       => $vehicle['capacity'][3],
+                    ],
+                ]),
+            ])->save();
+
+            return [$vehicle['seed_id'] => $model];
+        })->all();
+    }
+
+    protected function seedOrders(Company $company, array $places): array
+    {
+        $orders = [
+            'endpoint_only' => [
+                'payload_seed_id' => 'endpoint_only',
+                'name'       => 'VROOM Test Order - Pickup Dropoff',
+                'pickup'     => $places['depot'],
+                'dropoff'    => $places['orchard'],
+                'waypoints'  => [],
+                'entities'   => [
+                    ['name' => 'Small carton', 'type' => 'parcel', 'weight' => 12, 'weight_unit' => 'kg', 'length' => 60, 'width' => 40, 'height' => 35, 'dimensions_unit' => 'cm'],
+                    ['name' => 'Fragile tote', 'type' => 'parcel', 'weight' => 8, 'weight_unit' => 'kg', 'length' => 50, 'width' => 35, 'height' => 30, 'dimensions_unit' => 'cm'],
+                ],
+            ],
+            'waypoint_only' => [
+                'payload_seed_id' => 'waypoint_only',
+                'name'       => 'VROOM Test Order - Waypoints Only',
+                'pickup'     => null,
+                'dropoff'    => null,
+                'waypoints'  => [$places['rochor'], $places['novena'], $places['serangoon']],
+                'entities'   => [
+                    ['name' => 'Multi-stop parcel 1', 'type' => 'parcel', 'weight' => 25, 'weight_unit' => 'kg', 'length' => 80, 'width' => 50, 'height' => 40, 'dimensions_unit' => 'cm'],
+                    ['name' => 'Multi-stop parcel 2', 'type' => 'parcel', 'weight' => 18, 'weight_unit' => 'kg', 'length' => 70, 'width' => 45, 'height' => 35, 'dimensions_unit' => 'cm'],
+                    ['name' => 'Multi-stop parcel 3', 'type' => 'parcel', 'weight' => 15, 'weight_unit' => 'kg', 'length' => 65, 'width' => 40, 'height' => 35, 'dimensions_unit' => 'cm'],
+                ],
+            ],
+            'mixed' => [
+                'payload_seed_id' => 'mixed',
+                'name'       => 'VROOM Test Order - Mixed Stops',
+                'pickup'     => $places['depot'],
+                'dropoff'    => $places['changi'],
+                'waypoints'  => [$places['paya_lebar'], $places['tampines']],
+                'entities'   => [
+                    ['name' => 'Heavy equipment crate', 'type' => 'freight', 'weight' => 180, 'weight_unit' => 'kg', 'length' => 120, 'width' => 80, 'height' => 90, 'dimensions_unit' => 'cm'],
+                    ['name' => 'Accessory box', 'type' => 'parcel', 'weight' => 22, 'weight_unit' => 'kg', 'length' => 75, 'width' => 55, 'height' => 45, 'dimensions_unit' => 'cm'],
+                ],
+            ],
+            'single_waypoint' => [
+                'payload_seed_id' => 'single_waypoint',
+                'name'       => 'VROOM Test Order - Single Waypoint',
+                'pickup'     => null,
+                'dropoff'    => null,
+                'waypoints'  => [$places['woodlands']],
+                'entities'   => [
+                    ['name' => 'Oversized sample case', 'type' => 'parcel', 'weight' => 60, 'weight_unit' => 'kg', 'length' => 100, 'width' => 60, 'height' => 60, 'dimensions_unit' => 'cm'],
+                ],
+            ],
+        ];
+
+        return collect($orders)->mapWithKeys(function (array $definition, string $seedId) use ($company) {
+            $payload = $this->createPayload($company, $definition);
+            $order   = new Order();
+            $order->forceFill([
+                'uuid'                  => (string) Str::uuid(),
+                'internal_id'           => 'VROOM-SEED-' . Str::of($seedId)->upper(),
+                'company_uuid'          => $company->uuid,
+                'payload_uuid'          => $payload->uuid,
+                'status'                => 'created',
+                'type'                  => 'transport',
+                'notes'                 => $definition['name'],
+                'orchestrator_priority' => 50,
+                'required_skills'       => [],
+                'meta'                  => $this->meta($seedId),
+            ])->save();
+
+            $this->seedEntities($company, $payload, $definition['entities'] ?? []);
+
+            return [$seedId => $order];
+        })->all();
+    }
+
+    protected function createPayload(Company $company, array $definition): Payload
+    {
+        $payload = new Payload();
+        $payload->forceFill([
+            'uuid'         => (string) Str::uuid(),
+            'company_uuid' => $company->uuid,
+            'pickup_uuid'  => $definition['pickup']?->uuid,
+            'dropoff_uuid' => $definition['dropoff']?->uuid,
+            'type'         => 'transport',
+            'meta'         => $this->meta($definition['payload_seed_id']),
+        ])->save();
+
+        foreach ($definition['waypoints'] as $index => $place) {
+            $waypoint = new Waypoint();
+            $waypoint->forceFill([
+                'uuid'         => (string) Str::uuid(),
+                '_import_id'   => static::SEED_NAME . ':waypoint:' . $definition['payload_seed_id'] . ':' . ($index + 1),
+                'company_uuid' => $company->uuid,
+                'payload_uuid' => $payload->uuid,
+                'place_uuid'   => $place->uuid,
+                'type'         => 'dropoff',
+                'order'        => $index + 1,
+                'service_time' => 300,
+            ]);
+
+            Waypoint::withoutEvents(fn () => $waypoint->save());
+        }
+
+        return $payload;
+    }
+
+    protected function seedEntities(Company $company, Payload $payload, array $entities): void
+    {
+        foreach ($entities as $index => $definition) {
+            $entity = new Entity();
+            $entity->forceFill([
+                'uuid'            => (string) Str::uuid(),
+                'company_uuid'    => $company->uuid,
+                'payload_uuid'    => $payload->uuid,
+                'name'            => $definition['name'],
+                'type'            => $definition['type'],
+                'weight'          => $definition['weight'],
+                'weight_unit'     => $definition['weight_unit'],
+                'length'          => $definition['length'],
+                'width'           => $definition['width'],
+                'height'          => $definition['height'],
+                'dimensions_unit' => $definition['dimensions_unit'],
+                'meta'            => $this->meta($payload->getMeta('seed_id') . '_' . ($index + 1)),
+            ]);
+
+            Entity::withoutEvents(fn () => $entity->save());
+        }
+    }
+}

--- a/server/src/Http/Controllers/Api/v1/OrchestrationController.php
+++ b/server/src/Http/Controllers/Api/v1/OrchestrationController.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Fleetbase\FleetOps\Http\Controllers\Api\v1;
+
+use Fleetbase\FleetOps\Http\Controllers\Internal\v1\OrchestrationController as InternalOrchestrationController;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+/**
+ * Public consumable API for FleetOps orchestration.
+ *
+ * This controller delegates orchestration behavior to the internal workbench
+ * controller and only changes the public API serialization boundary.
+ */
+class OrchestrationController extends InternalOrchestrationController
+{
+    public function run(Request $request): JsonResponse
+    {
+        return $this->publicResponse(parent::run($request));
+    }
+
+    public function commit(Request $request): JsonResponse
+    {
+        return $this->publicResponse(parent::commit($request));
+    }
+
+    protected function publicResponse(JsonResponse $response): JsonResponse
+    {
+        return response()->json(
+            $this->sanitizePublicPayload($response->getData(true)),
+            $response->getStatusCode()
+        );
+    }
+
+    /**
+     * Recursively remove internal identifiers from public orchestrator payloads.
+     */
+    protected function sanitizePublicPayload(mixed $payload): mixed
+    {
+        if (!is_array($payload)) {
+            return $payload;
+        }
+
+        $sanitized = [];
+
+        foreach ($payload as $key => $value) {
+            if (is_string($key) && $this->isInternalIdentifierKey($key)) {
+                continue;
+            }
+
+            $sanitized[$key] = $this->sanitizePublicPayload($value);
+        }
+
+        return $sanitized;
+    }
+
+    protected function isInternalIdentifierKey(string $key): bool
+    {
+        return $key === 'uuid'
+            || str_ends_with($key, '_uuid')
+            || $key === 'internal_id'
+            || $key === 'company_uuid';
+    }
+}

--- a/server/src/Orchestration/Engines/CapacityAllocationEngine.php
+++ b/server/src/Orchestration/Engines/CapacityAllocationEngine.php
@@ -1,0 +1,220 @@
+<?php
+
+namespace Fleetbase\FleetOps\Orchestration\Engines;
+
+use Fleetbase\FleetOps\Orchestration\Contracts\OrchestrationEngineInterface;
+use Fleetbase\FleetOps\Orchestration\Support\OrchestrationPayloadBuilder;
+use Illuminate\Support\Collection;
+
+/**
+ * CapacityAllocationEngine.
+ *
+ * Deterministic built-in engine for clients who need feasibility allocation
+ * by capacity, skills, and task limits without route geometry or vehicle GPS.
+ */
+class CapacityAllocationEngine implements OrchestrationEngineInterface
+{
+    public function getName(): string
+    {
+        return 'Capacity (built-in)';
+    }
+
+    public function getIdentifier(): string
+    {
+        return 'capacity';
+    }
+
+    public function allocate(Collection $orders, Collection $vehicles, array $options = []): array
+    {
+        $respectCapacity = (bool) ($options['respect_capacity'] ?? true);
+        $respectSkills   = (bool) ($options['respect_skills'] ?? true);
+        $balanceWorkload = (bool) ($options['balance_workload'] ?? false);
+
+        $tasks       = OrchestrationPayloadBuilder::buildCapacityTasks($orders);
+        $vehiclePool = $this->buildVehiclePool(OrchestrationPayloadBuilder::buildCapacityVehicles($vehicles));
+
+        $assignments = [];
+        $unassigned  = [];
+        $reasons     = [];
+
+        foreach ($this->sortTasks($tasks) as $task) {
+            if (!empty($task['invalid'])) {
+                $this->markUnassigned($task['id'], $task['reason'] ?? 'invalid_task', $unassigned, $reasons);
+                continue;
+            }
+
+            $bestIndex = $this->findVehicleIndex($vehiclePool, $task, $respectCapacity, $respectSkills, $balanceWorkload);
+            if ($bestIndex === null) {
+                $this->markUnassigned($task['id'], $this->resolveFailureReason($vehiclePool, $task, $respectCapacity, $respectSkills), $unassigned, $reasons);
+                continue;
+            }
+
+            $sequence = ++$vehiclePool[$bestIndex]['assigned'];
+            $this->consumeCapacity($vehiclePool[$bestIndex]['remaining'], $task['amount'] ?? [0, 0, 0, 0]);
+
+            $assignments[] = [
+                'order_id'   => $task['id'],
+                'vehicle_id' => $vehiclePool[$bestIndex]['id'],
+                'driver_id'  => $vehiclePool[$bestIndex]['driver_id'],
+                'sequence'   => $sequence,
+                'arrival'    => null,
+                'duration'   => null,
+                'distance'   => null,
+            ];
+        }
+
+        return [
+            'assignments' => $assignments,
+            'unassigned'  => array_values(array_unique($unassigned)),
+            'summary'     => [
+                'engine'               => 'capacity',
+                'allocation_strategy'  => 'capacity_only',
+                'assigned'             => count($assignments),
+                'unassigned'           => count(array_unique($unassigned)),
+                'unassigned_reasons'   => $reasons,
+                'respect_capacity'     => $respectCapacity,
+                'respect_skills'       => $respectSkills,
+                'balance_workload'     => $balanceWorkload,
+            ],
+        ];
+    }
+
+    protected function buildVehiclePool(array $vehicles): array
+    {
+        return array_map(fn (array $vehicle) => [
+            'id'        => $vehicle['id'],
+            'driver_id' => $vehicle['driver_id'] ?? null,
+            'capacity'  => $this->normalizeVector($vehicle['capacity'] ?? [0, 0, 0, 0]),
+            'remaining' => $this->normalizeVector($vehicle['capacity'] ?? [0, 0, 0, 0]),
+            'skills'    => $vehicle['skills'] ?? [],
+            'max_tasks' => $vehicle['max_tasks'] ?? null,
+            'assigned'  => 0,
+        ], $vehicles);
+    }
+
+    protected function sortTasks(array $tasks): array
+    {
+        usort($tasks, fn (array $a, array $b) => ($b['priority'] ?? 0) <=> ($a['priority'] ?? 0));
+
+        return $tasks;
+    }
+
+    protected function findVehicleIndex(array $vehiclePool, array $task, bool $respectCapacity, bool $respectSkills, bool $balanceWorkload): ?int
+    {
+        $eligible = [];
+
+        foreach ($vehiclePool as $index => $vehicle) {
+            if (!$this->isVehicleFeasible($vehicle, $task, $respectCapacity, $respectSkills)) {
+                continue;
+            }
+
+            $eligible[] = $index;
+        }
+
+        if (empty($eligible)) {
+            return null;
+        }
+
+        if (!$balanceWorkload) {
+            return $eligible[0];
+        }
+
+        usort($eligible, function (int $a, int $b) use ($vehiclePool) {
+            $assignedCompare = $vehiclePool[$a]['assigned'] <=> $vehiclePool[$b]['assigned'];
+            if ($assignedCompare !== 0) {
+                return $assignedCompare;
+            }
+
+            return array_sum($vehiclePool[$b]['remaining']) <=> array_sum($vehiclePool[$a]['remaining']);
+        });
+
+        return $eligible[0];
+    }
+
+    protected function isVehicleFeasible(array $vehicle, array $task, bool $respectCapacity, bool $respectSkills): bool
+    {
+        if ($vehicle['max_tasks'] !== null && $vehicle['assigned'] >= $vehicle['max_tasks']) {
+            return false;
+        }
+
+        if ($respectSkills && !$this->hasRequiredSkills($vehicle['skills'], $task['skills'] ?? [])) {
+            return false;
+        }
+
+        if ($respectCapacity && !$this->hasCapacity($vehicle['remaining'], $task['amount'] ?? [0, 0, 0, 0])) {
+            return false;
+        }
+
+        return true;
+    }
+
+    protected function hasRequiredSkills(array $vehicleSkills, array $requiredSkills): bool
+    {
+        if (empty($requiredSkills)) {
+            return true;
+        }
+
+        return empty(array_diff($requiredSkills, $vehicleSkills));
+    }
+
+    protected function hasCapacity(array $remaining, array $demand): bool
+    {
+        foreach ($this->normalizeVector($demand) as $index => $amount) {
+            if ($amount > ($remaining[$index] ?? 0)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    protected function consumeCapacity(array &$remaining, array $demand): void
+    {
+        foreach ($this->normalizeVector($demand) as $index => $amount) {
+            $remaining[$index] = max(0, ($remaining[$index] ?? 0) - $amount);
+        }
+    }
+
+    protected function resolveFailureReason(array $vehiclePool, array $task, bool $respectCapacity, bool $respectSkills): string
+    {
+        if (empty($vehiclePool)) {
+            return 'no_available_vehicle';
+        }
+
+        $capacityEligible = false;
+        $skillsEligible   = false;
+        $taskEligible     = false;
+
+        foreach ($vehiclePool as $vehicle) {
+            $capacityEligible = $capacityEligible || !$respectCapacity || $this->hasCapacity($vehicle['remaining'], $task['amount'] ?? [0, 0, 0, 0]);
+            $skillsEligible   = $skillsEligible || !$respectSkills || $this->hasRequiredSkills($vehicle['skills'], $task['skills'] ?? []);
+            $taskEligible     = $taskEligible || $vehicle['max_tasks'] === null || $vehicle['assigned'] < $vehicle['max_tasks'];
+        }
+
+        if (!$capacityEligible) {
+            return 'capacity_exceeded';
+        }
+        if (!$skillsEligible) {
+            return 'missing_required_skills';
+        }
+        if (!$taskEligible) {
+            return 'max_tasks_exceeded';
+        }
+
+        return 'no_available_vehicle';
+    }
+
+    protected function normalizeVector(array $vector): array
+    {
+        return array_pad(array_map(fn ($value) => max(0, (int) round((float) $value)), array_values($vector)), 4, 0);
+    }
+
+    protected function markUnassigned(string $orderId, string $reason, array &$unassigned, array &$reasons): void
+    {
+        $unassigned[] = $orderId;
+        $reasons[]    = [
+            'order_id' => $orderId,
+            'reason'   => $reason,
+        ];
+    }
+}

--- a/server/src/Orchestration/Engines/VroomOrchestrationEngine.php
+++ b/server/src/Orchestration/Engines/VroomOrchestrationEngine.php
@@ -50,7 +50,7 @@ class VroomOrchestrationEngine implements OrchestrationEngineInterface
     /**
      * Run the VROOM VRP solver.
      *
-     * Constructs a VROOM-format payload from the normalized jobs/vehicles
+     * Constructs a VROOM-format payload from the normalized route tasks/vehicles
      * produced by OrchestrationPayloadBuilder, calls the VROOM HTTP API, and
      * maps the response back to the standard OrchestrationEngineInterface result
      * shape.
@@ -59,30 +59,56 @@ class VroomOrchestrationEngine implements OrchestrationEngineInterface
      */
     public function allocate(Collection $orders, Collection $vehicles, array $options = []): array
     {
-        $jobs          = OrchestrationPayloadBuilder::buildJobs($orders);
+        if (($options['allocation_strategy'] ?? null) === 'capacity_only') {
+            return $this->allocateCapacityOnly($orders, $vehicles, $options);
+        }
+
+        $tasks         = OrchestrationPayloadBuilder::buildRouteTasks($orders);
         $vroomVehicles = OrchestrationPayloadBuilder::buildVehicles($vehicles);
 
-        if (empty($jobs)) {
-            return ['assignments' => [], 'unassigned' => [], 'summary' => []];
+        [$routeTasks, $invalidTasks] = $this->partitionRouteTasks($tasks);
+
+        if (empty($routeTasks)) {
+            return $this->mergeInvalidTasks([
+                'assignments' => [],
+                'unassigned'  => [],
+                'summary'     => [],
+            ], $invalidTasks);
         }
+
+        $jobIdReverse = [];
+        $profile      = $options['profile'] ?? env('VROOM_PROFILE', 'driving');
 
         // Map normalized vehicle entries to VROOM vehicle objects.
         // The 'driver_id' key is not part of the VROOM spec — we carry it in
         // a description field and use it when mapping results back.
         $vroomPayload = [
-            'jobs'     => $jobs,
-            'vehicles' => array_map(function (array $v) {
+            'jobs'      => [],
+            'shipments' => [],
+            'vehicles' => array_map(function (array $v) use ($profile) {
                 $vehicle = [
                     'id'          => crc32($v['id']), // VROOM requires integer IDs
                     'description' => json_encode(['vehicle_id' => $v['id'], 'driver_id' => $v['driver_id']]),
                     'start'       => $v['start'],
                     'capacity'    => $v['capacity'],
                 ];
+                if ($profile) {
+                    $vehicle['profile'] = $profile;
+                }
+                if (isset($v['end'])) {
+                    $vehicle['end'] = $v['end'];
+                }
                 if (isset($v['time_window'])) {
                     $vehicle['time_window'] = $v['time_window'];
                 }
                 if (isset($v['skills'])) {
                     $vehicle['skills'] = $v['skills'];
+                }
+                if (isset($v['max_tasks'])) {
+                    $vehicle['max_tasks'] = $v['max_tasks'];
+                }
+                if (isset($v['max_travel_time'])) {
+                    $vehicle['max_travel_time'] = $v['max_travel_time'];
                 }
 
                 return $vehicle;
@@ -92,48 +118,182 @@ class VroomOrchestrationEngine implements OrchestrationEngineInterface
             ],
         ];
 
-        // Map job IDs to integer IDs for VROOM, keeping a reverse lookup
-        $jobIdMap     = [];
+        foreach ($routeTasks as $task) {
+            if (count($task['stops']) > 1) {
+                $shipment = $this->mapTaskToShipment($task, $jobIdReverse);
+                if ($shipment) {
+                    $vroomPayload['shipments'][] = $shipment;
+                }
+
+                continue;
+            }
+
+            $job = $this->mapTaskToVroomJob($task, $jobIdReverse);
+            if ($job) {
+                $vroomPayload['jobs'][] = $job;
+            }
+        }
+
+        if (empty($vroomPayload['jobs'])) {
+            unset($vroomPayload['jobs']);
+        }
+        if (empty($vroomPayload['shipments'])) {
+            unset($vroomPayload['shipments']);
+        }
+
+        $result = $this->callVroom($vroomPayload);
+
+        return $this->mergeInvalidTasks(
+            $this->mapVroomResponse($result, $jobIdReverse),
+            $invalidTasks
+        );
+    }
+
+    protected function allocateCapacityOnly(Collection $orders, Collection $vehicles, array $options = []): array
+    {
+        $tasks         = OrchestrationPayloadBuilder::buildCapacityTasks($orders);
+        $vroomVehicles = OrchestrationPayloadBuilder::buildCapacityVehicles($vehicles);
+
+        [$capacityTasks, $invalidTasks] = $this->partitionRouteTasks($tasks);
+
+        if (empty($capacityTasks)) {
+            return $this->mergeInvalidTasks([
+                'assignments' => [],
+                'unassigned'  => [],
+                'summary'     => [
+                    'engine'              => 'vroom',
+                    'allocation_strategy' => 'capacity_only',
+                ],
+            ], $invalidTasks);
+        }
+
         $jobIdReverse = [];
-        foreach ($vroomPayload['jobs'] as &$job) {
-            $intId                = crc32($job['id']);
-            $jobIdReverse[$intId] = $job['id'];
-            $job['id']            = $intId;
-            $jobIdMap[$job['id']] = true;
-        }
-        unset($job);
+        $vroomPayload = $this->buildCapacityOnlyPayload($capacityTasks, $vroomVehicles, $options, $jobIdReverse);
 
-        // ── Resolve connection config ─────────────────────────────────────────
-        $baseUri = $this->resolveVroomBaseUri();
-        $endpointMode = $this->resolveVroomEndpointMode();
-        $timeout = (int) env('VROOM_TIMEOUT', 30);
-
-        $apiKey = $this->resolveVroomApiKey();
-
-        // Build the solve URL — append api_key as query param when present.
-        $solveUrl = rtrim($baseUri, '/');
-        if ($endpointMode !== 'binary') {
-            $solveUrl .= '/solve';
-        }
-        if ($apiKey) {
-            $solveUrl .= '?api_key=' . urlencode($apiKey);
+        if (empty($vroomPayload['vehicles'])) {
+            return $this->mergeInvalidTasks([
+                'assignments' => [],
+                'unassigned'  => array_column($capacityTasks, 'id'),
+                'summary'     => [
+                    'engine'              => 'vroom',
+                    'allocation_strategy' => 'capacity_only',
+                    'assigned'            => 0,
+                    'unassigned'          => count($capacityTasks),
+                    'unassigned_reasons'  => array_map(fn (array $task) => [
+                        'order_id' => $task['id'],
+                        'reason'   => 'no_available_vehicle',
+                    ], $capacityTasks),
+                ],
+            ], $invalidTasks);
         }
 
-        // ── Call VROOM ────────────────────────────────────────────────────────
-        try {
-            $response = Http::timeout($timeout)->post($solveUrl, $vroomPayload);
-        } catch (\Exception $e) {
-            Log::error('[VroomOrchestrationEngine] HTTP request failed: ' . $e->getMessage());
-            throw new \RuntimeException('VROOM allocation engine is unavailable: ' . $e->getMessage() . ' — ensure VROOM_HOST is reachable or switch to the built-in greedy engine.', 0, $e);
+        $result = $this->mapVroomResponse($this->callVroom($vroomPayload), $jobIdReverse);
+
+        $result['summary'] = array_merge($result['summary'] ?? [], [
+            'engine'              => 'vroom',
+            'allocation_strategy' => 'capacity_only',
+        ]);
+
+        return $this->mergeInvalidTasks($result, $invalidTasks);
+    }
+
+    protected function buildCapacityOnlyPayload(array $capacityTasks, array $vroomVehicles, array $options, array &$jobIdReverse): array
+    {
+        $matrixSize      = count($capacityTasks) + 1;
+        $profile         = $options['profile'] ?? 'capacity_only';
+        $respectCapacity = (bool) ($options['respect_capacity'] ?? true);
+        $respectSkills   = (bool) ($options['respect_skills'] ?? true);
+
+        $vroomPayload = [
+            'jobs'     => [],
+            'vehicles' => array_map(function (array $v) use ($profile, $respectCapacity, $respectSkills) {
+                $vehicle = [
+                    'id'          => crc32($v['id']),
+                    'description' => json_encode(['vehicle_id' => $v['id'], 'driver_id' => $v['driver_id'] ?? null]),
+                    'profile'     => $profile,
+                    'start_index' => 0,
+                ];
+
+                if ($respectCapacity) {
+                    $vehicle['capacity'] = $v['capacity'];
+                }
+                if ($respectSkills && isset($v['skills'])) {
+                    $vehicle['skills'] = $v['skills'];
+                }
+
+                foreach (['time_window', 'max_tasks', 'max_travel_time'] as $key) {
+                    if (isset($v[$key])) {
+                        $vehicle[$key] = $v[$key];
+                    }
+                }
+
+                return $vehicle;
+            }, $vroomVehicles),
+            'matrices' => [
+                $profile => [
+                    'durations' => $this->buildUniformMatrix($matrixSize),
+                    'distances' => $this->buildUniformMatrix($matrixSize),
+                ],
+            ],
+            'options' => [
+                'g' => false,
+            ],
+        ];
+
+        foreach ($capacityTasks as $index => $task) {
+            $orderId              = $task['id'];
+            $intId                = crc32($orderId);
+            $jobIdReverse[$intId] = $orderId;
+
+            $job = [
+                'id'             => $intId,
+                'location_index' => $index + 1,
+                'description'    => $task['description'] ?? $orderId,
+            ];
+
+            if ($respectCapacity) {
+                $job['delivery'] = $task['amount'] ?? [0, 0, 0, 0];
+            }
+            if ($respectSkills && isset($task['skills'])) {
+                $job['skills'] = $task['skills'];
+            }
+
+            $this->copyTaskFields($task, $job, ['priority']);
+            $vroomPayload['jobs'][] = $job;
         }
 
-        if (!$response->successful()) {
-            throw new \RuntimeException('VROOM returned an error: HTTP ' . $response->status() . ' — ' . $response->body());
+        return $vroomPayload;
+    }
+
+    protected function buildUniformMatrix(int $size): array
+    {
+        $matrix = [];
+
+        for ($row = 0; $row < $size; $row++) {
+            $matrix[$row] = [];
+            for ($column = 0; $column < $size; $column++) {
+                $matrix[$row][$column] = $row === $column ? 0 : 1;
+            }
         }
 
-        $result = $response->json();
+        return $matrix;
+    }
 
-        return $this->mapVroomResponse($result, $jobIdReverse);
+    protected function partitionRouteTasks(array $tasks): array
+    {
+        $routeTasks   = [];
+        $invalidTasks = [];
+
+        foreach ($tasks as $task) {
+            if (!empty($task['invalid'])) {
+                $invalidTasks[] = $task;
+                continue;
+            }
+
+            $routeTasks[] = $task;
+        }
+
+        return [$routeTasks, $invalidTasks];
     }
 
     /**
@@ -152,7 +312,7 @@ class VroomOrchestrationEngine implements OrchestrationEngineInterface
             $sequence    = 0;
 
             foreach ($route['steps'] ?? [] as $step) {
-                if ($step['type'] !== 'job') {
+                if (!in_array($step['type'], ['job', 'delivery'], true)) {
                     continue;
                 }
                 $orderId = $jobIdReverse[$step['id']] ?? null;
@@ -178,9 +338,141 @@ class VroomOrchestrationEngine implements OrchestrationEngineInterface
 
         return [
             'assignments' => $assignments,
-            'unassigned'  => array_values($unassigned),
+            'unassigned'  => array_values(array_unique($unassigned)),
             'summary'     => $vroomResult['summary'] ?? [],
         ];
+    }
+
+    protected function mapTaskToVroomJob(array $task, array &$jobIdReverse): ?array
+    {
+        $stop = $task['stops'][0] ?? null;
+        if (!$stop || empty($stop['location'])) {
+            return null;
+        }
+
+        $orderId              = $task['id'];
+        $intId                = crc32($orderId);
+        $jobIdReverse[$intId] = $orderId;
+
+        $vroomJob = [
+            'id'          => $intId,
+            'location'    => $stop['location'],
+            'description' => $task['description'] ?? $orderId,
+        ];
+
+        $this->copyTaskFields($task, $vroomJob, ['service', 'amount', 'time_windows', 'skills', 'priority']);
+
+        return $vroomJob;
+    }
+
+    protected function mapTaskToShipment(array $task, array &$jobIdReverse): ?array
+    {
+        $stops = $task['stops'] ?? [];
+        $first = $stops[0] ?? null;
+        $last  = $stops[count($stops) - 1] ?? null;
+
+        if (!$first || !$last || empty($first['location']) || empty($last['location'])) {
+            return null;
+        }
+
+        $orderId    = $task['id'];
+        $pickupId   = crc32($orderId . ':pickup');
+        $deliveryId = crc32($orderId . ':delivery');
+
+        // We only create one FleetOps assignment per order, so route pickup
+        // steps are ignored while delivery and unassigned entries still map
+        // back to the order public_id.
+        $jobIdReverse[$pickupId]   = $orderId;
+        $jobIdReverse[$deliveryId] = $orderId;
+
+        $shipment = [
+            'pickup' => [
+                'id'          => $pickupId,
+                'location'    => $first['location'],
+                'description' => ($task['description'] ?? $orderId) . ' pickup',
+            ],
+            'delivery' => [
+                'id'          => $deliveryId,
+                'location'    => $last['location'],
+                'description' => ($task['description'] ?? $orderId) . ' delivery',
+            ],
+        ];
+
+        if (array_key_exists('service', $task)) {
+            $shipment['delivery']['service'] = $task['service'];
+        }
+        if (array_key_exists('time_windows', $task)) {
+            $shipment['delivery']['time_windows'] = $task['time_windows'];
+        }
+
+        $this->copyTaskFields($task, $shipment, ['amount', 'skills', 'priority']);
+
+        return $shipment;
+    }
+
+    protected function copyTaskFields(array $task, array &$target, array $keys): void
+    {
+        foreach ($keys as $key) {
+            if (array_key_exists($key, $task)) {
+                $target[$key] = $task[$key];
+            }
+        }
+    }
+
+    protected function mergeInvalidTasks(array $result, array $invalidTasks): array
+    {
+        if (empty($invalidTasks)) {
+            return $result;
+        }
+
+        $invalid = array_map(fn (array $task) => [
+            'order_id' => $task['id'],
+            'reason'   => $task['reason'] ?? 'Order has invalid route coordinates.',
+        ], $invalidTasks);
+
+        $result['unassigned'] = array_values(array_unique(array_merge(
+            $result['unassigned'] ?? [],
+            array_column($invalid, 'order_id')
+        )));
+
+        $summary             = $result['summary'] ?? [];
+        $summary['invalid']  = array_values(array_merge($summary['invalid'] ?? [], $invalid));
+        $result['summary']   = $summary;
+
+        return $result;
+    }
+
+    protected function callVroom(array $vroomPayload): array
+    {
+        // ── Resolve connection config ─────────────────────────────────────────
+        $baseUri      = $this->resolveVroomBaseUri();
+        $endpointMode = $this->resolveVroomEndpointMode();
+        $timeout      = (int) env('VROOM_TIMEOUT', 30);
+
+        $apiKey = $this->resolveVroomApiKey();
+
+        // Build the solve URL — append api_key as query param when present.
+        $solveUrl = rtrim($baseUri, '/');
+        if ($endpointMode !== 'binary') {
+            $solveUrl .= '/solve';
+        }
+        if ($apiKey) {
+            $solveUrl .= '?api_key=' . urlencode($apiKey);
+        }
+
+        // ── Call VROOM ────────────────────────────────────────────────────────
+        try {
+            $response = Http::timeout($timeout)->post($solveUrl, $vroomPayload);
+        } catch (\Exception $e) {
+            Log::error('[VroomOrchestrationEngine] HTTP request failed: ' . $e->getMessage());
+            throw new \RuntimeException('VROOM allocation engine is unavailable: ' . $e->getMessage() . ' — ensure VROOM_HOST is reachable or switch to the built-in greedy engine.', 0, $e);
+        }
+
+        if (!$response->successful()) {
+            throw new \RuntimeException('VROOM returned an error: HTTP ' . $response->status() . ' — ' . $response->body());
+        }
+
+        return $response->json();
     }
 
     protected function resolveVroomBaseUri(): string

--- a/server/src/Orchestration/Support/OrchestrationPayloadBuilder.php
+++ b/server/src/Orchestration/Support/OrchestrationPayloadBuilder.php
@@ -141,85 +141,243 @@ class OrchestrationPayloadBuilder
     }
 
     /**
-     * Build the normalized job list from a collection of Orders.
+     * Build normalized route tasks from Fleetbase orders.
      *
-     * Each job contains:
-     *   - id:            order public_id
-     *   - location:      [longitude, latitude] of the delivery destination
-     *   - pickup:        [longitude, latitude] of the pickup (for PDPTW shipments)
-     *   - service:       service time in seconds (waypoint.service_time → order meta → default 300)
-     *   - time_windows:  [[earliest_unix, latest_unix]] from order.time_window_start/end or scheduled_at
-     *   - skills:        integer skill codes from order.required_skills or custom fields
-     *   - amount:        multi-dimensional capacity demand [weight_kg, volume_litres, pallets, parcels]
-     *   - priority:      orchestrator_priority (0–100, higher = more important)
-     *   - description:   human-readable label for debugging
+     * Fleetbase orders must remain atomic during allocation. A task contains
+     * the full ordered stop list for the order, but engine adapters decide how
+     * much of that route shape their solver can safely model.
      */
-    public static function buildJobs(Collection $orders): array
+    public static function buildRouteTasks(Collection $orders): array
     {
         return $orders->map(function (Order $order) {
-            $payload     = $order->payload;
-            $destination = $payload?->dropoff ?? $payload?->waypoints?->last();
+            $candidates  = static::buildRouteStopCandidates($order);
+            $invalidStop = collect($candidates)->first(fn (array $stop) => !static::coordinatesFromPlace($stop['place'] ?? null));
+            $stops       = static::normalizeRouteStops($candidates);
 
-            if (!$destination || !$destination->location) {
-                return null;
+            if ($invalidStop) {
+                return [
+                    'id'          => $order->public_id,
+                    'description' => $order->public_id,
+                    'invalid'     => true,
+                    'reason'      => sprintf('Order %s stop is missing valid coordinates.', $invalidStop['role'] ?? 'route'),
+                    'stops'       => [],
+                ];
             }
 
-            // --- Location ---
-            $job = [
+            if (empty($stops)) {
+                return [
+                    'id'          => $order->public_id,
+                    'description' => $order->public_id,
+                    'invalid'     => true,
+                    'reason'      => 'Order has no routable pickup, dropoff, or waypoint coordinates.',
+                    'stops'       => [],
+                ];
+            }
+
+            $task = [
                 'id'          => $order->public_id,
-                'location'    => [$destination->location->getLng(), $destination->location->getLat()],
                 'description' => $order->public_id,
+                'stops'       => $stops,
+                'amount'      => static::computePayloadDemand($order),
+                'service'     => static::resolveServiceTime($order),
             ];
 
-            // Pickup location (for pickup-and-delivery problems)
-            $pickup = $payload?->pickup;
-            if ($pickup && $pickup->location) {
-                $job['pickup'] = [$pickup->location->getLng(), $pickup->location->getLat()];
-            }
-
-            // --- Service time ---
-            // Prefer waypoint-level service_time, then order meta, then default 300s
-            $waypointMarker = $payload?->waypointMarkers?->last();
-            $job['service'] = (int) (
-                $waypointMarker?->service_time
-                ?? $order->getMeta('service_time_seconds')
-                ?? 300
-            );
-
-            // --- Capacity demand ---
-            // Aggregated dynamically from payload entities; falls back to order meta.
-            $job['amount'] = static::computePayloadDemand($order);
-
-            // --- Time windows ---
-            // Prefer explicit orchestrator time_window columns, fall back to scheduled_at
             if ($order->time_window_start && $order->time_window_end) {
-                $job['time_windows'] = [[
+                $task['time_windows'] = [[
                     $order->time_window_start->timestamp,
                     $order->time_window_end->timestamp,
                 ]];
             } elseif ($order->scheduled_at) {
-                $start               = $order->scheduled_at->timestamp;
-                $end                 = $order->scheduled_at->copy()->addHours(4)->timestamp;
-                $job['time_windows'] = [[$start, $end]];
+                $start                = $order->scheduled_at->timestamp;
+                $end                  = $order->scheduled_at->copy()->addHours(4)->timestamp;
+                $task['time_windows'] = [[$start, $end]];
             }
 
-            // --- Skills ---
-            // Prefer first-class required_skills JSON column, fall back to custom fields
             $skills = static::resolveSkills(
                 $order->required_skills ?? [],
                 $order->custom_fields ?? []
             );
             if (!empty($skills)) {
-                $job['skills'] = $skills;
+                $task['skills'] = $skills;
             }
 
-            // --- Priority ---
             if ($order->orchestrator_priority !== null && $order->orchestrator_priority > 0) {
-                $job['priority'] = (int) $order->orchestrator_priority;
+                $task['priority'] = (int) $order->orchestrator_priority;
             }
 
-            return $job;
-        })->filter()->values()->toArray();
+            return $task;
+        })->values()->toArray();
+    }
+
+    /**
+     * @deprecated Use buildRouteTasks(). Kept for older engine adapters.
+     */
+    public static function buildJobs(Collection $orders): array
+    {
+        return array_values(array_filter(
+            static::buildRouteTasks($orders),
+            fn (array $task) => empty($task['invalid'])
+        ));
+    }
+
+    /**
+     * Build normalized capacity-only tasks from Fleetbase orders.
+     *
+     * Capacity allocation does not require route stops. It only needs an order
+     * demand vector plus optional skills, priority, and task limits.
+     */
+    public static function buildCapacityTasks(Collection $orders): array
+    {
+        return $orders->map(function (Order $order) {
+            if (!$order->payload) {
+                return [
+                    'id'          => $order->public_id,
+                    'description' => $order->public_id,
+                    'invalid'     => true,
+                    'reason'      => 'Order has no payload to compute capacity demand.',
+                    'amount'      => [0, 0, 0, 0],
+                ];
+            }
+
+            $task = [
+                'id'          => $order->public_id,
+                'description' => $order->public_id,
+                'amount'      => static::computePayloadDemand($order),
+                'service'     => static::resolveServiceTime($order),
+            ];
+
+            $skills = static::resolveSkills(
+                $order->required_skills ?? [],
+                $order->custom_fields ?? []
+            );
+            if (!empty($skills)) {
+                $task['skills'] = $skills;
+            }
+
+            if ($order->orchestrator_priority !== null && $order->orchestrator_priority > 0) {
+                $task['priority'] = (int) $order->orchestrator_priority;
+            }
+
+            return $task;
+        })->values()->toArray();
+    }
+
+    /**
+     * Return Fleetbase's canonical ordered stops for an order:
+     * pickup, then waypoints by marker order, then dropoff.
+     */
+    public static function buildRouteStops(Order $order): array
+    {
+        return static::normalizeRouteStops(static::buildRouteStopCandidates($order));
+    }
+
+    protected static function buildRouteStopCandidates(Order $order): array
+    {
+        $payload = $order->payload;
+        if (!$payload) {
+            return [];
+        }
+
+        $stops = [];
+
+        if ($payload->pickup) {
+            $stops[] = ['role' => 'pickup', 'place' => $payload->pickup];
+        }
+
+        $waypointMarkers = method_exists($payload, 'relationLoaded') && $payload->relationLoaded('waypointMarkers')
+            ? $payload->waypointMarkers
+            : collect();
+        if ($waypointMarkers->isNotEmpty()) {
+            foreach ($waypointMarkers->sortBy('order')->values() as $index => $waypoint) {
+                $stops[] = [
+                    'role'          => 'waypoint',
+                    'place'         => $waypoint->place,
+                    'waypoint_id'   => $waypoint->public_id,
+                    'waypoint_uuid' => $waypoint->uuid,
+                    'order'         => $waypoint->order ?? $index,
+                ];
+            }
+        } elseif (isset($payload->waypoints) && $payload->waypoints) {
+            foreach ($payload->waypoints->values() as $index => $waypoint) {
+                $stops[] = [
+                    'role'  => 'waypoint',
+                    'place' => $waypoint,
+                    'order' => $index,
+                ];
+            }
+        }
+
+        if ($payload->dropoff) {
+            $stops[] = ['role' => 'dropoff', 'place' => $payload->dropoff];
+        }
+
+        return $stops;
+    }
+
+    protected static function normalizeRouteStops(array $stops): array
+    {
+        return collect($stops)
+            ->map(function (array $stop) {
+                $coordinates = static::coordinatesFromPlace($stop['place'] ?? null);
+                if (!$coordinates) {
+                    return null;
+                }
+
+                unset($stop['place'], $stop['waypoint_uuid']);
+
+                return array_merge($stop, [
+                    'location' => $coordinates,
+                ]);
+            })
+            ->filter()
+            ->values()
+            ->toArray();
+    }
+
+    protected static function resolveServiceTime(Order $order): int
+    {
+        $payload        = $order->payload;
+        $waypointMarker = $payload?->waypointMarkers?->last();
+
+        return (int) (
+            $waypointMarker?->service_time
+            ?? $order->getMeta('service_time_seconds')
+            ?? 300
+        );
+    }
+
+    protected static function coordinatesFromPlace($place): ?array
+    {
+        $location = $place?->location;
+        if (!$location) {
+            return null;
+        }
+
+        $lng = $location->getLng();
+        $lat = $location->getLat();
+
+        if (!static::isValidCoordinate($lng, $lat)) {
+            return null;
+        }
+
+        return [(float) $lng, (float) $lat];
+    }
+
+    protected static function isValidCoordinate($lng, $lat): bool
+    {
+        if (!is_numeric($lng) || !is_numeric($lat)) {
+            return false;
+        }
+
+        $lng = (float) $lng;
+        $lat = (float) $lat;
+
+        return is_finite($lng)
+            && is_finite($lat)
+            && $lng >= -180
+            && $lng <= 180
+            && $lat >= -90
+            && $lat <= 90;
     }
 
     /**
@@ -335,6 +493,56 @@ class OrchestrationPayloadBuilder
 
             return $entry;
         })->filter()->values()->toArray();
+    }
+
+    /**
+     * Build vehicles for non-geospatial capacity allocation.
+     *
+     * Unlike buildVehicles(), this intentionally does not require a vehicle or
+     * driver location because no routing engine will be asked to calculate
+     * travel distance or duration.
+     */
+    public static function buildCapacityVehicles(Collection $vehicles): array
+    {
+        return $vehicles->map(function (Vehicle $vehicle) {
+            $driver = $vehicle->driver;
+            $entry  = [
+                'id'        => $vehicle->public_id,
+                'driver_id' => $driver?->public_id,
+                'capacity'  => static::buildVehicleCapacity($vehicle),
+            ];
+
+            if ($vehicle->max_tasks !== null && $vehicle->max_tasks > 0) {
+                $entry['max_tasks'] = (int) $vehicle->max_tasks;
+            }
+
+            $maxTravel = $driver?->max_travel_time ?? static::safeMeta($vehicle, 'max_travel_time_seconds');
+            if ($maxTravel) {
+                $entry['max_travel_time'] = (int) $maxTravel;
+            }
+
+            if ($driver?->time_window_start && $driver?->time_window_end) {
+                $entry['time_window'] = [
+                    $driver->time_window_start->timestamp,
+                    $driver->time_window_end->timestamp,
+                ];
+            } elseif ($vehicle->time_window_start && $vehicle->time_window_end) {
+                $entry['time_window'] = [
+                    $vehicle->time_window_start->timestamp,
+                    $vehicle->time_window_end->timestamp,
+                ];
+            }
+
+            $skills = array_values(array_unique(array_merge(
+                static::resolveSkills($vehicle->skills ?? [], $vehicle->custom_fields ?? []),
+                static::resolveSkills($driver?->skills ?? [], $driver?->custom_fields ?? [])
+            )));
+            if (!empty($skills)) {
+                $entry['skills'] = $skills;
+            }
+
+            return $entry;
+        })->values()->toArray();
     }
 
     /**

--- a/server/src/Providers/FleetOpsServiceProvider.php
+++ b/server/src/Providers/FleetOpsServiceProvider.php
@@ -135,6 +135,9 @@ class FleetOpsServiceProvider extends CoreServiceProvider
                 if (!$registry->has('greedy')) {
                     $registry->register(new \Fleetbase\FleetOps\Orchestration\Engines\GreedyOrchestrationEngine());
                 }
+                if (!$registry->has('capacity')) {
+                    $registry->register(new \Fleetbase\FleetOps\Orchestration\Engines\CapacityAllocationEngine());
+                }
             }
         );
         $this->loadRoutesFrom(__DIR__ . '/../routes.php');

--- a/server/src/routes.php
+++ b/server/src/routes.php
@@ -203,6 +203,12 @@ Route::prefix(config('fleetops.api.routing.prefix', null))->namespace('Fleetbase
                 $router->get('{id}', 'LabelController@getLabel');
             });
 
+            // orchestrator routes
+            $router->group(['prefix' => 'orchestrator'], function () use ($router) {
+                $router->post('run', 'OrchestrationController@run');
+                $router->post('commit', 'OrchestrationController@commit');
+            });
+
             // navigator routes
             $router->group(['prefix' => 'onboard'], function () use ($router) {
                 $router->get('driver-onboard-settings/{companyId}', 'NavigatorController@getDriverOnboardSettings');

--- a/server/tests/CapacityAllocationEngineTest.php
+++ b/server/tests/CapacityAllocationEngineTest.php
@@ -1,0 +1,108 @@
+<?php
+
+use Fleetbase\FleetOps\Models\Order;
+use Fleetbase\FleetOps\Models\Vehicle;
+use Fleetbase\FleetOps\Orchestration\Engines\CapacityAllocationEngine;
+
+function capacityTestOrder(string $publicId, float $weightKg, float $volumeLitres = 0, array $skills = []): Order
+{
+    $payload = new class($weightKg, $volumeLitres) {
+        public $entities;
+
+        public function __construct(float $weightKg, float $volumeLitres)
+        {
+            $this->entities = collect([
+                new class($weightKg, $volumeLitres) {
+                    public float $weight;
+                    public string $weight_unit = 'kg';
+                    public float $length;
+                    public float $width = 1;
+                    public float $height = 1;
+                    public string $dimensions_unit = 'm';
+
+                    public function __construct(float $weightKg, float $volumeLitres)
+                    {
+                        $this->weight = $weightKg;
+                        $this->length = $volumeLitres / 1000;
+                    }
+                },
+            ]);
+        }
+    };
+
+    $order = new Order();
+    $order->public_id = $publicId;
+    $order->required_skills = $skills;
+    $order->setRelation('payload', $payload);
+
+    return $order;
+}
+
+function capacityTestVehicle(string $publicId, float $weightKg, float $volumeM3 = 0, int $maxTasks = 0, array $skills = []): Vehicle
+{
+    $vehicle = new Vehicle();
+    $vehicle->public_id = $publicId;
+    $vehicle->payload_capacity = $weightKg;
+    $vehicle->payload_capacity_volume = $volumeM3;
+    $vehicle->payload_capacity_pallets = 0;
+    $vehicle->payload_capacity_parcels = 100;
+    $vehicle->max_tasks = $maxTasks;
+    $vehicle->skills = $skills;
+    $vehicle->setRelation('driver', null);
+
+    return $vehicle;
+}
+
+test('capacity engine assigns orders without vehicle locations', function () {
+    $engine = new CapacityAllocationEngine();
+
+    $result = $engine->allocate(collect([
+        capacityTestOrder('order_light', 10, 250),
+        capacityTestOrder('order_medium', 20, 500),
+    ]), collect([
+        capacityTestVehicle('vehicle_van', 100, 2),
+    ]), [
+        'balance_workload' => false,
+    ]);
+
+    expect($result['assignments'])->toHaveCount(2);
+    expect(array_column($result['assignments'], 'vehicle_id'))->toBe(['vehicle_van', 'vehicle_van']);
+    expect($result['unassigned'])->toBe([]);
+    expect($result['summary']['allocation_strategy'])->toBe('capacity_only');
+});
+
+test('capacity engine rejects over-capacity orders with useful reasons', function () {
+    $engine = new CapacityAllocationEngine();
+
+    $result = $engine->allocate(collect([
+        capacityTestOrder('order_heavy', 250),
+    ]), collect([
+        capacityTestVehicle('vehicle_small', 100),
+    ]));
+
+    expect($result['assignments'])->toBe([]);
+    expect($result['unassigned'])->toBe(['order_heavy']);
+    expect($result['summary']['unassigned_reasons'][0])->toMatchArray([
+        'order_id' => 'order_heavy',
+        'reason'   => 'capacity_exceeded',
+    ]);
+});
+
+test('capacity engine respects skills max tasks and balanced workload', function () {
+    $engine = new CapacityAllocationEngine();
+
+    $result = $engine->allocate(collect([
+        capacityTestOrder('order_cold_1', 10, 0, ['cold_chain']),
+        capacityTestOrder('order_cold_2', 10, 0, ['cold_chain']),
+        capacityTestOrder('order_fragile', 10, 0, ['fragile']),
+    ]), collect([
+        capacityTestVehicle('vehicle_cold_a', 100, 0, 1, ['cold_chain']),
+        capacityTestVehicle('vehicle_cold_b', 100, 0, 1, ['cold_chain']),
+    ]), [
+        'balance_workload' => true,
+    ]);
+
+    expect(array_column($result['assignments'], 'vehicle_id'))->toBe(['vehicle_cold_a', 'vehicle_cold_b']);
+    expect($result['unassigned'])->toBe(['order_fragile']);
+    expect($result['summary']['unassigned_reasons'][0]['reason'])->toBe('missing_required_skills');
+});

--- a/server/tests/OrchestrationPayloadBuilderTest.php
+++ b/server/tests/OrchestrationPayloadBuilderTest.php
@@ -1,0 +1,132 @@
+<?php
+
+use Fleetbase\FleetOps\Models\Order;
+use Fleetbase\FleetOps\Orchestration\Support\OrchestrationPayloadBuilder;
+use Illuminate\Support\Collection;
+
+function orchestrationTestPlace($lng, $lat)
+{
+    return new class($lng, $lat) {
+        public $location;
+
+        public function __construct($lng, $lat)
+        {
+            $this->location = new class($lng, $lat) {
+                public function __construct(private $lng, private $lat)
+                {
+                }
+
+                public function getLng()
+                {
+                    return $this->lng;
+                }
+
+                public function getLat()
+                {
+                    return $this->lat;
+                }
+            };
+        }
+    };
+}
+
+function orchestrationTestOrder($pickup = null, $dropoff = null, array $waypoints = []): Order
+{
+    $payload = new class($pickup, $dropoff, $waypoints) {
+        public Collection $entities;
+        public Collection $waypointMarkers;
+
+        public function __construct(public $pickup, public $dropoff, array $waypoints)
+        {
+            $this->entities         = collect();
+            $this->waypointMarkers = collect($waypoints)->map(function ($place, $index) {
+                return new class($place, $index) {
+                    public string $public_id;
+                    public string $uuid;
+                    public int $order;
+
+                    public function __construct(public $place, int $index)
+                    {
+                        $this->public_id = 'waypoint_' . $index;
+                        $this->uuid      = 'internal-waypoint-' . $index;
+                        $this->order     = $index;
+                    }
+                };
+            });
+        }
+
+        public function relationLoaded(string $relation): bool
+        {
+            return $relation === 'waypointMarkers';
+        }
+    };
+
+    $order = new Order();
+    $order->public_id = 'order_test';
+    $order->setRelation('payload', $payload);
+
+    return $order;
+}
+
+test('route stops use pickup waypoint dropoff order for mixed payloads', function () {
+    $order = orchestrationTestOrder(
+        orchestrationTestPlace(103.85, 1.28),
+        orchestrationTestPlace(103.90, 1.31),
+        [
+            orchestrationTestPlace(103.86, 1.29),
+            orchestrationTestPlace(103.87, 1.30),
+        ]
+    );
+
+    $stops = OrchestrationPayloadBuilder::buildRouteStops($order);
+
+    expect(array_column($stops, 'role'))->toBe(['pickup', 'waypoint', 'waypoint', 'dropoff']);
+    expect(array_column($stops, 'location'))->toBe([
+        [103.85, 1.28],
+        [103.86, 1.29],
+        [103.87, 1.30],
+        [103.90, 1.31],
+    ]);
+    expect($stops[1])->not->toHaveKey('waypoint_uuid');
+});
+
+test('route stops support endpoint only and waypoint only payloads', function () {
+    $endpointOnly = OrchestrationPayloadBuilder::buildRouteStops(orchestrationTestOrder(
+        orchestrationTestPlace(103.85, 1.28),
+        orchestrationTestPlace(103.90, 1.31)
+    ));
+    $waypointOnly = OrchestrationPayloadBuilder::buildRouteStops(orchestrationTestOrder(
+        null,
+        null,
+        [orchestrationTestPlace(103.86, 1.29)]
+    ));
+
+    expect(array_column($endpointOnly, 'role'))->toBe(['pickup', 'dropoff']);
+    expect(array_column($waypointOnly, 'role'))->toBe(['waypoint']);
+});
+
+test('route stops drop invalid coordinates before vroom payload mapping', function () {
+    $stops = OrchestrationPayloadBuilder::buildRouteStops(orchestrationTestOrder(
+        orchestrationTestPlace('and', 1.28),
+        orchestrationTestPlace(103.90, 1.31)
+    ));
+
+    expect(array_column($stops, 'role'))->toBe(['dropoff']);
+    expect($stops[0]['location'])->toBe([103.90, 1.31]);
+});
+
+test('route tasks mark declared invalid-coordinate stops unassigned', function () {
+    $tasks = OrchestrationPayloadBuilder::buildRouteTasks(collect([
+        orchestrationTestOrder(
+            orchestrationTestPlace('and', 1.28),
+            orchestrationTestPlace(103.90, 1.31)
+        ),
+    ]));
+
+    expect($tasks[0])->toMatchArray([
+        'id'      => 'order_test',
+        'invalid' => true,
+        'stops'   => [],
+    ]);
+    expect($tasks[0]['reason'])->toContain('pickup stop is missing valid coordinates');
+});

--- a/server/tests/OrchestratorConsumableApiTest.php
+++ b/server/tests/OrchestratorConsumableApiTest.php
@@ -1,0 +1,74 @@
+<?php
+
+use Fleetbase\FleetOps\Http\Controllers\Api\v1\OrchestrationController;
+use Fleetbase\FleetOps\Orchestration\OrchestrationEngineRegistry;
+
+function sanitize_orchestrator_payload(array $payload): array
+{
+    $controller = new OrchestrationController(new OrchestrationEngineRegistry());
+    $method     = new ReflectionMethod($controller, 'sanitizePublicPayload');
+    $method->setAccessible(true);
+
+    return $method->invoke($controller, $payload);
+}
+
+function assert_no_internal_orchestrator_identifiers(array $payload): void
+{
+    foreach ($payload as $key => $value) {
+        expect($key)->not->toBe('uuid');
+        expect($key)->not->toBe('company_uuid');
+        expect($key)->not->toBe('internal_id');
+        expect(str_ends_with((string) $key, '_uuid'))->toBeFalse();
+
+        if (is_array($value)) {
+            assert_no_internal_orchestrator_identifiers($value);
+        }
+    }
+}
+
+test('consumable orchestrator responses remove internal identifiers recursively', function () {
+    $payload = [
+        'assignments' => [
+            [
+                'order_id'      => 'order_123',
+                'order_uuid'    => '6a76d5ef-9d08-4eb9-a235-62406d6a0ed2',
+                'vehicle_id'    => 'vehicle_123',
+                'vehicle_uuid'  => '9a05d9d1-9ff7-460f-a6ee-509a0ed9b345',
+                'driver_id'     => 'driver_123',
+                'internal_id'   => 123,
+                'nested'        => [
+                    'uuid'         => '793f2f9d-5225-49f7-ad22-d73a2c4ea2d1',
+                    'company_uuid' => 'company-internal',
+                    'public_id'    => 'safe_public_id',
+                ],
+            ],
+        ],
+        'unassigned' => ['order_456'],
+        'summary'    => [
+            'routes' => 1,
+            'meta'   => [
+                'request_uuid' => '524c5175-1df2-4e9a-a27b-3107f9e08545',
+            ],
+        ],
+    ];
+
+    $sanitized = sanitize_orchestrator_payload($payload);
+
+    expect($sanitized['assignments'][0])->toMatchArray([
+        'order_id'   => 'order_123',
+        'vehicle_id' => 'vehicle_123',
+        'driver_id'  => 'driver_123',
+    ]);
+    expect($sanitized['assignments'][0]['nested']['public_id'])->toBe('safe_public_id');
+    expect($sanitized['summary']['routes'])->toBe(1);
+
+    assert_no_internal_orchestrator_identifiers($sanitized);
+});
+
+test('consumable orchestrator routes are registered under the public api group', function () {
+    $routes = file_get_contents(__DIR__ . '/../src/routes.php');
+
+    expect($routes)->toContain("['prefix' => 'orchestrator']");
+    expect($routes)->toContain("\$router->post('run', 'OrchestrationController@run');");
+    expect($routes)->toContain("\$router->post('commit', 'OrchestrationController@commit');");
+});

--- a/server/tests/VroomOrchestrationEngineTest.php
+++ b/server/tests/VroomOrchestrationEngineTest.php
@@ -1,0 +1,159 @@
+<?php
+
+use Fleetbase\FleetOps\Orchestration\Engines\VroomOrchestrationEngine;
+
+test('vroom maps multi stop route tasks to shipments', function () {
+    $engine  = new VroomOrchestrationEngine();
+    $method  = new ReflectionMethod($engine, 'mapTaskToShipment');
+    $reverse = [];
+
+    $method->setAccessible(true);
+
+    $shipment = $method->invokeArgs($engine, [[
+        'id'          => 'order_gkATxX2U3P',
+        'stops'       => [
+            ['role' => 'pickup', 'location' => [103.85, 1.28]],
+            ['role' => 'waypoint', 'location' => [103.87, 1.30]],
+            ['role' => 'dropoff', 'location' => [103.90, 1.31]],
+        ],
+        'service'     => 300,
+        'amount'      => [1, 0, 0, 1],
+        'description' => 'order_gkATxX2U3P',
+    ], &$reverse]);
+
+    expect($shipment)->toHaveKeys(['pickup', 'delivery', 'amount']);
+    expect($shipment)->not->toHaveKey('location');
+    expect($shipment['pickup']['location'])->toBe([103.85, 1.28]);
+    expect($shipment['delivery']['location'])->toBe([103.90, 1.31]);
+    expect($shipment['delivery']['service'])->toBe(300);
+    expect(array_values($reverse))->toBe(['order_gkATxX2U3P', 'order_gkATxX2U3P']);
+});
+
+test('vroom maps single stop route tasks to jobs without pickup coordinates', function () {
+    $engine  = new VroomOrchestrationEngine();
+    $method  = new ReflectionMethod($engine, 'mapTaskToVroomJob');
+    $reverse = [];
+
+    $method->setAccessible(true);
+
+    $job = $method->invokeArgs($engine, [[
+        'id'          => 'order_waypointOnly',
+        'stops'       => [
+            ['role' => 'waypoint', 'location' => [103.86, 1.29]],
+        ],
+        'service'     => 300,
+        'amount'      => [1, 0, 0, 1],
+        'description' => 'order_waypointOnly',
+    ], &$reverse]);
+
+    expect($job)->toMatchArray([
+        'location'    => [103.86, 1.29],
+        'description' => 'order_waypointOnly',
+        'service'     => 300,
+        'amount'      => [1, 0, 0, 1],
+    ]);
+    expect($job)->not->toHaveKey('pickup');
+    expect(array_values($reverse))->toBe(['order_waypointOnly']);
+});
+
+test('vroom dedupes unassigned pickup and delivery task ids to one order id', function () {
+    $engine = new VroomOrchestrationEngine();
+    $method = new ReflectionMethod($engine, 'mapVroomResponse');
+
+    $method->setAccessible(true);
+
+    $result = $method->invoke($engine, [
+        'routes'     => [],
+        'unassigned' => [
+            ['id' => 1001],
+            ['id' => 1002],
+        ],
+        'summary' => ['routes' => 0],
+    ], [
+        1001 => 'order_gkATxX2U3P',
+        1002 => 'order_gkATxX2U3P',
+    ]);
+
+    expect($result['unassigned'])->toBe(['order_gkATxX2U3P']);
+});
+
+test('vroom maps shipment delivery steps back to fleetops assignments', function () {
+    $engine = new VroomOrchestrationEngine();
+    $method = new ReflectionMethod($engine, 'mapVroomResponse');
+
+    $method->setAccessible(true);
+
+    $result = $method->invoke($engine, [
+        'routes' => [
+            [
+                'description' => json_encode(['vehicle_id' => 'vehicle_w747Bat', 'driver_id' => null]),
+                'steps'       => [
+                    ['type' => 'start'],
+                    ['type' => 'pickup', 'id' => 1001],
+                    ['type' => 'delivery', 'id' => 1002, 'arrival' => 1778918400, 'duration' => 900, 'distance' => 4200],
+                    ['type' => 'end'],
+                ],
+            ],
+        ],
+        'unassigned' => [],
+        'summary'    => ['routes' => 1],
+    ], [
+        1001 => 'order_gkATxX2U3P',
+        1002 => 'order_gkATxX2U3P',
+    ]);
+
+    expect($result['assignments'])->toHaveCount(1);
+    expect($result['assignments'][0])->toMatchArray([
+        'order_id'   => 'order_gkATxX2U3P',
+        'vehicle_id' => 'vehicle_w747Bat',
+        'driver_id'  => null,
+        'sequence'   => 1,
+        'arrival'    => 1778918400,
+        'duration'   => 900,
+        'distance'   => 4200,
+    ]);
+    expect($result['summary'])->toBe(['routes' => 1]);
+});
+
+test('vroom capacity-only payload uses matrix indexes instead of coordinates', function () {
+    $engine  = new VroomOrchestrationEngine();
+    $method  = new ReflectionMethod($engine, 'buildCapacityOnlyPayload');
+    $reverse = [];
+
+    $method->setAccessible(true);
+
+    $payload = $method->invokeArgs($engine, [[
+        [
+            'id'          => 'order_capacity',
+            'description' => 'order_capacity',
+            'amount'      => [100, 250, 1, 2],
+            'skills'      => [123],
+        ],
+    ], [
+        [
+            'id'        => 'vehicle_capacity',
+            'driver_id' => null,
+            'capacity'  => [500, 1000, 4, 20],
+            'skills'    => [123],
+            'max_tasks' => 3,
+        ],
+    ], [], &$reverse]);
+
+    expect($payload['vehicles'][0])->toMatchArray([
+        'profile'     => 'capacity_only',
+        'start_index' => 0,
+        'capacity'    => [500, 1000, 4, 20],
+        'skills'      => [123],
+        'max_tasks'   => 3,
+    ]);
+    expect($payload['vehicles'][0])->not->toHaveKey('start');
+    expect($payload['jobs'][0])->toMatchArray([
+        'location_index' => 1,
+        'delivery'       => [100, 250, 1, 2],
+        'skills'         => [123],
+    ]);
+    expect($payload['jobs'][0])->not->toHaveKey('location');
+    expect($payload['jobs'][0])->not->toHaveKey('pickup');
+    expect($payload['matrices']['capacity_only']['durations'])->toHaveCount(2);
+    expect(array_values($reverse))->toBe(['order_capacity']);
+});

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -1989,6 +1989,9 @@ orchestrator:
     mode-allocate: Allocate Orders
     mode-optimize: Optimize Routes
     engine: Engine
+    allocation-strategy: Allocation Strategy
+    allocation-strategy-route-aware: Route + Capacity
+    allocation-strategy-capacity-only: Capacity Only
     respect-skills: Respect Skills
     respect-capacity: Respect Capacity
     return-to-depot: Return to Depot
@@ -2029,6 +2032,7 @@ orchestrator:
     no-search-results: No results match your search.
     search-drivers: Search drivers...
     search-vehicles: Search vehicles...
+    no-position: No position
     filter-online: Online
     filter-offline: Offline
     filter-on-shift: On Job


### PR DESCRIPTION
## Summary
- Exposes FleetOps orchestration through consumable API endpoints for run and commit.
- Refactors VROOM payloads around Fleetbase route semantics and adds VROOM capacity-only allocation.
- Adds native capacity allocation, a VROOM test seeder, UI allocation controls, position indicators, and focused tests.

## Validation
- PHP syntax checks passed for changed backend files.
- ESLint and ember-template-lint passed for changed orchestrator UI files.
- git diff --check passed.
- Pest execution is blocked locally by missing Pest/Symfony vendor autoload dependencies.