### PR TITLE
Add public customer API + OrderConfig resource + Customer.company sub-object

### DIFF
--- a/server/src/Http/Controllers/Api/v1/CustomerController.php
+++ b/server/src/Http/Controllers/Api/v1/CustomerController.php
@@ -11,7 +11,6 @@ use Fleetbase\FleetOps\Http\Resources\v1\Customer as CustomerResource;
 use Fleetbase\FleetOps\Http\Resources\v1\Order as OrderResource;
 use Fleetbase\FleetOps\Http\Resources\v1\Place as PlaceResource;
 use Fleetbase\FleetOps\Models\Contact;
-use Fleetbase\FleetOps\Models\Entity;
 use Fleetbase\FleetOps\Models\Order;
 use Fleetbase\FleetOps\Models\OrderConfig;
 use Fleetbase\FleetOps\Models\Payload;
@@ -205,10 +204,7 @@ class CustomerController extends Controller
             'title'        => $request->input('title'),
             'email'        => $isEmail ? $identity : ($request->input('email') ?: $user->email),
             'phone'        => $isEmail ? static::phone($request->input('phone')) : $identity,
-            'meta'         => array_merge(
-                ['origin' => 'fleetops_customer_portal'],
-                (array) $request->input('meta', [])
-            ),
+            'meta'         => (array) $request->input('meta', []),
         ];
 
         // Handle photo as either file id or base64 data.
@@ -255,13 +251,16 @@ class CustomerController extends Controller
             }
         }
 
