### PR TITLE
Add VROOM capacity-only vehicle packing bias

### DIFF
--- a/addon/components/orchestrator-workbench.js
+++ b/addon/components/orchestrator-workbench.js
@@ -271,6 +271,7 @@ export default class OrchestratorWorkbenchComponent extends Component {
                 options: {
                     engine: phase.engine ?? 'greedy',
                     allocation_strategy: phase.allocationStrategy ?? 'route_aware',
+                    vehicle_packing: phase.vehiclePacking ?? 'minimize_vehicles',
                     balance_workload: phase.balanceWorkload ?? false,
                     respect_skills: phase.respectSkills ?? true,
                     respect_capacity: phase.respectCapacity ?? true,

--- a/addon/components/orchestrator/phase-builder.hbs
+++ b/addon/components/orchestrator/phase-builder.hbs
@@ -130,6 +130,27 @@
                         </InputGroup>
                     {{/if}}
 
+                    {{#if this.shouldShowVehiclePacking}}
+                        <InputGroup @name={{t "orchestrator.vehicle-packing"}}>
+                            <div class="grid grid-cols-2 gap-1">
+                                {{#each this.vehiclePackingOptions as |opt|}}
+                                    <button
+                                        type="button"
+                                        class="flex items-center justify-center gap-1.5 px-2 py-1.5 rounded border text-xs transition-colors
+                                            {{if
+                                                (eq this.draftPhase.vehiclePacking opt.value)
+                                                'bg-indigo-50 dark:bg-indigo-900/30 border-indigo-400 dark:border-indigo-600 text-indigo-700 dark:text-indigo-300'
+                                                'border-gray-200 dark:border-gray-600 text-gray-600 dark:text-gray-400 hover:border-gray-300 dark:hover:border-gray-500'
+                                            }}"
+                                        {{on "click" (fn this.setDraftOption "vehiclePacking" opt.value)}}
+                                    >
+                                        {{opt.label}}
+                                    </button>
+                                {{/each}}
+                            </div>
+                        </InputGroup>
+                    {{/if}}
+
                     {{! Constraint toggles }}
                     <InputGroup @name={{t "orchestrator.constraints"}}>
                         <div class="space-y-1.5">

--- a/addon/components/orchestrator/phase-builder.js
+++ b/addon/components/orchestrator/phase-builder.js
@@ -51,6 +51,7 @@ export default class OrchestratorPhaseBuilderComponent extends Component {
             label: this.intl.t(`orchestrator.mode-${mode.replace(/_/g, '-')}`),
             engine: 'greedy',
             allocationStrategy: 'route_aware',
+            vehiclePacking: 'minimize_vehicles',
             orderStatuses: ['created'],
             balanceWorkload: false,
             respectSkills: true,
@@ -130,6 +131,7 @@ export default class OrchestratorPhaseBuilderComponent extends Component {
             ...this.draftPhase,
             engine,
             allocationStrategy: engine === 'capacity' ? 'capacity_only' : (this.draftPhase.allocationStrategy ?? 'route_aware'),
+            vehiclePacking: this.draftPhase.vehiclePacking ?? 'minimize_vehicles',
         };
     }
 
@@ -158,8 +160,19 @@ export default class OrchestratorPhaseBuilderComponent extends Component {
         ];
     }
 
+    get vehiclePackingOptions() {
+        return [
+            { value: 'minimize_vehicles', label: this.intl.t('orchestrator.vehicle-packing-minimize-vehicles') },
+            { value: 'balanced', label: this.intl.t('orchestrator.vehicle-packing-balanced') },
+        ];
+    }
+
     get shouldShowAllocationStrategy() {
         return this.draftPhase?.mode === 'assign_vehicles' && this.draftPhase?.engine === 'vroom';
+    }
+
+    get shouldShowVehiclePacking() {
+        return this.shouldShowAllocationStrategy && this.draftPhase?.allocationStrategy === 'capacity_only';
     }
 
     get shouldShowRouteOptions() {

--- a/server/seeders/Testing/VroomOrchestrationSeeder.php
+++ b/server/seeders/Testing/VroomOrchestrationSeeder.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Fleetbase\FleetOps\Seeders;
+namespace Fleetbase\FleetOps\Seeders\Testing;
 
 use Fleetbase\FleetOps\Models\Entity;
 use Fleetbase\FleetOps\Models\Order;
@@ -15,6 +15,13 @@ use Illuminate\Database\Seeder;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
 
+/**
+ * Explicit test-data seeder. Kept below server/seeders/Testing so fleetbase:seed
+ * does not auto-discover it during deploys.
+ *
+ * Run with:
+ * php artisan db:seed --class="Fleetbase\\FleetOps\\Seeders\\Testing\\VroomOrchestrationSeeder"
+ */
 class VroomOrchestrationSeeder extends Seeder
 {
     use ResolvesSeedCompany;

--- a/server/src/Orchestration/Engines/VroomOrchestrationEngine.php
+++ b/server/src/Orchestration/Engines/VroomOrchestrationEngine.php
@@ -171,12 +171,17 @@ class VroomOrchestrationEngine implements OrchestrationEngineInterface
         $vroomPayload = $this->buildCapacityOnlyPayload($capacityTasks, $vroomVehicles, $options, $jobIdReverse);
 
         if (empty($vroomPayload['vehicles'])) {
+            $vehiclePacking   = $this->resolveVehiclePacking($options);
+            $vehicleFixedCost = $this->resolveVehicleFixedCost($options);
+
             return $this->mergeInvalidTasks([
                 'assignments' => [],
                 'unassigned'  => array_column($capacityTasks, 'id'),
                 'summary'     => [
                     'engine'              => 'vroom',
                     'allocation_strategy' => 'capacity_only',
+                    'vehicle_packing'     => $vehiclePacking,
+                    'vehicle_fixed_cost'  => $vehiclePacking === 'minimize_vehicles' ? $vehicleFixedCost : null,
                     'assigned'            => 0,
                     'unassigned'          => count($capacityTasks),
                     'unassigned_reasons'  => array_map(fn (array $task) => [
@@ -192,6 +197,8 @@ class VroomOrchestrationEngine implements OrchestrationEngineInterface
         $result['summary'] = array_merge($result['summary'] ?? [], [
             'engine'              => 'vroom',
             'allocation_strategy' => 'capacity_only',
+            'vehicle_packing'     => $this->resolveVehiclePacking($options),
+            'vehicle_fixed_cost'  => $this->resolveVehiclePacking($options) === 'minimize_vehicles' ? $this->resolveVehicleFixedCost($options) : null,
         ]);
 
         return $this->mergeInvalidTasks($result, $invalidTasks);
@@ -203,16 +210,22 @@ class VroomOrchestrationEngine implements OrchestrationEngineInterface
         $profile         = $options['profile'] ?? 'capacity_only';
         $respectCapacity = (bool) ($options['respect_capacity'] ?? true);
         $respectSkills   = (bool) ($options['respect_skills'] ?? true);
+        $vehiclePacking  = $this->resolveVehiclePacking($options);
+        $fixedCost       = $this->resolveVehicleFixedCost($options);
 
         $vroomPayload = [
             'jobs'     => [],
-            'vehicles' => array_map(function (array $v) use ($profile, $respectCapacity, $respectSkills) {
+            'vehicles' => array_map(function (array $v) use ($profile, $respectCapacity, $respectSkills, $vehiclePacking, $fixedCost) {
                 $vehicle = [
                     'id'          => crc32($v['id']),
                     'description' => json_encode(['vehicle_id' => $v['id'], 'driver_id' => $v['driver_id'] ?? null]),
                     'profile'     => $profile,
                     'start_index' => 0,
                 ];
+
+                if ($vehiclePacking === 'minimize_vehicles') {
+                    $vehicle['costs'] = ['fixed' => $fixedCost];
+                }
 
                 if ($respectCapacity) {
                     $vehicle['capacity'] = $v['capacity'];
@@ -263,6 +276,20 @@ class VroomOrchestrationEngine implements OrchestrationEngineInterface
         }
 
         return $vroomPayload;
+    }
+
+    protected function resolveVehiclePacking(array $options): string
+    {
+        $packing = strtolower((string) ($options['vehicle_packing'] ?? 'minimize_vehicles'));
+
+        return in_array($packing, ['minimize_vehicles', 'balanced', 'none'], true)
+            ? $packing
+            : 'minimize_vehicles';
+    }
+
+    protected function resolveVehicleFixedCost(array $options): int
+    {
+        return max(0, (int) ($options['vehicle_fixed_cost'] ?? 100000));
     }
 
     protected function buildUniformMatrix(int $size): array

--- a/server/tests/VroomOrchestrationEngineTest.php
+++ b/server/tests/VroomOrchestrationEngineTest.php
@@ -157,3 +157,94 @@ test('vroom capacity-only payload uses matrix indexes instead of coordinates', f
     expect($payload['matrices']['capacity_only']['durations'])->toHaveCount(2);
     expect(array_values($reverse))->toBe(['order_capacity']);
 });
+
+test('vroom capacity-only payload minimizes vehicles by default', function () {
+    $engine  = new VroomOrchestrationEngine();
+    $method  = new ReflectionMethod($engine, 'buildCapacityOnlyPayload');
+    $reverse = [];
+
+    $method->setAccessible(true);
+
+    $payload = $method->invokeArgs($engine, [[
+        ['id' => 'order_a', 'description' => 'order_a', 'amount' => [100, 250, 1, 2]],
+        ['id' => 'order_b', 'description' => 'order_b', 'amount' => [80, 100, 0, 1]],
+    ], [
+        ['id' => 'vehicle_large', 'driver_id' => null, 'capacity' => [500, 1000, 4, 20]],
+        ['id' => 'vehicle_spare', 'driver_id' => null, 'capacity' => [500, 1000, 4, 20]],
+    ], [], &$reverse]);
+
+    expect($payload['vehicles'][0]['costs'])->toBe(['fixed' => 100000]);
+    expect($payload['vehicles'][1]['costs'])->toBe(['fixed' => 100000]);
+    expect($payload['jobs'])->toHaveCount(2);
+    expect($payload['jobs'][0]['delivery'])->toBe([100, 250, 1, 2]);
+    expect($payload['jobs'][1]['delivery'])->toBe([80, 100, 0, 1]);
+});
+
+test('vroom capacity-only payload accepts custom minimize vehicles fixed cost', function () {
+    $engine  = new VroomOrchestrationEngine();
+    $method  = new ReflectionMethod($engine, 'buildCapacityOnlyPayload');
+    $reverse = [];
+
+    $method->setAccessible(true);
+
+    $payload = $method->invokeArgs($engine, [[
+        ['id' => 'order_a', 'description' => 'order_a', 'amount' => [100, 250, 1, 2]],
+    ], [
+        ['id' => 'vehicle_large', 'driver_id' => null, 'capacity' => [500, 1000, 4, 20]],
+    ], [
+        'vehicle_packing'    => 'minimize_vehicles',
+        'vehicle_fixed_cost' => 50000,
+    ], &$reverse]);
+
+    expect($payload['vehicles'][0]['costs'])->toBe(['fixed' => 50000]);
+});
+
+test('vroom capacity-only payload can disable vehicle packing bias', function (string $packing) {
+    $engine  = new VroomOrchestrationEngine();
+    $method  = new ReflectionMethod($engine, 'buildCapacityOnlyPayload');
+    $reverse = [];
+
+    $method->setAccessible(true);
+
+    $payload = $method->invokeArgs($engine, [[
+        ['id' => 'order_a', 'description' => 'order_a', 'amount' => [100, 250, 1, 2]],
+    ], [
+        ['id' => 'vehicle_large', 'driver_id' => null, 'capacity' => [500, 1000, 4, 20]],
+    ], [
+        'vehicle_packing' => $packing,
+    ], &$reverse]);
+
+    expect($payload['vehicles'][0])->not->toHaveKey('costs');
+})->with(['balanced', 'none']);
+
+test('vroom capacity-only response can assign multiple orders to one large vehicle', function () {
+    $engine = new VroomOrchestrationEngine();
+    $method = new ReflectionMethod($engine, 'mapVroomResponse');
+
+    $method->setAccessible(true);
+
+    $result = $method->invoke($engine, [
+        'routes' => [
+            [
+                'description' => json_encode(['vehicle_id' => 'vehicle_large', 'driver_id' => null]),
+                'steps'       => [
+                    ['type' => 'start'],
+                    ['type' => 'job', 'id' => 1001],
+                    ['type' => 'job', 'id' => 1002],
+                    ['type' => 'job', 'id' => 1003],
+                    ['type' => 'end'],
+                ],
+            ],
+        ],
+        'unassigned' => [],
+        'summary'    => ['routes' => 1],
+    ], [
+        1001 => 'order_a',
+        1002 => 'order_b',
+        1003 => 'order_c',
+    ]);
+
+    expect($result['assignments'])->toHaveCount(3);
+    expect(collect($result['assignments'])->pluck('vehicle_id')->unique()->values()->all())->toBe(['vehicle_large']);
+    expect(collect($result['assignments'])->pluck('order_id')->all())->toBe(['order_a', 'order_b', 'order_c']);
+});

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -1992,6 +1992,9 @@ orchestrator:
     allocation-strategy: Allocation Strategy
     allocation-strategy-route-aware: Route + Capacity
     allocation-strategy-capacity-only: Capacity Only
+    vehicle-packing: Vehicle Packing
+    vehicle-packing-minimize-vehicles: Minimize Vehicles
+    vehicle-packing-balanced: Balanced
     respect-skills: Respect Skills
     respect-capacity: Respect Capacity
     return-to-depot: Return to Depot


### PR DESCRIPTION
## Summary
- Adds VROOM capacity-only vehicle packing policy support with minimize-vehicles as the default.
- Adds fixed vehicle costs to capacity-only VROOM payloads so VROOM prefers filling feasible vehicles before opening another vehicle.
- Adds an orchestrator UI packing selector for VROOM capacity-only phases.
- Moves the VROOM orchestration test seeder under server/seeders/Testing so deploy seeding does not auto-run it.

## Behavior
- Supports options.vehicle_packing values: minimize_vehicles, balanced, none.
- Supports options.vehicle_fixed_cost with default 100000.
- Route-aware VROOM allocation remains unchanged.

## Validation
- php -l server/src/Orchestration/Engines/VroomOrchestrationEngine.php
- php -l server/tests/VroomOrchestrationEngineTest.php
- php -l server/seeders/Testing/VroomOrchestrationSeeder.php
- npx eslint addon/components/orchestrator/phase-builder.js addon/components/orchestrator-workbench.js
- npx ember-template-lint addon/components/orchestrator/phase-builder.hbs
- git diff --check

## Local test blocker
- ./server_vendor/bin/pest server/tests/VroomOrchestrationEngineTest.php is blocked locally because server_vendor/pestphp/pest/vendor/autoload.php is missing and Symfony Console classes are unavailable in this checkout.