### PR TITLE
Fix unassigned tracking driver state

### DIFF
--- a/addon/components/order/details/tracking.hbs
+++ b/addon/components/order/details/tracking.hbs
@@ -28,18 +28,15 @@
                 <div class="tracking-intelligence-alert {{if (eq this.driverSignal 'Missing') 'tracking-intelligence-alert--critical'}}">
                     <div class="tracking-intelligence-alert__icon"><FaIcon @icon="triangle-exclamation" @size="xs" /></div>
                     <div class="min-w-0">
-                        <div class="tracking-intelligence-alert__title">
-                            {{#if (eq this.driverSignal "Missing")}}
-                                Pending GPS fix
-                            {{else if (eq this.driverSignal "Stale")}}
-                                Stale driver location
-                            {{else}}
-                                Tracking estimate warning
-                            {{/if}}
-                        </div>
+                        <div class="tracking-intelligence-alert__title">{{this.operatorWarningTitle}}</div>
                         <div class="tracking-intelligence-alert__body">{{this.operatorWarning}}</div>
                     </div>
-                    {{#if (or (eq this.driverSignal "Missing") (eq this.driverSignal "Stale"))}}
+                    {{#if this.canAssignDriver}}
+                        <button type="button" class="tracking-intelligence-alert__cta" {{on "click" this.assignDriver}}>
+                            <FaIcon @icon="user-plus" @size="xs" />
+                            <span>Assign driver</span>
+                        </button>
+                    {{else if this.canPingDriver}}
                         <button type="button" class="tracking-intelligence-alert__cta" disabled={{this.pingDriver.isRunning}} {{on "click" (perform this.pingDriver)}}>
                             <FaIcon @icon="bell" @size="xs" />
                             <span>{{if this.pingDriver.isRunning "Pinging..." "Ping driver app"}}</span>
@@ -69,7 +66,7 @@
                         {{#if this.hasDisplayedReportedEta}}
                             {{format-duration this.displayedReportedEtaSeconds}}
                         {{else}}
-                            Pending GPS fix
+                            {{this.etaUnavailableLabel}}
                         {{/if}}
                     </div>
                     <div class="tracking-intelligence-cell__sub {{if this.isReportedEtaUntrusted 'tracking-intelligence-cell__sub--warn'}}">{{this.reportedEtaWarning}}</div>
@@ -97,7 +94,7 @@
                             {{#if this.hasActiveEta}}
                                 {{format-duration this.activeEtaSeconds}}
                             {{else}}
-                                Pending GPS fix
+                                {{this.etaUnavailableLabel}}
                             {{/if}}
                         </strong>
                     </div>

--- a/addon/components/order/details/tracking.js
+++ b/addon/components/order/details/tracking.js
@@ -1,5 +1,6 @@
 import Component from '@glimmer/component';
 import { inject as service } from '@ember/service';
+import { action } from '@ember/object';
 import { debug } from '@ember/debug';
 import { task } from 'ember-concurrency';
 
@@ -56,6 +57,10 @@ export default class OrderDetailsTrackingComponent extends Component {
     }
 
     get smartAdjustedEtaUnavailableLabel() {
+        if (this.driverSignal === 'Unassigned') {
+            return 'Pending driver assignment';
+        }
+
         if (this.driverSignal === 'Missing' || this.driverSignal === 'Stale') {
             return 'Pending GPS fix';
         }
@@ -71,8 +76,18 @@ export default class OrderDetailsTrackingComponent extends Component {
         return this.trackerData?.route?.distance_m !== null && this.trackerData?.route?.distance_m !== undefined;
     }
 
+    get hasAssignedDriver() {
+        const order = this.args.resource;
+
+        return Boolean(order?.driver_assigned || order?.driver_assigned_uuid);
+    }
+
     get driverSignal() {
         const trackerData = this.trackerData;
+
+        if (!this.hasAssignedDriver) {
+            return 'Unassigned';
+        }
 
         if (!trackerData?.driver?.location) {
             return 'Missing';
@@ -93,6 +108,8 @@ export default class OrderDetailsTrackingComponent extends Component {
                 return 'Driver stale';
             case 'Missing':
                 return 'Driver missing GPS';
+            case 'Unassigned':
+                return 'No driver assigned';
             default:
                 return 'Driver offline';
         }
@@ -110,6 +127,8 @@ export default class OrderDetailsTrackingComponent extends Component {
                 return 'text-yellow-600 dark:text-yellow-400';
             case 'Missing':
                 return 'text-red-600 dark:text-red-400';
+            case 'Unassigned':
+                return 'text-yellow-600 dark:text-yellow-400';
             default:
                 return 'text-gray-600 dark:text-gray-300';
         }
@@ -261,6 +280,39 @@ export default class OrderDetailsTrackingComponent extends Component {
         return this.operatorWarning ?? 'Reported ETA may not reflect the latest tracking signal.';
     }
 
+    get etaUnavailableLabel() {
+        if (this.driverSignal === 'Unassigned') {
+            return 'Pending driver assignment';
+        }
+
+        if (this.driverSignal === 'Missing' || this.driverSignal === 'Stale') {
+            return 'Pending GPS fix';
+        }
+
+        return '-';
+    }
+
+    get operatorWarningTitle() {
+        switch (this.driverSignal) {
+            case 'Unassigned':
+                return 'No driver assigned';
+            case 'Missing':
+                return 'Pending GPS fix';
+            case 'Stale':
+                return 'Stale driver location';
+            default:
+                return 'Tracking estimate warning';
+        }
+    }
+
+    get canAssignDriver() {
+        return this.driverSignal === 'Unassigned';
+    }
+
+    get canPingDriver() {
+        return this.driverSignal === 'Missing' || this.driverSignal === 'Stale';
+    }
+
     get warningsCount() {
         return (this.trackerData?.warnings ?? []).length;
     }
@@ -307,7 +359,7 @@ export default class OrderDetailsTrackingComponent extends Component {
             return Math.max(0, Math.min(100, explicit));
         }
 
-        if (this.driverSignal === 'Missing') {
+        if (this.driverSignal === 'Unassigned' || this.driverSignal === 'Missing') {
             return 0;
         }
 
@@ -348,6 +400,10 @@ export default class OrderDetailsTrackingComponent extends Component {
 
         if (!trackerData) {
             return null;
+        }
+
+        if (!this.hasAssignedDriver) {
+            return 'Assign a driver to start live tracking and improve ETA accuracy.';
         }
 
         if (!trackerData?.driver?.location) {
@@ -393,6 +449,16 @@ export default class OrderDetailsTrackingComponent extends Component {
         }
 
         return stop.uuid === activeStop.uuid || stop.public_id === activeStop.public_id || stop.id === activeStop.id;
+    }
+
+    @action assignDriver() {
+        const order = this.args.resource;
+
+        if (!order || typeof this.orderActions.assignDriver !== 'function') {
+            return;
+        }
+
+        return this.orderActions.assignDriver(order);
     }
 
     @task *pingDriver() {

--- a/tests/integration/components/order/details/tracking-test.js
+++ b/tests/integration/components/order/details/tracking-test.js
@@ -1,20 +1,35 @@
 import Service from '@ember/service';
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'dummy/tests/helpers';
-import { render } from '@ember/test-helpers';
+import { click, render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Component | order/details/tracking', function (hooks) {
     setupRenderingTest(hooks);
 
     hooks.beforeEach(function () {
-        this.owner.register('service:order-actions', class OrderActionsService extends Service {});
+        this.assignedDriverOrder = null;
+        const testContext = this;
+
+        this.owner.register(
+            'service:order-actions',
+            class OrderActionsService extends Service {
+                assignDriver(order) {
+                    testContext.assignedDriverOrder = order;
+                }
+            }
+        );
     });
 
     function buildOrder(overrides = {}) {
         return {
             tracking: 'FLE2177254646SG',
             public_id: 'order_test',
+            driver_assigned_uuid: 'driver_1',
+            driver_assigned: {
+                id: 'driver_1',
+                name: 'Test Driver',
+            },
             tracking_number: {
                 qr_code: '',
                 barcode: '',
@@ -147,9 +162,10 @@ module('Integration | Component | order/details/tracking', function (hooks) {
 
         assert.dom().containsText('Driver stale');
         assert.dom().containsText('Driver location is stale');
+        assert.dom().containsText('Ping driver app');
     });
 
-    test('it shows missing driver location as the clearest warning', async function (assert) {
+    test('it shows missing driver location for assigned drivers', async function (assert) {
         this.set(
             'order',
             buildOrder({
@@ -167,5 +183,36 @@ module('Integration | Component | order/details/tracking', function (hooks) {
         assert.dom().containsText('Driver missing GPS');
         assert.dom().containsText('Driver location is missing');
         assert.dom().containsText('Ping driver app');
+    });
+
+    test('it shows assignment state instead of gps recovery when no driver is assigned', async function (assert) {
+        const order = buildOrder({
+            driver_assigned_uuid: null,
+            driver_assigned: null,
+            tracker_data: {
+                driver: {
+                    online: false,
+                    location: null,
+                },
+                eta: {
+                    active_stop_seconds: null,
+                    completion_at: null,
+                },
+            },
+        });
+
+        this.set('order', order);
+
+        await render(hbs`<Order::Details::Tracking @resource={{this.order}} />`);
+
+        assert.dom().containsText('No driver assigned');
+        assert.dom().containsText('Assign driver');
+        assert.dom().containsText('Pending driver assignment');
+        assert.dom().doesNotContainText('Pending GPS fix');
+        assert.dom().doesNotContainText('Ping driver app');
+
+        await click('.tracking-intelligence-alert__cta');
+
+        assert.strictEqual(this.assignedDriverOrder, order);
     });
 });


### PR DESCRIPTION
## Summary
- Distinguish unassigned orders from assigned drivers with missing GPS in the tracking intelligence panel.
- Show a No driver assigned state with an Assign driver CTA wired to the existing order assignment flow.
- Keep Pending GPS fix and Ping driver app only for assigned drivers with missing or stale GPS.
- Update tracking component coverage for unassigned and assigned-missing GPS states.

## Verification
- npx prettier --write addon/components/order/details/tracking.js addon/components/order/details/tracking.hbs tests/integration/components/order/details/tracking-test.js
- npx eslint addon/components/order/details/tracking.js tests/integration/components/order/details/tracking-test.js
- npx ember-template-lint addon/components/order/details/tracking.hbs
- npx ember test --filter="Integration | Component | order/details/tracking" (blocked by existing vendor.js global error before tests.js loads)