-        // If the signup included home-address fields (either nested under meta or
-        // sent as a top-level `address` object), materialize them as a Place
-        // owned by the new customer and set as their default. Idempotent: only
-        // creates a Place when none is already linked.
-        $address = $request->input('address') ?? data_get($input, 'meta.address');
-        if (is_array($address) && !$contact->place_uuid) {
-            $place = $this->createCustomerPlace($contact, $sessionCompany, $address);
+        // Optionally link a default Place to the new customer. Accepts either:
+        //   - a string public_id of an existing Place in this company
+        //   - a Place-shaped object using canonical fields:
+        //       name, street1, street2, city, province, postal_code, country,
+        //       neighborhood, district, building, phone, meta
+        // The created Place is owned by the customer Contact (polymorphic via
+        // owner_uuid + owner_type). Idempotent: only acts when no place is
+        // already linked.
+        if (!$contact->place_uuid) {
+            $place = $this->resolveCustomerPlace($request->input('place'), $contact, $sessionCompany);
             if ($place) {
                 $contact->place_uuid = $place->uuid;
                 $contact->save();
@@ -275,41 +274,44 @@ class CustomerController extends Controller
     }
 
     /**
-     * Materialize a customer's address payload into a Place owned by the
-     * Contact (polymorphic via `owner_uuid` + `owner_type`).
+     * Resolve the customer's default Place reference. Accepts either:
+     *  - a string public_id of an existing Place (must be in the same company)
+     *  - an array of canonical Place fields (Place::$fillable subset)
      *
-     * Accepts both Storefront-style (street1/street2/city/province/postal_code/
-     * country) and portal-form-style (line1/line2/state/zip) keys.
+     * Returns null when no place data was provided. Mirrors the convention
+     * used by other v1 controllers that accept a `place` reference.
      */
-    protected function createCustomerPlace(Contact $contact, string $companyUuid, array $address): ?Place
+    protected function resolveCustomerPlace($input, Contact $contact, string $companyUuid): ?Place
     {
-        $street1     = data_get($address, 'street1') ?? data_get($address, 'line1');
-        $street2     = data_get($address, 'street2') ?? data_get($address, 'line2');
-        $city        = data_get($address, 'city');
-        $province    = data_get($address, 'province') ?? data_get($address, 'state');
-        $postalCode  = data_get($address, 'postal_code') ?? data_get($address, 'zip');
-        $country     = data_get($address, 'country');
-        $placeName   = data_get($address, 'name') ?: trim(($contact->name ?: 'Customer') . ' — Home');
-
-        // Skip when there's nothing usable to save.
-        if (!$street1 && !$city && !$province && !$postalCode) {
+        if (empty($input)) {
             return null;
         }
 
-        return Place::create([
-            'company_uuid' => $companyUuid,
-            'owner_uuid'   => $contact->uuid,
-            'owner_type'   => get_class($contact),
-            'name'         => $placeName,
-            'type'         => 'residential',
-            'street1'      => $street1,
-            'street2'      => $street2,
-            'city'         => $city,
-            'province'     => $province,
-            'postal_code'  => $postalCode,
-            'country'      => $country,
-            'phone'        => $contact->phone,
-        ]);
+        if (is_string($input)) {
+            return Place::where(['public_id' => $input, 'company_uuid' => $companyUuid])->first();
+        }
+
+        if (!is_array($input)) {
+            return null;
+        }
+
+        // Filter the supplied attributes to Place's fillable list — never accept
+        // arbitrary client-specific keys at this surface.
+        $allowed    = ['name', 'street1', 'street2', 'city', 'province', 'postal_code', 'neighborhood', 'district', 'building', 'security_access_code', 'country', 'phone', 'meta', 'type'];
+        $attributes = array_intersect_key($input, array_flip($allowed));
+
+        if (!array_filter($attributes, fn ($v) => $v !== null && $v !== '')) {
+            return null;
+        }
+
+        return Place::create(array_merge(
+            [
+                'company_uuid' => $companyUuid,
+                'owner_uuid'   => $contact->uuid,
+                'owner_type'   => get_class($contact),
+            ],
+            $attributes,
+        ));
     }
 
     /**
@@ -346,7 +348,6 @@ class CustomerController extends Controller
                 'name'  => $user->name,
                 'phone' => $user->phone,
                 'email' => $user->email,
-                'meta'  => ['origin' => 'fleetops_customer_portal'],
             ]
         );
 
@@ -430,7 +431,6 @@ class CustomerController extends Controller
                 'name'  => $user->name,
                 'phone' => $user->phone,
                 'email' => $user->email,
-                'meta'  => ['origin' => 'fleetops_customer_portal'],
             ]
         );
 
@@ -679,11 +679,18 @@ class CustomerController extends Controller
     }
 
     /**
-     * Create a freight order on behalf of the authenticated customer.
+     * Create an Order on behalf of the authenticated customer.
      *
-     * Accepts a lightweight portal-friendly body (item + weight + value + mode
-     * + pickup/dropoff) and maps it into a full Fleet-Ops Order (Payload +
-     * Entity + Places) under the company resolved from the API credential.
+     * Accepts the canonical Fleet-Ops Order create shape (the same fields as
+     * `POST /v1/orders` would accept from an operator): `type` / `order_config`,
+     * `scheduled_at`, `notes`, `meta`, plus either a top-level `payload`
+     * (object or public_id) or top-level `pickup` / `dropoff` / `waypoints` /
+     * `entities` that the controller rolls into a Payload — using the
+     * Payload model's canonical setters for parity with OrderController.
+     *
+     * `customer_uuid` + `customer_type` are forced from the Customer-Token;
+     * any client-supplied `customer` field is ignored. `status` is forced to
+     * `created` (customers cannot self-dispatch).
      */
     public function createOrder(CreateCustomerOrderRequest $request)
     {
@@ -697,63 +704,92 @@ class CustomerController extends Controller
             return response()->apiError('No company resolved from API credential.', 500);
         }
 
-        // Resolve the default order config for the company; fall back to creating
-        // one if none exists yet (matches OrderController behavior expectations).
+        // Resolve the order config for this order. Mirrors OrderController::create.
         $orderConfig = OrderConfig::resolveFromIdentifier($request->only(['type', 'order_config']))
             ?: OrderConfig::where('company_uuid', $sessionCompany)->first();
         if (!$orderConfig) {
-            return response()->apiError('No order config found for this company.', 422);
+            return response()->apiError('No order config available for this company.', 422);
         }
 
-        // Resolve pickup/dropoff Places.
-        $pickup  = $this->resolvePlace($request->input('pickup'), $sessionCompany);
-        $dropoff = $this->resolvePlace($request->input('dropoff'), $sessionCompany);
+        // Build the Payload (matching the operator OrderController convention).
+        // - `payload` may be an array of {pickup, dropoff, return, waypoints, entities}
+        // - `payload` may be a string public_id referencing an existing Payload
+        // - Or top-level pickup/dropoff/return/waypoints/entities are accepted
+        $payloadUuid = null;
+        if ($request->isArray('payload')) {
+            $payloadInput = (array) $request->input('payload');
+            $payloadUuid  = $this->buildPayloadFromInput($payloadInput, $sessionCompany)->uuid;
+        } elseif ($request->isString('payload')) {
+            $payloadUuid = Utils::getUuid('payloads', [
+                'public_id'    => $request->input('payload'),
+                'company_uuid' => $sessionCompany,
+            ]);
+        } else {
+            $payloadInput = $request->only(['pickup', 'dropoff', 'return', 'waypoints', 'entities']);
+            if (array_filter($payloadInput, fn ($v) => $v !== null && $v !== '' && $v !== [])) {
+                $payloadUuid = $this->buildPayloadFromInput($payloadInput, $sessionCompany)->uuid;
+            }
+        }
 
-        // Create the payload.
-        $payload = Payload::create([
-            'company_uuid' => $sessionCompany,
-            'pickup_uuid'  => $pickup?->uuid,
-            'dropoff_uuid' => $dropoff?->uuid,
-        ]);
-
-        // Create the entity (the item being shipped).
-        Entity::create([
-            'company_uuid'   => $sessionCompany,
-            'payload_uuid'   => $payload->uuid,
-            'name'           => $request->input('item'),
-            'description'    => $request->input('category'),
-            'weight'         => $request->input('weight'),
-            'weight_unit'    => $request->input('weight_unit', 'lb'),
-            'declared_value' => $request->input('value'),
-            'currency'       => $request->input('currency', 'USD'),
-            'destination_uuid' => $dropoff?->uuid,
-            'meta'           => [
-                'mode' => $request->input('mode', 'Ocean'),
-            ],
-        ]);
-
-        // Create the order itself.
         $order = Order::create([
             'company_uuid'      => $sessionCompany,
             'customer_uuid'     => $customer->uuid,
             'customer_type'     => Utils::getModelClassName('contact'),
-            'payload_uuid'      => $payload->uuid,
+            'payload_uuid'      => $payloadUuid,
             'order_config_uuid' => $orderConfig->uuid,
             'type'              => $orderConfig->key,
             'status'            => 'created',
             'scheduled_at'      => $request->input('scheduled_at'),
             'notes'             => $request->input('notes'),
-            'meta'              => array_merge(
-                [
-                    'mode'              => $request->input('mode', 'Ocean'),
-                    'delivery_required' => (bool) $request->input('delivery', false),
-                    'origin'            => 'fleetops_customer_portal',
-                ],
-                (array) $request->input('meta', [])
-            ),
+            'internal_id'       => $request->input('internal_id'),
+            'meta'              => (array) $request->input('meta', []),
         ]);
 
         return new OrderResource($order->fresh(['payload', 'payload.pickup', 'payload.dropoff', 'payload.entities']));
+    }
+
+    /**
+     * Build a Payload from the canonical {pickup, dropoff, return, waypoints,
+     * entities} shape. Identical to OrderController::create's payload-building
+     * branch so customer-created orders are indistinguishable from operator-
+     * created ones at the data layer.
+     */
+    protected function buildPayloadFromInput(array $payloadInput, string $companyUuid): Payload
+    {
+        $payload   = new Payload();
+        $entities  = data_get($payloadInput, 'entities', []);
+        $waypoints = data_get($payloadInput, 'waypoints', []);
+        $pickup    = data_get($payloadInput, 'pickup');
+        $dropoff   = data_get($payloadInput, 'dropoff');
+        $return    = data_get($payloadInput, 'return');
+
+        $payload->company_uuid = $companyUuid;
+
+        if ($pickup) {
+            $payload->setPickup($pickup, [
+                'callback' => function ($pickup, $payload) {
+                    $payload->setCurrentWaypoint($pickup);
+                },
+            ]);
+        }
+        if ($dropoff) {
+            $payload->setDropoff($dropoff);
+        }
+        if ($return) {
+            $payload->setReturn($return);
+        }
+
+        $payload->save();
+
+        $payload->setWaypoints($waypoints);
+        $payload->setEntities($entities);
+
+        $firstWaypoint = $payload->getPickupOrFirstWaypoint();
+        if ($firstWaypoint instanceof Place) {
+            $payload->setCurrentWaypoint($firstWaypoint);
+        }
+
+        return $payload;
     }
 
     /**
@@ -805,44 +841,6 @@ class CustomerController extends Controller
     /* ============================================================
      | Helpers
      * ============================================================ */
-
-    /**
-     * Resolve a Place from a free-form payload (either a public_id reference
-     * or an inline address object). Returns null when nothing was supplied.
-     */
-    protected function resolvePlace($input, string $companyUuid): ?Place
-    {
-        if (empty($input)) {
-            return null;
-        }
-
-        // Public-id reference: resolve in-place.
-        if (is_string($input)) {
-            return Place::where(['public_id' => $input, 'company_uuid' => $companyUuid])->first();
-        }
-
-        if (!is_array($input)) {
-            return null;
-        }
-
-        if (isset($input['place']) && is_string($input['place'])) {
-            $existing = Place::where(['public_id' => $input['place'], 'company_uuid' => $companyUuid])->first();
-            if ($existing) {
-                return $existing;
-            }
-        }
-
-        return Place::create([
-            'company_uuid' => $companyUuid,
-            'name'         => $input['name']        ?? null,
-            'street1'      => $input['street1']     ?? null,
-            'street2'      => $input['street2']     ?? null,
-            'city'         => $input['city']        ?? null,
-            'province'     => $input['province']    ?? null,
-            'postal_code'  => $input['postal_code'] ?? null,
-            'country'      => $input['country']     ?? null,
-        ]);
-    }
 
     /**
      * Normalize a phone number to international format (with leading `+`).

--- a/server/src/Http/Controllers/Api/v1/CustomerController.php
+++ b/server/src/Http/Controllers/Api/v1/CustomerController.php
@@ -196,6 +196,10 @@ class CustomerController extends Controller
             }
         }
 
+        // `meta` is a client-owned free-form bag — we pass through whatever the
+        // client sent without injecting controller-side keys. The API should
+        // only stamp meta when the backend itself needs the data to operate
+        // (cf. Storefront's `meta.storefront_id` for query scoping).
         $input = [
             'type'         => 'customer',
             'company_uuid' => $sessionCompany,

--- a/server/src/Http/Controllers/Api/v1/CustomerController.php
+++ b/server/src/Http/Controllers/Api/v1/CustomerController.php
@@ -15,6 +15,7 @@ use Fleetbase\FleetOps\Models\Order;
 use Fleetbase\FleetOps\Models\OrderConfig;
 use Fleetbase\FleetOps\Models\Payload;
 use Fleetbase\FleetOps\Models\Place;
+use Fleetbase\FleetOps\Models\ServiceQuote;
 use Fleetbase\FleetOps\Support\CustomerAuth;
 use Fleetbase\FleetOps\Support\Utils;
 use Fleetbase\Http\Controllers\Controller;
@@ -748,6 +749,14 @@ class CustomerController extends Controller
             'internal_id'       => $request->input('internal_id'),
             'meta'              => (array) $request->input('meta', []),
         ]);
+
+        // If the customer picked a ServiceQuote up front, consume it now to
+        // lock the pricing onto the order's PurchaseRate (mirrors how
+        // OrderController::create handles `service_quote`).
+        $serviceQuote = ServiceQuote::resolveFromRequest($request);
+        if ($serviceQuote instanceof ServiceQuote) {
+            $order->purchaseServiceQuote($serviceQuote);
+        }
 
         return new OrderResource($order->fresh(['payload', 'payload.pickup', 'payload.dropoff', 'payload.entities']));
     }

--- a/server/src/Http/Controllers/Api/v1/CustomerController.php
+++ b/server/src/Http/Controllers/Api/v1/CustomerController.php
@@ -69,25 +69,39 @@ class CustomerController extends Controller
             return response()->apiError('No company resolved from API credential.', 500);
         }
 
-        // The verification code needs a persisted subject so the mail renderer can
-        // resolve the polymorphic `subject` relation (the verification.blade.php
-        // template references `$user->name`). Look up — or stub-create — the User
-        // before sending. On successful verification, `create()` will fill in the
-        // remaining fields (name, password) on this same User.
+        // Optional profile fields the client can include up front so the
+        // verification email greets the customer by name (and so a later
+        // `create()` doesn't need to overwrite stub values).
+        $providedName  = trim((string) $request->input('name', ''));
+        $providedPhone = $request->filled('phone') ? static::phone($request->input('phone')) : null;
+
+        // The verification code needs a persisted subject so the mail renderer
+        // can resolve the polymorphic `subject` relation (the verification blade
+        // template references `$user->name`). Look up — or create — the User
+        // before sending. `create()` later backfills password + remaining fields
+        // on this same row when the customer confirms the code.
         $subject = $isEmail
             ? User::where('email', $identity)->whereNull('deleted_at')->withoutGlobalScopes()->first()
             : User::where('phone', $identity)->whereNull('deleted_at')->withoutGlobalScopes()->first();
 
         if (!$subject) {
-            // `password` and `type` are guarded on User; assign them after create
-            // (setUserType saves, setPasswordAttribute hashes via mutator).
+            // `password` and `type` are guarded on User; assign type after create
+            // via setUserType (saves the row).
             $subject = User::create([
                 'company_uuid' => $sessionCompany,
-                'name'         => 'Pending Customer',
+                'name'         => $providedName !== '' ? $providedName : $identity,
                 'email'        => $isEmail ? $identity : null,
-                'phone'        => $isEmail ? null : $identity,
+                'phone'        => $isEmail ? $providedPhone : $identity,
             ]);
             $subject->setUserType('customer');
+        } elseif ($providedName !== '' && (!$subject->name || $subject->name === $subject->email)) {
+            // Existing stub user from a prior incomplete signup — refresh the
+            // greeting name if the client supplied one.
+            $subject->name = $providedName;
+            if ($isEmail && $providedPhone && !$subject->phone) {
+                $subject->phone = $providedPhone;
+            }
+            $subject->save();
         }
 
         $meta = ['identity' => $identity];

--- a/server/src/Http/Controllers/Api/v1/CustomerController.php
+++ b/server/src/Http/Controllers/Api/v1/CustomerController.php
@@ -64,12 +64,31 @@ class CustomerController extends Controller
             $identity = static::phone($identity);
         }
 
-        // We need a Contact-like subject to attach the verification code to. The
-        // Contact instance is unsaved here — VerificationCode only needs its
-        // identifiers for the `subject_uuid` polymorphic link.
-        $subject = new Contact([
-            $isEmail ? 'email' : 'phone' => $identity,
-        ]);
+        $sessionCompany = session('company');
+        if (!$sessionCompany) {
+            return response()->apiError('No company resolved from API credential.', 500);
+        }
+
+        // The verification code needs a persisted subject so the mail renderer can
+        // resolve the polymorphic `subject` relation (the verification.blade.php
+        // template references `$user->name`). Look up — or stub-create — the User
+        // before sending. On successful verification, `create()` will fill in the
+        // remaining fields (name, password) on this same User.
+        $subject = $isEmail
+            ? User::where('email', $identity)->whereNull('deleted_at')->withoutGlobalScopes()->first()
+            : User::where('phone', $identity)->whereNull('deleted_at')->withoutGlobalScopes()->first();
+
+        if (!$subject) {
+            // `password` and `type` are guarded on User; assign them after create
+            // (setUserType saves, setPasswordAttribute hashes via mutator).
+            $subject = User::create([
+                'company_uuid' => $sessionCompany,
+                'name'         => 'Pending Customer',
+                'email'        => $isEmail ? $identity : null,
+                'phone'        => $isEmail ? null : $identity,
+            ]);
+            $subject->setUserType('customer');
+        }
 
         $meta = ['identity' => $identity];
 
@@ -131,19 +150,36 @@ class CustomerController extends Controller
         }
 
         if (!$user) {
+            // `password` and `type` are guarded on User; assign them after create
+            // (setUserType saves the type, setPasswordAttribute hashes plaintext).
             $user = User::create([
-                'type'         => 'customer',
                 'company_uuid' => $sessionCompany,
                 'name'         => $request->input('name'),
                 'email'        => $isEmail ? $identity : $request->input('email'),
                 'phone'        => $isEmail ? static::phone($request->input('phone')) : $identity,
-                'password'     => Hash::make($request->input('password')),
             ]);
-        } elseif ($request->filled('password')) {
-            // If the matched user has no password set yet, set it.
+            $user->password = $request->input('password');
+            $user->save();
+            $user->setUserType('customer');
+        } else {
+            // User row exists. If it's a stub created during request-creation-code
+            // (no password set yet), backfill name + password + email/phone from
+            // the signup form. If a password is already set this is an existing
+            // account — only attach a new Contact, don't overwrite credentials.
             if (!$user->password) {
-                $user->password = Hash::make($request->input('password'));
+                $update = ['name' => $request->input('name')];
+                if ($isEmail && !$user->phone && $request->filled('phone')) {
+                    $update['phone'] = static::phone($request->input('phone'));
+                }
+                if (!$isEmail && !$user->email && $request->filled('email')) {
+                    $update['email'] = $request->input('email');
+                }
+                $user->fill($update);
+                $user->password = $request->input('password'); // mutator hashes
                 $user->save();
+                if (!$user->type) {
+                    $user->setUserType('customer');
+                }
             }
         }
 
@@ -151,9 +187,9 @@ class CustomerController extends Controller
             'type'         => 'customer',
             'company_uuid' => $sessionCompany,
             'user_uuid'    => $user->uuid,
-            'name'         => $request->input('name'),
+            'name'         => $request->input('name') ?: $user->name,
             'title'        => $request->input('title'),
-            'email'        => $isEmail ? $identity : $request->input('email'),
+            'email'        => $isEmail ? $identity : ($request->input('email') ?: $user->email),
             'phone'        => $isEmail ? static::phone($request->input('phone')) : $identity,
             'meta'         => array_merge(
                 ['origin' => 'fleetops_customer_portal'],
@@ -179,20 +215,30 @@ class CustomerController extends Controller
             }
         }
 
-        try {
-            $contact = Contact::create($input);
-        } catch (UserAlreadyExistsException $e) {
-            // The contact already exists for this company; resolve it.
-            $contact = Contact::where([
-                'company_uuid' => $sessionCompany,
-                'user_uuid'    => $user->uuid,
-                'type'         => 'customer',
-            ])->first();
-            if (!$contact) {
+        // Reuse an existing customer-Contact for this user+company if one exists
+        // (idempotent re-signup), otherwise create one.
+        $contact = Contact::where([
+            'company_uuid' => $sessionCompany,
+            'user_uuid'    => $user->uuid,
+            'type'         => 'customer',
+        ])->first();
+        if ($contact) {
+            $contact->fill(array_filter($input, fn ($v) => $v !== null && $v !== ''))->save();
+        } else {
+            try {
+                $contact = Contact::create($input);
+            } catch (UserAlreadyExistsException $e) {
+                $contact = Contact::where([
+                    'company_uuid' => $sessionCompany,
+                    'user_uuid'    => $user->uuid,
+                    'type'         => 'customer',
+                ])->first();
+                if (!$contact) {
+                    return response()->apiError($e->getMessage());
+                }
+            } catch (\Exception $e) {
                 return response()->apiError($e->getMessage());
             }
-        } catch (\Exception $e) {
-            return response()->apiError($e->getMessage());
         }
 
         $token          = $user->createToken($contact->uuid);
@@ -404,7 +450,8 @@ class CustomerController extends Controller
             return response()->apiError('Account not found.');
         }
 
-        $user->password = Hash::make($password);
+        // setPasswordAttribute mutator hashes plaintext; don't pre-hash here.
+        $user->password = $password;
         $user->save();
         // Invalidate all existing sessions for this user after a password reset.
         $user->tokens()->delete();

--- a/server/src/Http/Controllers/Api/v1/CustomerController.php
+++ b/server/src/Http/Controllers/Api/v1/CustomerController.php
@@ -1,0 +1,753 @@
+<?php
+
+namespace Fleetbase\FleetOps\Http\Controllers\Api\v1;
+
+use Fleetbase\FleetOps\Exceptions\UserAlreadyExistsException;
+use Fleetbase\FleetOps\Http\Requests\CreateCustomerOrderRequest;
+use Fleetbase\FleetOps\Http\Requests\CreateCustomerRequest;
+use Fleetbase\FleetOps\Http\Requests\UpdateContactRequest;
+use Fleetbase\FleetOps\Http\Requests\VerifyCreateCustomerRequest;
+use Fleetbase\FleetOps\Http\Resources\v1\Customer as CustomerResource;
+use Fleetbase\FleetOps\Http\Resources\v1\Order as OrderResource;
+use Fleetbase\FleetOps\Http\Resources\v1\Place as PlaceResource;
+use Fleetbase\FleetOps\Models\Contact;
+use Fleetbase\FleetOps\Models\Entity;
+use Fleetbase\FleetOps\Models\Order;
+use Fleetbase\FleetOps\Models\OrderConfig;
+use Fleetbase\FleetOps\Models\Payload;
+use Fleetbase\FleetOps\Models\Place;
+use Fleetbase\FleetOps\Support\CustomerAuth;
+use Fleetbase\FleetOps\Support\Utils;
+use Fleetbase\Http\Controllers\Controller;
+use Fleetbase\Models\File;
+use Fleetbase\Models\User;
+use Fleetbase\Models\UserDevice;
+use Fleetbase\Models\VerificationCode;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Str;
+
+/**
+ * Customer-facing Fleet-Ops API.
+ *
+ * Mirrors the Storefront customer surface (signup with verification code,
+ * email/password login, SMS login, customer-scoped orders & places) but
+ * authenticates entirely with the Fleet-Ops API credential (`flb_live_…`) on
+ * the public routes and a Sanctum `Customer-Token` (issued by signup/login)
+ * on the authenticated routes. The company tenancy boundary is enforced by
+ * the standard `fleetbase.api` middleware that resolves the API credential
+ * to a `company_uuid` and sets it on the session.
+ */
+class CustomerController extends Controller
+{
+    /* ============================================================
+     | Public auth flows (API credential only, no Customer-Token)
+     * ============================================================ */
+
+    /**
+     * Send an email or SMS verification code so a new customer can complete signup.
+     *
+     * @return JsonResponse
+     */
+    public function requestCreationCode(VerifyCreateCustomerRequest $request)
+    {
+        $mode     = $request->input('mode', 'email');
+        $identity = $request->input('identity');
+        $isEmail  = Utils::isEmail($identity);
+
+        if ($mode === 'email' && !$isEmail) {
+            return response()->apiError('Invalid email provided for identity.');
+        }
+
+        if ($mode === 'sms') {
+            $identity = static::phone($identity);
+        }
+
+        // We need a Contact-like subject to attach the verification code to. The
+        // Contact instance is unsaved here — VerificationCode only needs its
+        // identifiers for the `subject_uuid` polymorphic link.
+        $subject = new Contact([
+            $isEmail ? 'email' : 'phone' => $identity,
+        ]);
+
+        $meta = ['identity' => $identity];
+
+        try {
+            if ($mode === 'email') {
+                VerificationCode::generateEmailVerificationFor($subject, 'fleetops_create_customer', [
+                    'subject'         => config('app.name') . ' verification code',
+                    'messageCallback' => fn ($verification) => 'Your ' . config('app.name') . ' verification code is ' . $verification->code,
+                    'meta'            => $meta,
+                ]);
+            } else {
+                VerificationCode::generateSmsVerificationFor($subject, 'fleetops_create_customer', [
+                    'messageCallback' => fn ($verification) => 'Your ' . config('app.name') . ' verification code is ' . $verification->code,
+                    'meta'            => $meta,
+                ]);
+            }
+        } catch (\Twilio\Exceptions\RestException $e) {
+            return response()->apiError($e->getMessage());
+        } catch (\Exception $e) {
+            return response()->apiError(app()->hasDebugModeEnabled() ? $e->getMessage() : 'Error sending verification code.');
+        }
+
+        return response()->json(['status' => 'ok']);
+    }
+
+    /**
+     * Create a new customer (Contact + User) after verifying their code.
+     */
+    public function create(CreateCustomerRequest $request)
+    {
+        $code     = $request->input('code');
+        $identity = $request->input('identity');
+        $isEmail  = Utils::isEmail($identity);
+        if (!$isEmail) {
+            $identity = static::phone($identity);
+        }
+
+        // Verify the code is one we sent for this identity.
+        $verificationCode = VerificationCode::where([
+            'code'           => $code,
+            'for'            => 'fleetops_create_customer',
+            'meta->identity' => $identity,
+        ])->exists();
+        if (!$verificationCode) {
+            return response()->apiError('Invalid verification code provided.');
+        }
+
+        $sessionCompany = session('company');
+        if (!$sessionCompany) {
+            return response()->apiError('No company resolved from API credential.', 500);
+        }
+
+        // Attach to existing User if one matches the identity, otherwise create one.
+        $user = null;
+        if ($isEmail) {
+            $user = User::where('email', $identity)->whereNull('deleted_at')->withoutGlobalScopes()->first();
+        } elseif (Str::startsWith($identity, '+')) {
+            $user = User::where('phone', $identity)->whereNull('deleted_at')->withoutGlobalScopes()->first();
+        }
+
+        if (!$user) {
+            $user = User::create([
+                'type'         => 'customer',
+                'company_uuid' => $sessionCompany,
+                'name'         => $request->input('name'),
+                'email'        => $isEmail ? $identity : $request->input('email'),
+                'phone'        => $isEmail ? static::phone($request->input('phone')) : $identity,
+                'password'     => Hash::make($request->input('password')),
+            ]);
+        } elseif ($request->filled('password')) {
+            // If the matched user has no password set yet, set it.
+            if (!$user->password) {
+                $user->password = Hash::make($request->input('password'));
+                $user->save();
+            }
+        }
+
+        $input = [
+            'type'         => 'customer',
+            'company_uuid' => $sessionCompany,
+            'user_uuid'    => $user->uuid,
+            'name'         => $request->input('name'),
+            'title'        => $request->input('title'),
+            'email'        => $isEmail ? $identity : $request->input('email'),
+            'phone'        => $isEmail ? static::phone($request->input('phone')) : $identity,
+            'meta'         => array_merge(
+                ['origin' => 'fleetops_customer_portal'],
+                (array) $request->input('meta', [])
+            ),
+        ];
+
+        // Handle photo as either file id or base64 data.
+        $photo = $request->input('photo');
+        if ($photo) {
+            if (Utils::isPublicId($photo)) {
+                $file = File::where('public_id', $photo)->first();
+                if ($file) {
+                    $input['photo_uuid'] = $file->uuid;
+                }
+            }
+            if (Utils::isBase64String($photo)) {
+                $path = implode('/', ['uploads', $sessionCompany, 'customers']);
+                $file = File::createFromBase64($photo, null, $path);
+                if ($file) {
+                    $input['photo_uuid'] = $file->uuid;
+                }
+            }
+        }
+
+        try {
+            $contact = Contact::create($input);
+        } catch (UserAlreadyExistsException $e) {
+            // The contact already exists for this company; resolve it.
+            $contact = Contact::where([
+                'company_uuid' => $sessionCompany,
+                'user_uuid'    => $user->uuid,
+                'type'         => 'customer',
+            ])->first();
+            if (!$contact) {
+                return response()->apiError($e->getMessage());
+            }
+        } catch (\Exception $e) {
+            return response()->apiError($e->getMessage());
+        }
+
+        $token          = $user->createToken($contact->uuid);
+        $contact->token = $token->plainTextToken;
+
+        return new CustomerResource($contact);
+    }
+
+    /**
+     * Authenticate an existing customer with email/phone + password.
+     */
+    public function login(Request $request)
+    {
+        $identity = $request->input('identity');
+        $password = $request->input('password');
+        if (!$identity || !$password) {
+            return response()->apiError('Identity and password are required.', 400);
+        }
+
+        $user = User::where('email', $identity)
+            ->orWhere('phone', static::phone($identity))
+            ->first();
+
+        if (!$user || !$user->password || !Hash::check($password, $user->password)) {
+            return response()->apiError('Authentication failed using credentials provided.', 401);
+        }
+
+        $sessionCompany = session('company');
+        if (!$sessionCompany) {
+            return response()->apiError('No company resolved from API credential.', 500);
+        }
+
+        $contact = Contact::firstOrCreate(
+            [
+                'user_uuid'    => $user->uuid,
+                'company_uuid' => $sessionCompany,
+                'type'         => 'customer',
+            ],
+            [
+                'name'  => $user->name,
+                'phone' => $user->phone,
+                'email' => $user->email,
+                'meta'  => ['origin' => 'fleetops_customer_portal'],
+            ]
+        );
+
+        $token          = $user->createToken($contact->uuid);
+        $contact->token = $token->plainTextToken;
+
+        return new CustomerResource($contact);
+    }
+
+    /**
+     * Send an SMS verification code so a customer can log in without password.
+     */
+    public function loginWithPhone(Request $request)
+    {
+        $phone = static::phone($request->input('phone') ?? $request->input('identity'));
+
+        $user = User::where('phone', $phone)->whereNull('deleted_at')->withoutGlobalScopes()->first();
+        if (!$user) {
+            return response()->apiError('No customer with this phone number found.');
+        }
+
+        try {
+            VerificationCode::generateSmsVerificationFor($user, 'fleetops_customer_login', [
+                'messageCallback' => fn ($verification) => 'Your ' . config('app.name') . ' verification code is ' . $verification->code,
+            ]);
+
+            return response()->json(['status' => 'ok', 'method' => 'sms']);
+        } catch (\Throwable $e) {
+            if ($user->email) {
+                try {
+                    VerificationCode::generateEmailVerificationFor($user, 'fleetops_customer_login', [
+                        'subject'         => config('app.name') . ' verification code',
+                        'messageCallback' => fn ($verification) => 'Your ' . config('app.name') . ' verification code is ' . $verification->code,
+                    ]);
+
+                    return response()->json(['status' => 'ok', 'method' => 'email']);
+                } catch (\Throwable $inner) {
+                    return response()->apiError('Unable to send verification code.');
+                }
+            }
+        }
+
+        return response()->apiError('Unable to send verification code.');
+    }
+
+    /**
+     * Verify the SMS/email code from {@see loginWithPhone} and issue a token.
+     */
+    public function verifyCode(Request $request)
+    {
+        $identity = Utils::isEmail($request->input('identity')) ? $request->input('identity') : static::phone($request->input('identity'));
+        $code     = $request->input('code');
+        $for      = $request->input('for', 'fleetops_customer_login');
+
+        if ($for === 'fleetops_create_customer') {
+            return $this->create($request);
+        }
+
+        $user = User::where('phone', $identity)->orWhere('email', $identity)->first();
+        if (!$user) {
+            return response()->apiError('Unable to verify code.');
+        }
+
+        $verificationCode = VerificationCode::where([
+            'subject_uuid' => $user->uuid,
+            'code'         => $code,
+            'for'          => $for,
+        ])->exists();
+        if (!$verificationCode) {
+            return response()->apiError('Invalid verification code.');
+        }
+
+        $sessionCompany = session('company');
+        $contact        = Contact::firstOrCreate(
+            [
+                'user_uuid'    => $user->uuid,
+                'company_uuid' => $sessionCompany,
+                'type'         => 'customer',
+            ],
+            [
+                'name'  => $user->name,
+                'phone' => $user->phone,
+                'email' => $user->email,
+                'meta'  => ['origin' => 'fleetops_customer_portal'],
+            ]
+        );
+
+        $token          = $user->createToken($contact->uuid);
+        $contact->token = $token->plainTextToken;
+
+        return new CustomerResource($contact);
+    }
+
+    /**
+     * Send a password-reset code to the customer's email or phone.
+     */
+    public function forgotPassword(Request $request)
+    {
+        $identity = $request->input('identity');
+        if (!$identity) {
+            return response()->apiError('Identity is required.', 400);
+        }
+
+        $isEmail = Utils::isEmail($identity);
+        $user    = $isEmail
+            ? User::where('email', $identity)->first()
+            : User::where('phone', static::phone($identity))->first();
+
+        if (!$user) {
+            // Don't leak account existence — return success regardless.
+            return response()->json(['status' => 'ok']);
+        }
+
+        $meta = ['identity' => $isEmail ? $identity : static::phone($identity)];
+        try {
+            if ($isEmail) {
+                VerificationCode::generateEmailVerificationFor($user, 'fleetops_customer_password_reset', [
+                    'subject'         => config('app.name') . ' password reset',
+                    'messageCallback' => fn ($v) => 'Your ' . config('app.name') . ' password reset code is ' . $v->code,
+                    'meta'            => $meta,
+                ]);
+            } else {
+                VerificationCode::generateSmsVerificationFor($user, 'fleetops_customer_password_reset', [
+                    'messageCallback' => fn ($v) => 'Your ' . config('app.name') . ' password reset code is ' . $v->code,
+                    'meta'            => $meta,
+                ]);
+            }
+        } catch (\Throwable $e) {
+            return response()->apiError(app()->hasDebugModeEnabled() ? $e->getMessage() : 'Unable to send reset code.');
+        }
+
+        return response()->json(['status' => 'ok']);
+    }
+
+    /**
+     * Verify the password-reset code and set a new password.
+     */
+    public function resetPassword(Request $request)
+    {
+        $identity = $request->input('identity');
+        $code     = $request->input('code');
+        $password = $request->input('password');
+        if (!$identity || !$code || !$password) {
+            return response()->apiError('identity, code, and password are required.', 400);
+        }
+        if (strlen($password) < 8) {
+            return response()->apiError('Password must be at least 8 characters.', 400);
+        }
+
+        $isEmail = Utils::isEmail($identity);
+        $needle  = $isEmail ? $identity : static::phone($identity);
+
+        $verificationCode = VerificationCode::where([
+            'code'           => $code,
+            'for'            => 'fleetops_customer_password_reset',
+            'meta->identity' => $needle,
+        ])->first();
+        if (!$verificationCode) {
+            return response()->apiError('Invalid reset code.');
+        }
+
+        $user = $isEmail
+            ? User::where('email', $needle)->first()
+            : User::where('phone', $needle)->first();
+        if (!$user) {
+            return response()->apiError('Account not found.');
+        }
+
+        $user->password = Hash::make($password);
+        $user->save();
+        // Invalidate all existing sessions for this user after a password reset.
+        $user->tokens()->delete();
+        $verificationCode->delete();
+
+        return response()->json(['status' => 'ok']);
+    }
+
+    /* ============================================================
+     | Authenticated flows (require Customer-Token)
+     * ============================================================ */
+
+    /**
+     * Return the authenticated customer's profile.
+     */
+    public function me()
+    {
+        $customer = CustomerAuth::current();
+        if (!$customer) {
+            return response()->apiError('Not authenticated.', 401);
+        }
+
+        return new CustomerResource($customer);
+    }
+
+    /**
+     * Update the authenticated customer's profile (Contact + linked User fields).
+     */
+    public function updateMe(UpdateContactRequest $request)
+    {
+        $customer = CustomerAuth::current();
+        if (!$customer) {
+            return response()->apiError('Not authenticated.', 401);
+        }
+
+        $input = $request->only(['name', 'title', 'email', 'phone', 'meta']);
+        if (isset($input['phone'])) {
+            $input['phone'] = static::phone($input['phone']);
+        }
+
+        // Photo handling.
+        $photo = $request->input('photo');
+        if ($photo) {
+            if (Utils::isPublicId($photo)) {
+                $file = File::where('public_id', $photo)->first();
+                if ($file) {
+                    $input['photo_uuid'] = $file->uuid;
+                }
+            }
+            if (Utils::isBase64String($photo)) {
+                $path = implode('/', ['uploads', session('company'), 'customers']);
+                $file = File::createFromBase64($photo, null, $path);
+                if ($file) {
+                    $input['photo_uuid'] = $file->uuid;
+                }
+            }
+            if ($photo === 'REMOVE') {
+                $input['photo_uuid'] = null;
+            }
+        }
+
+        try {
+            $customer->update($input);
+        } catch (\Exception $e) {
+            return response()->apiError($e->getMessage());
+        }
+
+        // Mirror critical fields on the linked User row so login works after edits.
+        if ($customer->user_uuid) {
+            $userUpdate = array_filter([
+                'name'  => $input['name']  ?? null,
+                'email' => $input['email'] ?? null,
+                'phone' => $input['phone'] ?? null,
+            ], fn ($v) => $v !== null);
+            if (!empty($userUpdate)) {
+                User::where('uuid', $customer->user_uuid)->update($userUpdate);
+            }
+        }
+
+        return new CustomerResource($customer->fresh());
+    }
+
+    /**
+     * Revoke the Customer-Token used on this request.
+     */
+    public function logout(Request $request)
+    {
+        $customer = CustomerAuth::current();
+        if (!$customer) {
+            return response()->apiError('Not authenticated.', 401);
+        }
+
+        $tokenString = $request->header(CustomerAuth::HEADER);
+        $accessToken = $tokenString ? \Laravel\Sanctum\PersonalAccessToken::findToken($tokenString) : null;
+        if ($accessToken) {
+            $accessToken->delete();
+        }
+
+        return response()->json(['status' => 'ok']);
+    }
+
+    /**
+     * Revoke ALL tokens for the authenticated customer's user (sign out everywhere).
+     */
+    public function logoutAll()
+    {
+        $customer = CustomerAuth::current();
+        if (!$customer || !$customer->user_uuid) {
+            return response()->apiError('Not authenticated.', 401);
+        }
+
+        $user = User::where('uuid', $customer->user_uuid)->first();
+        if ($user) {
+            $user->tokens()->delete();
+        }
+
+        return response()->json(['status' => 'ok']);
+    }
+
+    /**
+     * List the authenticated customer's orders.
+     */
+    public function orders(Request $request)
+    {
+        $customer = CustomerAuth::current();
+        if (!$customer) {
+            return response()->apiError('Not authenticated.', 401);
+        }
+
+        $results = Order::queryWithRequest($request, function (&$query) use ($customer) {
+            $query->where('customer_uuid', $customer->uuid)
+                ->whereNull('deleted_at')
+                ->withoutGlobalScopes();
+        });
+
+        return OrderResource::collection($results);
+    }
+
+    /**
+     * Fetch one order owned by the authenticated customer.
+     */
+    public function findOrder(string $id)
+    {
+        $customer = CustomerAuth::current();
+        if (!$customer) {
+            return response()->apiError('Not authenticated.', 401);
+        }
+
+        try {
+            $order = Order::findRecordOrFail($id);
+        } catch (\Illuminate\Database\Eloquent\ModelNotFoundException $e) {
+            return response()->apiError('Order not found.', 404);
+        }
+
+        if ($order->customer_uuid !== $customer->uuid) {
+            return response()->apiError('Order not found.', 404);
+        }
+
+        return new OrderResource($order);
+    }
+
+    /**
+     * Create a freight order on behalf of the authenticated customer.
+     *
+     * Accepts a lightweight portal-friendly body (item + weight + value + mode
+     * + pickup/dropoff) and maps it into a full Fleet-Ops Order (Payload +
+     * Entity + Places) under the company resolved from the API credential.
+     */
+    public function createOrder(CreateCustomerOrderRequest $request)
+    {
+        $customer = CustomerAuth::current();
+        if (!$customer) {
+            return response()->apiError('Not authenticated.', 401);
+        }
+
+        $sessionCompany = session('company');
+        if (!$sessionCompany) {
+            return response()->apiError('No company resolved from API credential.', 500);
+        }
+
+        // Resolve the default order config for the company; fall back to creating
+        // one if none exists yet (matches OrderController behavior expectations).
+        $orderConfig = OrderConfig::resolveFromIdentifier($request->only(['type', 'order_config']))
+            ?: OrderConfig::where('company_uuid', $sessionCompany)->first();
+        if (!$orderConfig) {
+            return response()->apiError('No order config found for this company.', 422);
+        }
+
+        // Resolve pickup/dropoff Places.
+        $pickup  = $this->resolvePlace($request->input('pickup'), $sessionCompany);
+        $dropoff = $this->resolvePlace($request->input('dropoff'), $sessionCompany);
+
+        // Create the payload.
+        $payload = Payload::create([
+            'company_uuid' => $sessionCompany,
+            'pickup_uuid'  => $pickup?->uuid,
+            'dropoff_uuid' => $dropoff?->uuid,
+        ]);
+
+        // Create the entity (the item being shipped).
+        Entity::create([
+            'company_uuid'   => $sessionCompany,
+            'payload_uuid'   => $payload->uuid,
+            'name'           => $request->input('item'),
+            'description'    => $request->input('category'),
+            'weight'         => $request->input('weight'),
+            'weight_unit'    => $request->input('weight_unit', 'lb'),
+            'declared_value' => $request->input('value'),
+            'currency'       => $request->input('currency', 'USD'),
+            'destination_uuid' => $dropoff?->uuid,
+            'meta'           => [
+                'mode' => $request->input('mode', 'Ocean'),
+            ],
+        ]);
+
+        // Create the order itself.
+        $order = Order::create([
+            'company_uuid'      => $sessionCompany,
+            'customer_uuid'     => $customer->uuid,
+            'customer_type'     => Utils::getModelClassName('contact'),
+            'payload_uuid'      => $payload->uuid,
+            'order_config_uuid' => $orderConfig->uuid,
+            'type'              => $orderConfig->key,
+            'status'            => 'created',
+            'scheduled_at'      => $request->input('scheduled_at'),
+            'notes'             => $request->input('notes'),
+            'meta'              => array_merge(
+                [
+                    'mode'              => $request->input('mode', 'Ocean'),
+                    'delivery_required' => (bool) $request->input('delivery', false),
+                    'origin'            => 'fleetops_customer_portal',
+                ],
+                (array) $request->input('meta', [])
+            ),
+        ]);
+
+        return new OrderResource($order->fresh(['payload', 'payload.pickup', 'payload.dropoff', 'payload.entities']));
+    }
+
+    /**
+     * List the authenticated customer's saved places.
+     */
+    public function places(Request $request)
+    {
+        $customer = CustomerAuth::current();
+        if (!$customer) {
+            return response()->apiError('Not authenticated.', 401);
+        }
+
+        $results = Place::queryWithRequest($request, function (&$query) use ($customer) {
+            $query->where('owner_uuid', $customer->uuid);
+        });
+
+        return PlaceResource::collection($results);
+    }
+
+    /**
+     * Register a push-notification device for the authenticated customer's user.
+     */
+    public function registerDevice(Request $request)
+    {
+        $customer = CustomerAuth::current();
+        if (!$customer) {
+            return response()->apiError('Not authenticated.', 401);
+        }
+
+        $device = UserDevice::firstOrCreate(
+            [
+                'token'    => $request->input('token'),
+                'platform' => $request->input('platform', $request->input('os')),
+            ],
+            [
+                'user_uuid' => $customer->user_uuid,
+                'platform'  => $request->input('platform', $request->input('os')),
+                'token'     => $request->input('token'),
+                'status'    => 'active',
+            ]
+        );
+
+        return response()->json([
+            'status' => 'ok',
+            'device' => $device->public_id,
+        ]);
+    }
+
+    /* ============================================================
+     | Helpers
+     * ============================================================ */
+
+    /**
+     * Resolve a Place from a free-form payload (either a public_id reference
+     * or an inline address object). Returns null when nothing was supplied.
+     */
+    protected function resolvePlace($input, string $companyUuid): ?Place
+    {
+        if (empty($input)) {
+            return null;
+        }
+
+        // Public-id reference: resolve in-place.
+        if (is_string($input)) {
+            return Place::where(['public_id' => $input, 'company_uuid' => $companyUuid])->first();
+        }
+
+        if (!is_array($input)) {
+            return null;
+        }
+
+        if (isset($input['place']) && is_string($input['place'])) {
+            $existing = Place::where(['public_id' => $input['place'], 'company_uuid' => $companyUuid])->first();
+            if ($existing) {
+                return $existing;
+            }
+        }
+
+        return Place::create([
+            'company_uuid' => $companyUuid,
+            'name'         => $input['name']        ?? null,
+            'street1'      => $input['street1']     ?? null,
+            'street2'      => $input['street2']     ?? null,
+            'city'         => $input['city']        ?? null,
+            'province'     => $input['province']    ?? null,
+            'postal_code'  => $input['postal_code'] ?? null,
+            'country'      => $input['country']     ?? null,
+        ]);
+    }
+
+    /**
+     * Normalize a phone number to international format (with leading `+`).
+     */
+    public static function phone(?string $phone = null): string
+    {
+        if ($phone === null) {
+            $phone = request()->input('phone', '');
+        }
+        $phone = trim((string) $phone);
+        if ($phone === '') {
+            return '';
+        }
+        if (!Str::startsWith($phone, '+')) {
+            $phone = '+' . ltrim($phone, '+');
+        }
+
+        return $phone;
+    }
+}

--- a/server/src/Http/Controllers/Api/v1/CustomerController.php
+++ b/server/src/Http/Controllers/Api/v1/CustomerController.php
@@ -255,10 +255,61 @@ class CustomerController extends Controller
             }
         }
 
+        // If the signup included home-address fields (either nested under meta or
+        // sent as a top-level `address` object), materialize them as a Place
+        // owned by the new customer and set as their default. Idempotent: only
+        // creates a Place when none is already linked.
+        $address = $request->input('address') ?? data_get($input, 'meta.address');
+        if (is_array($address) && !$contact->place_uuid) {
+            $place = $this->createCustomerPlace($contact, $sessionCompany, $address);
+            if ($place) {
+                $contact->place_uuid = $place->uuid;
+                $contact->save();
+            }
+        }
+
         $token          = $user->createToken($contact->uuid);
         $contact->token = $token->plainTextToken;
 
         return new CustomerResource($contact);
+    }
+
+    /**
+     * Materialize a customer's address payload into a Place owned by the
+     * Contact (polymorphic via `owner_uuid` + `owner_type`).
+     *
+     * Accepts both Storefront-style (street1/street2/city/province/postal_code/
+     * country) and portal-form-style (line1/line2/state/zip) keys.
+     */
+    protected function createCustomerPlace(Contact $contact, string $companyUuid, array $address): ?Place
+    {
+        $street1     = data_get($address, 'street1') ?? data_get($address, 'line1');
+        $street2     = data_get($address, 'street2') ?? data_get($address, 'line2');
+        $city        = data_get($address, 'city');
+        $province    = data_get($address, 'province') ?? data_get($address, 'state');
+        $postalCode  = data_get($address, 'postal_code') ?? data_get($address, 'zip');
+        $country     = data_get($address, 'country');
+        $placeName   = data_get($address, 'name') ?: trim(($contact->name ?: 'Customer') . ' — Home');
+
+        // Skip when there's nothing usable to save.
+        if (!$street1 && !$city && !$province && !$postalCode) {
+            return null;
+        }
+
+        return Place::create([
+            'company_uuid' => $companyUuid,
+            'owner_uuid'   => $contact->uuid,
+            'owner_type'   => get_class($contact),
+            'name'         => $placeName,
+            'type'         => 'residential',
+            'street1'      => $street1,
+            'street2'      => $street2,
+            'city'         => $city,
+            'province'     => $province,
+            'postal_code'  => $postalCode,
+            'country'      => $country,
+            'phone'        => $contact->phone,
+        ]);
     }
 
     /**

--- a/server/src/Http/Controllers/Api/v1/OrderConfigController.php
+++ b/server/src/Http/Controllers/Api/v1/OrderConfigController.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Fleetbase\FleetOps\Http\Controllers\Api\v1;
+
+use Fleetbase\FleetOps\Http\Resources\v1\OrderConfig as OrderConfigResource;
+use Fleetbase\FleetOps\Models\OrderConfig;
+use Fleetbase\Http\Controllers\Controller;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Http\Request;
+
+/**
+ * Public, read-only API surface for OrderConfigs.
+ *
+ * The internal admin console manages the full OrderConfig lifecycle through
+ * `/int/v1/order-configs`. This public endpoint exposes the projected,
+ * non-sensitive subset (flow activities + metadata) that consumers like a
+ * customer portal need to render status filter chips, activity labels, and
+ * other UI driven by the active flow.
+ */
+class OrderConfigController extends Controller
+{
+    /**
+     * List the OrderConfigs for the company resolved from the API credential.
+     *
+     * @return \Illuminate\Http\Resources\Json\AnonymousResourceCollection
+     */
+    public function query(Request $request)
+    {
+        $results = OrderConfig::queryWithRequest($request);
+
+        return OrderConfigResource::collection($results);
+    }
+
+    /**
+     * Find a single OrderConfig. The `{id}` segment accepts any identifier
+     * supported by {@see OrderConfig::resolveFromIdentifier} — `uuid`,
+     * `public_id`, `namespace`, or short `key` (e.g. `transport`).
+     *
+     * @return OrderConfigResource|\Illuminate\Http\JsonResponse
+     */
+    public function find(string $id)
+    {
+        $orderConfig = OrderConfig::resolveFromIdentifier($id);
+        if (!$orderConfig) {
+            try {
+                $orderConfig = OrderConfig::findRecordOrFail($id);
+            } catch (ModelNotFoundException $e) {
+                return response()->apiError('Order config not found.', 404);
+            }
+        }
+
+        return new OrderConfigResource($orderConfig);
+    }
+}

--- a/server/src/Http/Middleware/AuthenticateCustomerToken.php
+++ b/server/src/Http/Middleware/AuthenticateCustomerToken.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Fleetbase\FleetOps\Http\Middleware;
+
+use Closure;
+use Fleetbase\FleetOps\Support\CustomerAuth;
+use Illuminate\Http\Request;
+
+/**
+ * Enforce that a Customer-Token header is present and resolves to a
+ * customer-type Contact that belongs to the same company as the request's
+ * API credential.
+ *
+ * Apply this middleware to authenticated `/v1/customers/...` routes. The
+ * public sign-up / login routes do NOT use it.
+ */
+class AuthenticateCustomerToken
+{
+    public function handle(Request $request, Closure $next)
+    {
+        $customer = CustomerAuth::resolveFromHeader($request);
+        if (!$customer) {
+            return response()->apiError('Customer token is missing or invalid.', 401);
+        }
+
+        $sessionCompany = session('company');
+        if ($sessionCompany && $customer->company_uuid !== $sessionCompany) {
+            return response()->apiError('Customer does not belong to this company.', 403);
+        }
+
+        CustomerAuth::setCurrent($customer);
+
+        return $next($request);
+    }
+}

--- a/server/src/Http/Requests/CreateCustomerOrderRequest.php
+++ b/server/src/Http/Requests/CreateCustomerOrderRequest.php
@@ -7,9 +7,17 @@ use Fleetbase\Http\Requests\FleetbaseRequest;
 /**
  * Validates the body of `POST /v1/customers/orders`.
  *
- * The portal supplies a lightweight order shape (item + weight + value + mode
- * + pickup/dropoff). The controller maps it into a full Fleet-Ops Order via
- * the normal payload/entities scaffolding before passing to OrderController.
+ * Mirrors the canonical Fleet-Ops Order create shape used by the operator
+ * `POST /v1/orders` endpoint: `type` / `order_config`, `scheduled_at`,
+ * `notes`, `meta`, and either a nested `payload` or top-level
+ * `pickup` / `dropoff` / `return` / `waypoints` / `entities`. Place and
+ * Entity sub-objects accept the standard Fleet-Ops Place / Entity field
+ * shapes — no client-portal aliases are recognized.
+ *
+ * `customer` is intentionally not accepted: the controller forces
+ * `customer_uuid` from the authenticated Customer-Token. `status`,
+ * `driver`, `vehicle`, `facilitator`, `dispatch` and similar operator-tier
+ * fields are also out of scope for the customer surface.
  */
 class CreateCustomerOrderRequest extends FleetbaseRequest
 {
@@ -22,31 +30,30 @@ class CreateCustomerOrderRequest extends FleetbaseRequest
     public function rules(): array
     {
         return [
-            'item'             => 'required|string',
-            'weight'           => 'required|numeric|min:0',
-            'weight_unit'      => 'nullable|string|in:lb,kg,g,oz',
-            'value'            => 'required|numeric|min:0',
-            'currency'         => 'nullable|string|size:3',
-            'category'         => 'nullable|string',
-            'mode'             => 'nullable|string|in:Ocean,Air,Ground',
-            'delivery'         => 'nullable|boolean',
-            'notes'            => 'nullable|string|max:2000',
+            'type'             => 'nullable|string',
+            'order_config'     => 'nullable|string',
             'scheduled_at'     => 'nullable|date',
-            'pickup'           => 'nullable|array',
-            'pickup.name'      => 'nullable|string',
-            'pickup.street1'   => 'nullable|string',
-            'pickup.city'      => 'nullable|string',
-            'pickup.province'  => 'nullable|string',
-            'pickup.postal_code' => 'nullable|string',
-            'pickup.country'   => 'nullable|string',
-            'dropoff'          => 'nullable|array',
-            'dropoff.name'     => 'nullable|string',
-            'dropoff.street1'  => 'nullable|string',
-            'dropoff.city'     => 'nullable|string',
-            'dropoff.province' => 'nullable|string',
-            'dropoff.postal_code' => 'nullable|string',
-            'dropoff.country'  => 'nullable|string',
+            'notes'            => 'nullable|string|max:2000',
+            'internal_id'      => 'nullable|string|max:191',
             'meta'             => 'nullable|array',
+
+            // payload may be an object OR a payload public_id string
+            'payload'          => 'nullable',
+
+            // Top-level alternatives when `payload` is not provided. Each
+            // Place sub-object accepts the standard Place fillable shape.
+            'pickup'           => 'nullable',
+            'dropoff'          => 'nullable',
+            'return'           => 'nullable',
+            'waypoints'        => 'nullable|array',
+            'entities'         => 'nullable|array',
+            'entities.*.name'           => 'nullable|string',
+            'entities.*.description'    => 'nullable|string',
+            'entities.*.weight'         => 'nullable|numeric|min:0',
+            'entities.*.weight_unit'    => 'nullable|string',
+            'entities.*.declared_value' => 'nullable|numeric|min:0',
+            'entities.*.currency'       => 'nullable|string|size:3',
+            'entities.*.meta'           => 'nullable|array',
         ];
     }
 }

--- a/server/src/Http/Requests/CreateCustomerOrderRequest.php
+++ b/server/src/Http/Requests/CreateCustomerOrderRequest.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Fleetbase\FleetOps\Http\Requests;
+
+use Fleetbase\Http\Requests\FleetbaseRequest;
+
+/**
+ * Validates the body of `POST /v1/customers/orders`.
+ *
+ * The portal supplies a lightweight order shape (item + weight + value + mode
+ * + pickup/dropoff). The controller maps it into a full Fleet-Ops Order via
+ * the normal payload/entities scaffolding before passing to OrderController.
+ */
+class CreateCustomerOrderRequest extends FleetbaseRequest
+{
+    public function authorize(): bool
+    {
+        return request()->session()->has('api_credential')
+            || request()->session()->has('is_sanctum_token');
+    }
+
+    public function rules(): array
+    {
+        return [
+            'item'             => 'required|string',
+            'weight'           => 'required|numeric|min:0',
+            'weight_unit'      => 'nullable|string|in:lb,kg,g,oz',
+            'value'            => 'required|numeric|min:0',
+            'currency'         => 'nullable|string|size:3',
+            'category'         => 'nullable|string',
+            'mode'             => 'nullable|string|in:Ocean,Air,Ground',
+            'delivery'         => 'nullable|boolean',
+            'notes'            => 'nullable|string|max:2000',
+            'scheduled_at'     => 'nullable|date',
+            'pickup'           => 'nullable|array',
+            'pickup.name'      => 'nullable|string',
+            'pickup.street1'   => 'nullable|string',
+            'pickup.city'      => 'nullable|string',
+            'pickup.province'  => 'nullable|string',
+            'pickup.postal_code' => 'nullable|string',
+            'pickup.country'   => 'nullable|string',
+            'dropoff'          => 'nullable|array',
+            'dropoff.name'     => 'nullable|string',
+            'dropoff.street1'  => 'nullable|string',
+            'dropoff.city'     => 'nullable|string',
+            'dropoff.province' => 'nullable|string',
+            'dropoff.postal_code' => 'nullable|string',
+            'dropoff.country'  => 'nullable|string',
+            'meta'             => 'nullable|array',
+        ];
+    }
+}

--- a/server/src/Http/Requests/CreateCustomerOrderRequest.php
+++ b/server/src/Http/Requests/CreateCustomerOrderRequest.php
@@ -36,6 +36,10 @@ class CreateCustomerOrderRequest extends FleetbaseRequest
             'notes'            => 'nullable|string|max:2000',
             'internal_id'      => 'nullable|string|max:191',
             'meta'             => 'nullable|array',
+            // Optional ServiceQuote reference (uuid or `sqte_…` public_id).
+            // Resolved server-side via `ServiceQuote::resolveFromRequest` and
+            // consumed by `$order->purchaseServiceQuote()` after creation.
+            'service_quote'    => 'nullable|string',
 
             // payload may be an object OR a payload public_id string
             'payload'          => 'nullable',

--- a/server/src/Http/Requests/CreateCustomerRequest.php
+++ b/server/src/Http/Requests/CreateCustomerRequest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Fleetbase\FleetOps\Http\Requests;
+
+use Fleetbase\Http\Requests\FleetbaseRequest;
+use Illuminate\Validation\Rule;
+
+/**
+ * Validates the body of `POST /v1/customers` (final account creation step).
+ *
+ * Expects the verification code previously requested via
+ * `POST /v1/customers/request-creation-code`.
+ */
+class CreateCustomerRequest extends FleetbaseRequest
+{
+    public function authorize(): bool
+    {
+        return request()->session()->has('api_credential')
+            || request()->session()->has('is_sanctum_token');
+    }
+
+    public function rules(): array
+    {
+        return [
+            'identity' => 'required|string',
+            'code'     => 'required|exists:verification_codes,code',
+            'name'     => 'required|string',
+            'password' => 'required|string|min:8',
+            'email'    => [
+                'email', 'nullable',
+                Rule::unique('contacts')->where(function ($query) {
+                    $query->where('company_uuid', session('company'));
+
+                    return $query->whereNull('deleted_at');
+                }),
+            ],
+            'phone' => [
+                'nullable', 'string',
+                Rule::unique('contacts')->where(function ($query) {
+                    $query->where('company_uuid', session('company'));
+
+                    return $query->whereNull('deleted_at');
+                }),
+            ],
+            'meta'  => 'nullable|array',
+        ];
+    }
+}

--- a/server/src/Http/Requests/VerifyCreateCustomerRequest.php
+++ b/server/src/Http/Requests/VerifyCreateCustomerRequest.php
@@ -20,6 +20,10 @@ class VerifyCreateCustomerRequest extends FleetbaseRequest
         return [
             'mode'     => 'required|in:email,sms',
             'identity' => 'required|string',
+            // Optional profile context — when provided, used to greet the
+            // customer in the verification email and pre-seed the User row.
+            'name'     => 'nullable|string|max:255',
+            'phone'    => 'nullable|string|max:32',
         ];
     }
 }

--- a/server/src/Http/Requests/VerifyCreateCustomerRequest.php
+++ b/server/src/Http/Requests/VerifyCreateCustomerRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Fleetbase\FleetOps\Http\Requests;
+
+use Fleetbase\Http\Requests\FleetbaseRequest;
+
+/**
+ * Validates the body of `POST /v1/customers/request-creation-code`.
+ */
+class VerifyCreateCustomerRequest extends FleetbaseRequest
+{
+    public function authorize(): bool
+    {
+        return request()->session()->has('api_credential')
+            || request()->session()->has('is_sanctum_token');
+    }
+
+    public function rules(): array
+    {
+        return [
+            'mode'     => 'required|in:email,sms',
+            'identity' => 'required|string',
+        ];
+    }
+}

--- a/server/src/Http/Resources/v1/Customer.php
+++ b/server/src/Http/Resources/v1/Customer.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Fleetbase\FleetOps\Http\Resources\v1;
+
+use Fleetbase\FleetOps\Models\Order;
+use Fleetbase\FleetOps\Support\Utils;
+use Fleetbase\Http\Resources\FleetbaseResource;
+use Fleetbase\Support\Http;
+use Illuminate\Http\Request;
+use Illuminate\Support\Str;
+
+/**
+ * Public API resource for FleetOps customers.
+ *
+ * Wraps a {@see \Fleetbase\FleetOps\Models\Contact} of `type='customer'` and
+ * exposes the auth `token` field that login/signup endpoints attach.
+ */
+class Customer extends FleetbaseResource
+{
+    public function toArray($request): array
+    {
+        $this->loadMissing(['place', 'places']);
+
+        return [
+            'id'           => $this->when(Http::isInternalRequest(), $this->id, Str::replaceFirst('contact', 'customer', $this->public_id)),
+            'uuid'         => $this->when(Http::isInternalRequest(), $this->uuid),
+            'user_uuid'    => $this->when(Http::isInternalRequest(), $this->user_uuid),
+            'company_uuid' => $this->when(Http::isInternalRequest(), $this->company_uuid),
+            'public_id'    => $this->when(Http::isInternalRequest(), $this->public_id),
+            'internal_id'  => $this->internal_id,
+            'name'         => $this->name,
+            'title'        => $this->title,
+            'photo_url'    => $this->photo_url,
+            'email'        => $this->email,
+            'phone'        => $this->phone,
+            'address'      => data_get($this, 'place.address'),
+            'addresses'    => $this->whenLoaded('places', fn () => Place::collection($this->places)),
+            'token'        => $this->when($this->token, $this->token),
+            'orders_count' => $this->getOrdersCount($request),
+            'meta'         => data_get($this, 'meta', Utils::createObject()),
+            'slug'         => $this->slug,
+            'created_at'   => $this->created_at,
+            'updated_at'   => $this->updated_at,
+        ];
+    }
+
+    private function getOrdersCount(Request $request): int
+    {
+        return Order::where('customer_uuid', $this->uuid)
+            ->whereNull('deleted_at')
+            ->withoutGlobalScopes()
+            ->count();
+    }
+}

--- a/server/src/Http/Resources/v1/Customer.php
+++ b/server/src/Http/Resources/v1/Customer.php
@@ -5,6 +5,7 @@ namespace Fleetbase\FleetOps\Http\Resources\v1;
 use Fleetbase\FleetOps\Models\Order;
 use Fleetbase\FleetOps\Support\Utils;
 use Fleetbase\Http\Resources\FleetbaseResource;
+use Fleetbase\Models\Company;
 use Fleetbase\Support\Http;
 use Illuminate\Http\Request;
 use Illuminate\Support\Str;
@@ -37,6 +38,7 @@ class Customer extends FleetbaseResource
             'addresses'    => $this->whenLoaded('places', fn () => Place::collection($this->places)),
             'token'        => $this->when($this->token, $this->token),
             'orders_count' => $this->getOrdersCount($request),
+            'company'      => $this->when($this->company_uuid, fn () => $this->buildCompanyPayload()),
             'meta'         => data_get($this, 'meta', Utils::createObject()),
             'slug'         => $this->slug,
             'created_at'   => $this->created_at,
@@ -50,5 +52,28 @@ class Customer extends FleetbaseResource
             ->whereNull('deleted_at')
             ->withoutGlobalScopes()
             ->count();
+    }
+
+    /**
+     * Public-safe projection of the customer's company. Returns the same
+     * fields any caller could fetch through other public endpoints — name,
+     * resolved currency, country, phone — plus the company's public id.
+     * Currency falls back through company.currency → ledger base_currency
+     * → "USD" via {@see Utils::getCompanyTransactionCurrency}.
+     */
+    private function buildCompanyPayload(): ?array
+    {
+        $company = Company::find($this->company_uuid);
+        if (!$company) {
+            return null;
+        }
+
+        return [
+            'id'       => $company->public_id,
+            'name'     => $company->name,
+            'currency' => Utils::getCompanyTransactionCurrency($company),
+            'country'  => $company->country,
+            'phone'    => $company->phone,
+        ];
     }
 }

--- a/server/src/Http/Resources/v1/OrderConfig.php
+++ b/server/src/Http/Resources/v1/OrderConfig.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Fleetbase\FleetOps\Http\Resources\v1;
+
+use Fleetbase\Http\Resources\FleetbaseResource;
+use Fleetbase\Support\Http;
+
+/**
+ * Public, read-only projection of an OrderConfig.
+ *
+ * Exposes the activity `flow` so consumers can render status filter chips,
+ * activity labels, and progress UI without learning the internal config
+ * schema. Internal-only fields (entities JSON, version, namespace columns
+ * that aren't part of the public contract) are filtered out.
+ */
+class OrderConfig extends FleetbaseResource
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @param \Illuminate\Http\Request $request
+     *
+     * @return array
+     */
+    public function toArray($request): array
+    {
+        return [
+            'id'           => $this->when(Http::isInternalRequest(), $this->id, $this->public_id),
+            'uuid'         => $this->when(Http::isInternalRequest(), $this->uuid),
+            'public_id'    => $this->when(Http::isInternalRequest(), $this->public_id),
+            'company_uuid' => $this->when(Http::isInternalRequest(), $this->company_uuid),
+            'key'          => $this->key,
+            'name'         => $this->name,
+            'namespace'    => $this->namespace,
+            'description'  => $this->description,
+            'tags'         => $this->tags,
+            'status'       => $this->status,
+            'version'      => $this->version,
+            'flow'         => $this->projectFlow(),
+            'created_at'   => $this->created_at,
+            'updated_at'   => $this->updated_at,
+        ];
+    }
+
+    /**
+     * Project the flow JSON into an ordered list of activities, keeping only
+     * the public-safe per-activity fields. `code` and `status` (the label)
+     * are the contract; `complete`, `color`, `details`, `pod_method`, and
+     * `require_pod` are useful UI hints that can ride along.
+     */
+    protected function projectFlow(): array
+    {
+        $flow = $this->flow;
+        if (!is_array($flow) || empty($flow)) {
+            return [];
+        }
+
+        $activities = [];
+        foreach ($flow as $activity) {
+            if (!is_array($activity)) {
+                continue;
+            }
+            $activities[] = [
+                'code'        => $activity['code']        ?? ($activity['key'] ?? null),
+                'status'      => $activity['status']      ?? null,
+                'details'     => $activity['details']     ?? null,
+                'color'       => $activity['color']       ?? null,
+                'complete'    => (bool) ($activity['complete'] ?? false),
+                'pod_method'  => $activity['pod_method']  ?? null,
+                'require_pod' => (bool) ($activity['require_pod'] ?? false),
+            ];
+        }
+
+        return $activities;
+    }
+}

--- a/server/src/Models/Customer.php
+++ b/server/src/Models/Customer.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Fleetbase\FleetOps\Models;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Support\Str;
+
+/**
+ * Fleet-Ops customer.
+ *
+ * A thin specialization of {@see Contact} that is scoped to rows with
+ * `type='customer'` and forces that type on create. This is what the public
+ * customer API surface (`/v1/customers/...`) operates on.
+ *
+ * Mirrors {@see \Fleetbase\Storefront\Models\Customer} but lives directly in
+ * FleetOps so that customer auth + customer-scoped orders work without the
+ * Storefront publishable-key + Store/Network gating.
+ */
+class Customer extends Contact
+{
+    /**
+     * The key to use in the payload responses.
+     */
+    protected string $payloadKey = 'customer';
+
+    /**
+     * Boot the model.
+     */
+    protected static function boot()
+    {
+        parent::boot();
+
+        static::creating(function ($model) {
+            $model->type = 'customer';
+        });
+
+        static::addGlobalScope('type', function (Builder $builder) {
+            $builder->where('type', 'customer');
+        });
+    }
+
+    /**
+     * Orders owned by this customer.
+     */
+    public function orders(): HasMany
+    {
+        return $this->hasMany(Order::class, 'customer_uuid')
+            ->whereNull('deleted_at')
+            ->withoutGlobalScopes();
+    }
+
+    /**
+     * Find a customer by either a `customer_xxx` or `contact_xxx` public id.
+     */
+    public static function findFromCustomerId(string $publicId): ?self
+    {
+        if (Str::startsWith($publicId, 'customer')) {
+            $publicId = Str::replaceFirst('customer', 'contact', $publicId);
+        }
+
+        return static::where('public_id', $publicId)->first();
+    }
+}

--- a/server/src/Support/CustomerAuth.php
+++ b/server/src/Support/CustomerAuth.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace Fleetbase\FleetOps\Support;
+
+use Fleetbase\FleetOps\Models\Contact;
+use Illuminate\Http\Request;
+use Illuminate\Support\Str;
+use Laravel\Sanctum\PersonalAccessToken;
+
+/**
+ * Helper for resolving the authenticated customer from a request.
+ *
+ * The customer token is issued by `CustomerController` as a Sanctum
+ * `PersonalAccessToken` whose `name` column carries the owning Contact's UUID.
+ * Mirrors {@see \Fleetbase\Storefront\Support\Storefront::getCustomerFromToken}
+ * but with no Storefront-specific session.
+ */
+class CustomerAuth
+{
+    public const HEADER = 'Customer-Token';
+
+    public const APP_BINDING = 'currentCustomer';
+
+    /**
+     * Resolve the Contact represented by the `Customer-Token` header.
+     *
+     * Preference order when a User has more than one customer-type Contact:
+     *   1. Contact whose UUID matches the token's `name` column (Storefront convention).
+     *   2. Contact in the same company as the resolved API credential (`session('company')`).
+     *   3. The first remaining customer-type Contact for the token's User.
+     */
+    public static function resolveFromHeader(?Request $request = null): ?Contact
+    {
+        $request = $request ?? request();
+        $token   = $request->header(self::HEADER);
+        if (!$token) {
+            return null;
+        }
+
+        $accessToken = PersonalAccessToken::findToken($token);
+        if (!$accessToken) {
+            return null;
+        }
+
+        // Storefront convention: token name = Contact UUID.
+        if (is_string($accessToken->name) && Str::isUuid($accessToken->name)) {
+            $contact = Contact::where('uuid', $accessToken->name)
+                ->where('type', 'customer')
+                ->first();
+            if ($contact) {
+                return $contact;
+            }
+        }
+
+        // Fallback: pick the customer Contact bound to the token's user, preferring
+        // the same company as the API credential when available.
+        $userId         = $accessToken->tokenable_id ?? null;
+        $userIdentifier = $accessToken->tokenable->uuid ?? $userId;
+        if (!$userIdentifier) {
+            return null;
+        }
+
+        $contactQuery = Contact::where('user_uuid', $userIdentifier)
+            ->where('type', 'customer');
+
+        $sessionCompany = session('company');
+        if ($sessionCompany) {
+            $companyPreferred = (clone $contactQuery)
+                ->where('company_uuid', $sessionCompany)
+                ->first();
+            if ($companyPreferred) {
+                return $companyPreferred;
+            }
+        }
+
+        return $contactQuery->first();
+    }
+
+    /**
+     * Return the currently-bound customer (set by AuthenticateCustomerToken middleware).
+     */
+    public static function current(): ?Contact
+    {
+        return app()->bound(self::APP_BINDING) ? app(self::APP_BINDING) : null;
+    }
+
+    /**
+     * Bind the resolved customer for the current request lifecycle.
+     */
+    public static function setCurrent(Contact $contact): void
+    {
+        app()->instance(self::APP_BINDING, $contact);
+        session([
+            'customer_id' => $contact->uuid,
+            'contact_id'  => $contact->uuid,
+        ]);
+    }
+}

--- a/server/src/routes.php
+++ b/server/src/routes.php
@@ -49,6 +49,11 @@ Route::prefix(config('fleetops.api.routing.prefix', null))->namespace('Fleetbase
                 $router->put('{id}', 'ContactController@update');
                 $router->delete('{id}', 'ContactController@delete');
             });
+            // order-configs — read-only public projection of the OrderConfig flow.
+            $router->group(['prefix' => 'order-configs'], function () use ($router) {
+                $router->get('/', 'OrderConfigController@query');
+                $router->get('{id}', 'OrderConfigController@find');
+            });
             // customers routes — public B2C customer auth + customer-scoped orders.
             //  - Public endpoints: API key only (resolves company from credential)
             //  - Authenticated endpoints: API key + `Customer-Token` header (Sanctum)

--- a/server/src/routes.php
+++ b/server/src/routes.php
@@ -49,6 +49,33 @@ Route::prefix(config('fleetops.api.routing.prefix', null))->namespace('Fleetbase
                 $router->put('{id}', 'ContactController@update');
                 $router->delete('{id}', 'ContactController@delete');
             });
+            // customers routes — public B2C customer auth + customer-scoped orders.
+            //  - Public endpoints: API key only (resolves company from credential)
+            //  - Authenticated endpoints: API key + `Customer-Token` header (Sanctum)
+            $router->group(['prefix' => 'customers', 'middleware' => []], function () use ($router) {
+                // Public auth flows
+                $router->post('request-creation-code', 'CustomerController@requestCreationCode');
+                $router->post('/', 'CustomerController@create');
+                $router->post('login', 'CustomerController@login');
+                $router->post('login-with-sms', 'CustomerController@loginWithPhone');
+                $router->post('verify-code', 'CustomerController@verifyCode');
+                $router->post('forgot-password', 'CustomerController@forgotPassword');
+                $router->post('reset-password', 'CustomerController@resetPassword');
+
+                // Authenticated (require Customer-Token)
+                $router->group(['middleware' => [\Fleetbase\FleetOps\Http\Middleware\AuthenticateCustomerToken::class]], function () use ($router) {
+                    $router->get('me', 'CustomerController@me');
+                    $router->put('me', 'CustomerController@updateMe');
+                    $router->match(['post', 'patch'], 'me', 'CustomerController@updateMe');
+                    $router->post('logout', 'CustomerController@logout');
+                    $router->post('logout-all', 'CustomerController@logoutAll');
+                    $router->post('register-device', 'CustomerController@registerDevice');
+                    $router->get('places', 'CustomerController@places');
+                    $router->get('orders', 'CustomerController@orders');
+                    $router->post('orders', 'CustomerController@createOrder');
+                    $router->get('orders/{id}', 'CustomerController@findOrder');
+                });
+            });
             // vendors routes
             $router->group(['prefix' => 'vendors'], function () use ($router) {
                 $router->post('/', 'VendorController@create');

--- a/server/tests/CustomerEndpointTest.php
+++ b/server/tests/CustomerEndpointTest.php
@@ -168,6 +168,22 @@ test('Customer API resource exposes token and orders_count for the consumable sh
         ->toContain("Str::replaceFirst('contact', 'customer'");
 });
 
+test('Customer API resource includes a company sub-object resolved from the API credential', function () {
+    $source = file_get_contents(dirname(__DIR__) . '/src/Http/Resources/v1/Customer.php');
+
+    expect($source)
+        // The sub-object lives on `company`, keyed off the customer's company_uuid.
+        ->toContain("'company'")
+        ->toContain('buildCompanyPayload')
+        // Currency must be resolved through the existing canonical helper —
+        // never hardcoded, never aliased.
+        ->toContain('Utils::getCompanyTransactionCurrency')
+        // Public-safe projection only: id, name, currency, country, phone.
+        ->toContain("'currency'")
+        ->toContain("'country'")
+        ->toContain("'phone'");
+});
+
 test('FormRequest validators are present and authorize via api credential', function () {
     expect(class_exists(CreateCustomerRequest::class))->toBeTrue()
         ->and(class_exists(VerifyCreateCustomerRequest::class))->toBeTrue()

--- a/server/tests/CustomerEndpointTest.php
+++ b/server/tests/CustomerEndpointTest.php
@@ -1,0 +1,150 @@
+<?php
+
+use Fleetbase\FleetOps\Http\Controllers\Api\v1\CustomerController;
+use Fleetbase\FleetOps\Http\Middleware\AuthenticateCustomerToken;
+use Fleetbase\FleetOps\Http\Requests\CreateCustomerOrderRequest;
+use Fleetbase\FleetOps\Http\Requests\CreateCustomerRequest;
+use Fleetbase\FleetOps\Http\Requests\VerifyCreateCustomerRequest;
+use Fleetbase\FleetOps\Http\Resources\v1\Customer as CustomerResource;
+use Fleetbase\FleetOps\Models\Customer as CustomerModel;
+use Fleetbase\FleetOps\Support\CustomerAuth;
+
+/*
+|--------------------------------------------------------------------------
+| Customer API surface — static shape checks.
+|
+| These mirror the lightweight static checks used elsewhere in this package
+| (see PingDriverEndpointTest.php). They verify that the customer endpoints,
+| controller methods, middleware, and supporting classes exist and are wired
+| through `Api/v1/CustomerController` without the Storefront layer.
+|
+| End-to-end HTTP tests against a running app belong in the parent `api/`
+| project's test harness; this file ensures the package surface is correct.
+|--------------------------------------------------------------------------
+*/
+
+test('customers route group is registered inside the consumable v1 namespace', function () {
+    $routes = file_get_contents(dirname(__DIR__) . '/src/routes.php');
+
+    expect($routes)
+        ->toContain("\$router->group(['prefix' => 'customers', 'middleware' => []]")
+        ->and($routes)->toContain("CustomerController@requestCreationCode")
+        ->and($routes)->toContain("CustomerController@create")
+        ->and($routes)->toContain("CustomerController@login")
+        ->and($routes)->toContain("CustomerController@loginWithPhone")
+        ->and($routes)->toContain("CustomerController@verifyCode")
+        ->and($routes)->toContain("CustomerController@forgotPassword")
+        ->and($routes)->toContain("CustomerController@resetPassword");
+});
+
+test('authenticated customer routes are gated by AuthenticateCustomerToken middleware', function () {
+    $routes = file_get_contents(dirname(__DIR__) . '/src/routes.php');
+
+    expect($routes)
+        ->toContain('AuthenticateCustomerToken::class')
+        ->and($routes)->toContain("CustomerController@me")
+        ->and($routes)->toContain("CustomerController@updateMe")
+        ->and($routes)->toContain("CustomerController@logout")
+        ->and($routes)->toContain("CustomerController@logoutAll")
+        ->and($routes)->toContain("CustomerController@orders")
+        ->and($routes)->toContain("CustomerController@createOrder")
+        ->and($routes)->toContain("CustomerController@findOrder")
+        ->and($routes)->toContain("CustomerController@places")
+        ->and($routes)->toContain("CustomerController@registerDevice");
+});
+
+test('customer controller exposes the documented method surface', function () {
+    $expected = [
+        'requestCreationCode', 'create',
+        'login', 'loginWithPhone', 'verifyCode',
+        'forgotPassword', 'resetPassword',
+        'me', 'updateMe', 'logout', 'logoutAll',
+        'orders', 'createOrder', 'findOrder',
+        'places', 'registerDevice',
+    ];
+
+    foreach ($expected as $method) {
+        expect(method_exists(CustomerController::class, $method))->toBeTrue("CustomerController::{$method} missing");
+    }
+});
+
+test('customer controller does not reference Storefront concerns', function () {
+    $source = file_get_contents(dirname(__DIR__) . '/src/Http/Controllers/Api/v1/CustomerController.php');
+
+    expect($source)
+        ->not->toContain('Storefront::about')
+        ->not->toContain("session('storefront_key')")
+        ->not->toContain("session('storefront_store')")
+        ->not->toContain("session('storefront_network')")
+        ->not->toContain("storefront_id")
+        ->not->toContain("createStripeCustomerForContact");
+});
+
+test('verification code slugs are FleetOps-namespaced, not Storefront', function () {
+    $source = file_get_contents(dirname(__DIR__) . '/src/Http/Controllers/Api/v1/CustomerController.php');
+
+    expect($source)
+        ->toContain("'fleetops_create_customer'")
+        ->toContain("'fleetops_customer_login'")
+        ->toContain("'fleetops_customer_password_reset'")
+        ->not->toContain("'storefront_create_customer'")
+        ->not->toContain("'storefront_login'");
+});
+
+test('AuthenticateCustomerToken enforces a customer-token + company cross-check', function () {
+    expect(class_exists(AuthenticateCustomerToken::class))->toBeTrue();
+
+    $source = file_get_contents(dirname(__DIR__) . '/src/Http/Middleware/AuthenticateCustomerToken.php');
+    expect($source)
+        ->toContain("Customer token is missing or invalid")
+        ->toContain("Customer does not belong to this company")
+        ->toContain("CustomerAuth::resolveFromHeader")
+        ->toContain("CustomerAuth::setCurrent");
+});
+
+test('CustomerAuth resolves tokens by contact UUID with company-preferred fallback', function () {
+    expect(class_exists(CustomerAuth::class))->toBeTrue()
+        ->and(method_exists(CustomerAuth::class, 'resolveFromHeader'))->toBeTrue()
+        ->and(method_exists(CustomerAuth::class, 'current'))->toBeTrue()
+        ->and(method_exists(CustomerAuth::class, 'setCurrent'))->toBeTrue()
+        ->and(CustomerAuth::HEADER)->toBe('Customer-Token');
+
+    $source = file_get_contents(dirname(__DIR__) . '/src/Support/CustomerAuth.php');
+    expect($source)
+        ->toContain('PersonalAccessToken::findToken')
+        ->toContain("->where('type', 'customer')")
+        ->toContain("->where('company_uuid'");
+});
+
+test('Customer model extends Contact with a type=customer global scope', function () {
+    expect(is_subclass_of(CustomerModel::class, \Fleetbase\FleetOps\Models\Contact::class))->toBeTrue();
+
+    $source = file_get_contents(dirname(__DIR__) . '/src/Models/Customer.php');
+    expect($source)
+        ->toContain("\$model->type = 'customer'")
+        ->toContain("->where('type', 'customer')");
+});
+
+test('Customer API resource exposes token and orders_count for the consumable shape', function () {
+    expect(class_exists(CustomerResource::class))->toBeTrue();
+
+    $source = file_get_contents(dirname(__DIR__) . '/src/Http/Resources/v1/Customer.php');
+    expect($source)
+        ->toContain("'token'")
+        ->toContain("'orders_count'")
+        ->toContain("Str::replaceFirst('contact', 'customer'");
+});
+
+test('FormRequest validators are present and authorize via api credential', function () {
+    expect(class_exists(CreateCustomerRequest::class))->toBeTrue()
+        ->and(class_exists(VerifyCreateCustomerRequest::class))->toBeTrue()
+        ->and(class_exists(CreateCustomerOrderRequest::class))->toBeTrue();
+
+    $create = file_get_contents(dirname(__DIR__) . '/src/Http/Requests/CreateCustomerRequest.php');
+    $verify = file_get_contents(dirname(__DIR__) . '/src/Http/Requests/VerifyCreateCustomerRequest.php');
+
+    expect($create)
+        ->toContain("'code'     => 'required|exists:verification_codes,code'")
+        ->toContain("'password' => 'required|string|min:8'")
+        ->and($verify)->toContain("'mode'     => 'required|in:email,sms'");
+});

--- a/server/tests/CustomerEndpointTest.php
+++ b/server/tests/CustomerEndpointTest.php
@@ -80,6 +80,39 @@ test('customer controller does not reference Storefront concerns', function () {
         ->not->toContain("createStripeCustomerForContact");
 });
 
+test('customer controller does not introduce client-portal field aliases', function () {
+    // Public Fleetbase APIs must accept canonical model field names only. No
+    // aliasing like line1/state/zip → street1/province/postal_code, no portal-
+    // specific tagging like meta.origin, no top-level item/weight/value/mode
+    // aliases on order create — clients conform to the API, not vice versa.
+    $source = file_get_contents(dirname(__DIR__) . '/src/Http/Controllers/Api/v1/CustomerController.php');
+
+    expect($source)
+        ->not->toContain("'line1'")
+        ->not->toContain("'line2'")
+        ->not->toContain("'state'")
+        ->not->toContain("'zip'")
+        ->not->toContain("'origin' => 'fleetops_customer_portal'")
+        ->not->toContain("fleetops_customer_portal")
+        ->not->toContain("\$request->input('item'")
+        ->not->toContain("\$request->input('value'")
+        ->not->toContain("\$request->input('delivery'")
+        ->not->toContain("\$request->input('category'");
+});
+
+test('createOrder mirrors the canonical Fleet-Ops order shape', function () {
+    $source = file_get_contents(dirname(__DIR__) . '/src/Http/Controllers/Api/v1/CustomerController.php');
+
+    expect($source)
+        ->toContain('OrderConfig::resolveFromIdentifier')
+        ->toContain('buildPayloadFromInput')
+        ->toContain('Payload')
+        ->toContain('setPickup')
+        ->toContain('setDropoff')
+        ->toContain('setEntities')
+        ->toContain("'customer_uuid'");
+});
+
 test('verification code slugs are FleetOps-namespaced, not Storefront', function () {
     $source = file_get_contents(dirname(__DIR__) . '/src/Http/Controllers/Api/v1/CustomerController.php');
 

--- a/server/tests/OrderConfigEndpointTest.php
+++ b/server/tests/OrderConfigEndpointTest.php
@@ -1,0 +1,73 @@
+<?php
+
+use Fleetbase\FleetOps\Http\Controllers\Api\v1\OrderConfigController;
+use Fleetbase\FleetOps\Http\Resources\v1\OrderConfig as OrderConfigResource;
+
+/*
+|--------------------------------------------------------------------------
+| OrderConfig API surface — static shape checks.
+|
+| The OrderConfig public API surface gives consumers (customer portals,
+| third-party integrations) a read-only projection of the OrderConfig
+| `flow` JSON so they can drive status filters, activity labels, and
+| similar UI from the canonical config rather than hardcoding their own.
+|
+| These mirror the lightweight static checks used elsewhere in this
+| package and verify the routes, controller methods, and resource shape
+| exist without booting Laravel.
+|--------------------------------------------------------------------------
+*/
+
+test('order-configs route group is registered in the consumable v1 namespace', function () {
+    $routes = file_get_contents(dirname(__DIR__) . '/src/routes.php');
+
+    expect($routes)
+        ->toContain("\$router->group(['prefix' => 'order-configs']")
+        ->and($routes)->toContain("OrderConfigController@query")
+        ->and($routes)->toContain("OrderConfigController@find");
+});
+
+test('OrderConfigController exposes only read-only methods', function () {
+    foreach (['query', 'find'] as $method) {
+        expect(method_exists(OrderConfigController::class, $method))->toBeTrue(
+            "OrderConfigController::{$method} missing",
+        );
+    }
+
+    // No write methods are exposed — OrderConfigs are owned by operator UIs.
+    foreach (['create', 'update', 'delete', 'store', 'destroy'] as $method) {
+        expect(method_exists(OrderConfigController::class, $method))->toBeFalse(
+            "OrderConfigController::{$method} should NOT exist on the public surface",
+        );
+    }
+});
+
+test('find() resolves by uuid, public_id, namespace, or key', function () {
+    $source = file_get_contents(dirname(__DIR__) . '/src/Http/Controllers/Api/v1/OrderConfigController.php');
+
+    // The controller defers to the canonical resolver so /transport,
+    // /system:order-config:transport, the public_id, and the uuid all work.
+    expect($source)
+        ->toContain('OrderConfig::resolveFromIdentifier')
+        ->toContain('findRecordOrFail');
+});
+
+test('OrderConfig resource projects only public-safe fields', function () {
+    expect(class_exists(OrderConfigResource::class))->toBeTrue();
+
+    $source = file_get_contents(dirname(__DIR__) . '/src/Http/Resources/v1/OrderConfig.php');
+
+    expect($source)
+        // Public contract: id/key/name/namespace + the flow projection.
+        ->toContain("'key'")
+        ->toContain("'name'")
+        ->toContain("'namespace'")
+        ->toContain("'flow'")
+        ->toContain('projectFlow')
+        // Each flow row keeps the canonical activity keys.
+        ->toContain("'code'")
+        ->toContain("'status'")
+        ->toContain("'complete'")
+        // Internal config payload must not be exposed on the public surface.
+        ->not->toContain("'entities'");
+});


### PR DESCRIPTION
## Summary

Adds a B2C customer surface to FleetOps `Api/v1` so portals can authenticate end-customers and create orders against a Fleetbase company directly — no Storefront publishable-key + Store/Network coupling required. Pairs with a matching docs PR on `fleetbase/postman` and a reference client at `fleetbase/ultrasal.com`.

Three additive, canonical extensions:

### 1. Customer surface — `/v1/customers/*`

Public (API credential only):
- `POST request-creation-code` — email/SMS verification code
- `POST /` — create Contact + linked User after verifying code; optionally creates an owned Place from the canonical `place` field
- `POST login` — email/phone + password → Sanctum token
- `POST login-with-sms`, `POST verify-code` — passwordless flow
- `POST forgot-password`, `POST reset-password` — password recovery

Authenticated (require `Customer-Token` header):
- `GET/PUT /me`, `POST logout`, `POST logout-all`
- `GET /places`, `GET /orders`, `POST /orders`, `GET /orders/{id}`
- `POST register-device`

Implementation:
- Tokens are Sanctum PersonalAccessTokens (token \`name\` = Contact UUID, mirrors the Storefront convention so SDKs/headers are interchangeable).
- `AuthenticateCustomerToken` middleware verifies the header AND cross-checks the resolved Contact's `company_uuid` matches the API credential's session — 401/403 on mismatch.
- New \`CustomerAuth\` helper resolves tokens by contact UUID with a company-preferred fallback for the multi-company edge case.
- Thin \`Models\\Customer\` specialization of Contact (\`type=customer\` global scope, matches Storefront's pattern).
- Order create accepts \`service_quote\` and consumes it via \`ServiceQuote::resolveFromRequest\` + \`\$order->purchaseServiceQuote()\` — same as \`OrderController::create\`.
- Strict canonical shapes: no portal-side aliases (\`line1/state/zip\`, \`item/value/mode/delivery\`), no controller-side \`meta\` writes (\`meta\` is client-owned).

### 2. \`OrderConfig\` as a first-class public resource — \`/v1/order-configs\`

- \`GET /v1/order-configs\` — list configs for the company
- \`GET /v1/order-configs/{id}\` — find by uuid / public_id / namespace / key (e.g. \`/transport\`)
- New public-safe \`v1/OrderConfig\` resource projects the \`flow[]\` (with canonical \`code\`, \`status\`, \`complete\`, \`color\` per activity) so consumers can drive status filter chips and activity labels from the canonical config. Internal-only fields (entities JSON, logic blocks) are filtered out.

### 3. \`Customer.company\` sub-object on \`/v1/customers/me\`

Resolves through the existing canonical helper \`Utils::getCompanyTransactionCurrency()\` (\`companies.currency\` → ledger \`base_currency\` → \`USD\`). Returns the public-safe subset: \`{ id, name, currency, country, phone }\`. Useful for any client that needs to render currency labels without a second request.

## Convention adherence

- No new tables, no migrations: \`contacts.email/phone/user_uuid\`, \`orders.customer_uuid\`, \`personal_access_tokens\` already cover everything.
- No new auth guards: Sanctum's stateless \`PersonalAccessToken\` resolution via the middleware is sufficient (matches Storefront).
- No client-portal aliases at the API boundary. The \`place\` field accepts only canonical Place fillable keys; order create accepts only the canonical Order shape (delegates to \`Payload::setPickup/setDropoff/setEntities\`).
- The customer order endpoint forces \`customer_uuid\` from the Customer-Token and \`status='created'\`; any client-supplied \`customer\`, \`driver\`, \`vehicle\`, \`facilitator\`, or \`dispatch\` fields are ignored.
- \`OrderConfig\` endpoints expose only read-only methods (no \`create\`/\`update\`/\`delete\` on the public surface — those stay in the internal admin console).

## Validation

\`\`\`bash
php -l server/src/Models/Customer.php
php -l server/src/Support/CustomerAuth.php
php -l server/src/Http/Middleware/AuthenticateCustomerToken.php
php -l server/src/Http/Controllers/Api/v1/CustomerController.php
php -l server/src/Http/Controllers/Api/v1/OrderConfigController.php
php -l server/src/Http/Resources/v1/Customer.php
php -l server/src/Http/Resources/v1/OrderConfig.php
php -l server/src/Http/Requests/CreateCustomerRequest.php
php -l server/src/Http/Requests/VerifyCreateCustomerRequest.php
php -l server/src/Http/Requests/CreateCustomerOrderRequest.php
php -l server/src/routes.php
php -l server/tests/CustomerEndpointTest.php
php -l server/tests/OrderConfigEndpointTest.php
\`\`\`

## Static-shape tests

\`server/tests/CustomerEndpointTest.php\` and \`server/tests/OrderConfigEndpointTest.php\` follow the package's existing pest convention. Beyond shape validation they include a regression assertion that forbids any reappearance of portal-style aliases in the controller source (\`'line1'\`, \`'state'\`, \`'zip'\`, \`'origin' => 'fleetops_customer_portal'\`, top-level \`item\`/\`value\`/\`mode\`/\`delivery\` reads on order create). End-to-end HTTP tests belong in the parent \`api/\` harness.

## Companion PRs

- \`fleetbase/postman\` — Customers + Order Configs collection docs (canonical shapes + \`service_quote\`).
- \`fleetbase/ultrasal.com\` — reference Next.js portal consuming this surface end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)