### PR TITLE
Harden live map viewport loading

### DIFF
--- a/addon/components/map/leaflet-live-map.js
+++ b/addon/components/map/leaflet-live-map.js
@@ -8,11 +8,14 @@ import { guidFor } from '@ember/object/internals';
 import { camelize, capitalize, dasherize } from '@ember/string';
 import { singularize, pluralize } from 'ember-inflector';
 import { all } from 'rsvp';
-import { task } from 'ember-concurrency';
+import { task, timeout } from 'ember-concurrency';
 import { next } from '@ember/runloop';
 import getModelName from '@fleetbase/ember-core/utils/get-model-name';
 
 export default class MapLeafletLiveMapComponent extends Component {
+    liveViewportReloadDebounceMs = 300;
+    liveViewportResourceLimit = 500;
+
     @service mapManager;
     @service mapSettings;
     @service leafletMapManager;
@@ -98,6 +101,11 @@ export default class MapLeafletLiveMapComponent extends Component {
             this.universe.off('fleet-ops.geofence.exited', this._geofenceExitedHandler);
             this._geofenceExitedHandler = null;
         }
+        if (this._viewportReloadHandler && this.map && typeof this.map.off === 'function') {
+            this.map.off('moveend', this._viewportReloadHandler);
+            this.map.off('zoomend', this._viewportReloadHandler);
+            this._viewportReloadHandler = null;
+        }
     }
 
     @action didLoad({ target: map }) {
@@ -106,8 +114,9 @@ export default class MapLeafletLiveMapComponent extends Component {
         this.trigger('onLoad', ...arguments);
         this.load.perform();
         // Listen for map move/zoom events to trigger viewport-based resource reload
-        map.on('moveend', () => this.reloadResourcesInViewport.perform());
-        map.on('zoomend', () => this.reloadResourcesInViewport.perform());
+        this._viewportReloadHandler = () => this.reloadResourcesInViewport.perform();
+        map.on('moveend', this._viewportReloadHandler);
+        map.on('zoomend', this._viewportReloadHandler);
     }
 
     /**
@@ -231,7 +240,7 @@ export default class MapLeafletLiveMapComponent extends Component {
             // Get initial map bounds for spatial filtering (provider-agnostic)
             const mapBounds = this.mapManager.getBounds?.() ?? (this.map ? this.map.getBounds() : null);
             const bounds = this.#serializeBoundsForRequest(mapBounds);
-            const params = bounds ? { bounds } : {};
+            const params = this.#liveViewportRequestParams(bounds);
 
             const data = yield all([
                 this.loadResource.perform('routes'),
@@ -256,12 +265,19 @@ export default class MapLeafletLiveMapComponent extends Component {
         if (this.isViewportReloadSuspended) {
             return;
         }
+
+        yield timeout(this.liveViewportReloadDebounceMs);
+
+        if (this.isViewportReloadSuspended) {
+            return;
+        }
+
         // Get current map bounds (provider-agnostic)
         const rawBounds = this.mapManager.getBounds?.() ?? this.map?.getBounds();
         if (!rawBounds) return;
         const bounds = this.#serializeBoundsForRequest(rawBounds);
         if (!bounds) return;
-        const params = { bounds };
+        const params = this.#liveViewportRequestParams(bounds);
 
         // Reload spatially-filtered resources (drivers, vehicles, places)
         // Orders, routes, and service-areas are not spatially filtered
@@ -457,6 +473,10 @@ export default class MapLeafletLiveMapComponent extends Component {
         }
 
         return null;
+    }
+
+    #liveViewportRequestParams(bounds) {
+        return bounds ? { bounds, limit: this.liveViewportResourceLimit } : { limit: this.liveViewportResourceLimit };
     }
 
     #setResourceLayer(model, layer, options = {}) {

--- a/addon/components/vehicle/pill.hbs
+++ b/addon/components/vehicle/pill.hbs
@@ -20,7 +20,7 @@
     <:tooltip>
         <div>
             <div class="text-xs font-semibold">{{this.resource.name this.resource.yearMakeModel}}</div>
-            <div class="text-xs">{{t "this.resource.driver"}}: {{n-a this.resource.driver_name}}</div>
+            <div class="text-xs">{{t "resource.driver"}}: {{n-a this.resource.driver_name}}</div>
             <div class="text-xs">
                 <span>{{t "common.status"}}:</span>
                 <span class="{{if this.resource.online 'text-green-500' 'text-red-400'}}">

--- a/server/src/Http/Controllers/Internal/v1/LiveController.php
+++ b/server/src/Http/Controllers/Internal/v1/LiveController.php
@@ -22,6 +22,10 @@ use Illuminate\Http\Request;
  */
 class LiveController extends Controller
 {
+    protected const DEFAULT_VIEWPORT_LIMIT    = 500;
+    protected const MAX_VIEWPORT_LIMIT        = 1000;
+    protected const VIEWPORT_BOUNDS_PRECISION = 4;
+
     /**
      * Get coordinates for active orders.
      *
@@ -134,33 +138,19 @@ class LiveController extends Controller
      */
     public function drivers(Request $request)
     {
-        $bounds      = $request->input('bounds'); // Map viewport bounds: [south, west, north, east]
-        $cacheParams = ['bounds' => $bounds];
+        $bounds      = $this->normalizeLiveBounds($request);
+        $limit       = $this->normalizeLiveLimit($request);
+        $cacheParams = ['bounds' => $bounds, 'limit' => $limit];
 
-        return LiveCacheService::remember('drivers', $cacheParams, function () use ($bounds) {
+        return LiveCacheService::remember('drivers', $cacheParams, function () use ($bounds, $limit) {
             $query = Driver::where(['company_uuid' => session('company')])
                 ->with(['user', 'vehicle'])
                 ->applyDirectivesForPermissions('fleet-ops list driver');
 
-            // Filter out drivers with invalid coordinates
-            $query->whereNotNull('location')
-                ->whereRaw('
-                    ST_Y(location) BETWEEN -90 AND 90
-                    AND ST_X(location) BETWEEN -180 AND 180
-                    AND NOT (ST_X(location) = 0 AND ST_Y(location) = 0)
-                ');
+            $this->applyLiveLocationGuards($query);
+            $this->applyLiveViewportBounds($query, $bounds);
 
-            // Apply spatial filtering if bounds are provided
-            if ($bounds && is_array($bounds) && count($bounds) === 4) {
-                [$south, $west, $north, $east] = $bounds;
-
-                // Use MySQL spatial functions for POINT column
-                // ST_Within checks if location is within the bounding box
-                $query->whereRaw(
-                    'ST_Within(location, ST_MakeEnvelope(POINT(?, ?), POINT(?, ?)))',
-                    [$west, $south, $east, $north]
-                );
-            }
+            $query->orderByDesc('updated_at')->orderByDesc('id')->limit($limit);
 
             $drivers = $query->get();
 
@@ -175,34 +165,20 @@ class LiveController extends Controller
      */
     public function vehicles(Request $request)
     {
-        $bounds      = $request->input('bounds'); // Map viewport bounds: [south, west, north, east]
-        $cacheParams = ['bounds' => $bounds];
+        $bounds      = $this->normalizeLiveBounds($request);
+        $limit       = $this->normalizeLiveLimit($request);
+        $cacheParams = ['bounds' => $bounds, 'limit' => $limit];
 
-        return LiveCacheService::remember('vehicles', $cacheParams, function () use ($bounds) {
+        return LiveCacheService::remember('vehicles', $cacheParams, function () use ($bounds, $limit) {
             // Fetch vehicles that are online
             $query = Vehicle::where(['company_uuid' => session('company')])
                 ->with(['devices', 'driver'])
                 ->applyDirectivesForPermissions('fleet-ops list vehicle');
 
-            // Filter out vehicles with invalid coordinates
-            $query->whereNotNull('location')
-                ->whereRaw('
-                    ST_Y(location) BETWEEN -90 AND 90
-                    AND ST_X(location) BETWEEN -180 AND 180
-                    AND NOT (ST_X(location) = 0 AND ST_Y(location) = 0)
-                ');
+            $this->applyLiveLocationGuards($query);
+            $this->applyLiveViewportBounds($query, $bounds);
 
-            // Apply spatial filtering if bounds are provided
-            if ($bounds && is_array($bounds) && count($bounds) === 4) {
-                [$south, $west, $north, $east] = $bounds;
-
-                // Use MySQL spatial functions for POINT column
-                // ST_Within checks if location is within the bounding box
-                $query->whereRaw(
-                    'ST_Within(location, ST_MakeEnvelope(POINT(?, ?), POINT(?, ?)))',
-                    [$west, $south, $east, $north]
-                );
-            }
+            $query->orderByDesc('updated_at')->orderByDesc('id')->limit($limit);
 
             $vehicles = $query->get();
 
@@ -217,39 +193,98 @@ class LiveController extends Controller
      */
     public function places(Request $request)
     {
-        // Cache key includes filter parameters
-        $cacheParams = $request->only(['query', 'type', 'country', 'limit', 'bounds']);
+        $bounds = $this->normalizeLiveBounds($request);
+        $limit  = $this->normalizeLiveLimit($request);
 
-        return LiveCacheService::remember('places', $cacheParams, function () use ($request) {
+        // Cache key includes filter parameters
+        $cacheParams = array_merge($request->only(['query', 'type', 'country']), [
+            'bounds' => $bounds,
+            'limit'  => $limit,
+        ]);
+
+        return LiveCacheService::remember('places', $cacheParams, function () use ($request, $bounds, $limit) {
             // Query places based on filters
             $query = Place::where(['company_uuid' => session('company')])
                 ->filter(new PlaceFilter($request))
                 ->applyDirectivesForPermissions('fleet-ops list place');
 
-            // Filter out places with invalid coordinates
-            $query->whereNotNull('location')
-                ->whereRaw('
-                    ST_Y(location) BETWEEN -90 AND 90
-                    AND ST_X(location) BETWEEN -180 AND 180
-                    AND NOT (ST_X(location) = 0 AND ST_Y(location) = 0)
-                ');
+            $this->applyLiveLocationGuards($query);
+            $this->applyLiveViewportBounds($query, $bounds);
 
-            // Apply spatial filtering if bounds are provided
-            $bounds = $request->input('bounds');
-            if ($bounds && is_array($bounds) && count($bounds) === 4) {
-                [$south, $west, $north, $east] = $bounds;
-
-                // Use MySQL spatial functions for POINT column
-                // ST_Within checks if location is within the bounding box
-                $query->whereRaw(
-                    'ST_Within(location, ST_MakeEnvelope(POINT(?, ?), POINT(?, ?)))',
-                    [$west, $south, $east, $north]
-                );
-            }
+            $query->orderByDesc('updated_at')->orderByDesc('id')->limit($limit);
 
             $places = $query->get();
 
             return PlaceIndexResource::collection($places);
         });
+    }
+
+    protected function normalizeLiveBounds(Request $request): ?array
+    {
+        $bounds = $request->input('bounds');
+
+        if (!is_array($bounds) || count($bounds) !== 4) {
+            return null;
+        }
+
+        $bounds = array_values($bounds);
+
+        if (array_filter($bounds, fn ($value) => !is_numeric($value))) {
+            return null;
+        }
+
+        [$south, $west, $north, $east] = array_map('floatval', $bounds);
+
+        if ($south < -90 || $south > 90 || $north < -90 || $north > 90) {
+            return null;
+        }
+
+        if ($west < -180 || $west > 180 || $east < -180 || $east > 180) {
+            return null;
+        }
+
+        if ($south > $north || $west > $east) {
+            return null;
+        }
+
+        return array_map(
+            fn ($value) => round($value, static::VIEWPORT_BOUNDS_PRECISION),
+            [$south, $west, $north, $east]
+        );
+    }
+
+    protected function normalizeLiveLimit(Request $request): int
+    {
+        $limit = (int) $request->input('limit', static::DEFAULT_VIEWPORT_LIMIT);
+
+        if ($limit < 1) {
+            return static::DEFAULT_VIEWPORT_LIMIT;
+        }
+
+        return min($limit, static::MAX_VIEWPORT_LIMIT);
+    }
+
+    protected function applyLiveLocationGuards($query): void
+    {
+        $query->whereNotNull('location')
+            ->whereRaw('
+                ST_Y(location) BETWEEN -90 AND 90
+                AND ST_X(location) BETWEEN -180 AND 180
+                AND NOT (ST_X(location) = 0 AND ST_Y(location) = 0)
+            ');
+    }
+
+    protected function applyLiveViewportBounds($query, ?array $bounds): void
+    {
+        if (!$bounds) {
+            return;
+        }
+
+        [$south, $west, $north, $east] = $bounds;
+
+        $query->whereRaw(
+            'ST_Y(location) BETWEEN ? AND ? AND ST_X(location) BETWEEN ? AND ?',
+            [$south, $north, $west, $east]
+        );
     }
 }

--- a/server/tests/LiveControllerViewportTest.php
+++ b/server/tests/LiveControllerViewportTest.php
@@ -1,0 +1,60 @@
+<?php
+
+use Fleetbase\FleetOps\Http\Controllers\Internal\v1\LiveController;
+use Fleetbase\FleetOps\Models\Driver;
+use Illuminate\Http\Request;
+
+function callLiveControllerMethod(string $method, array $arguments = [])
+{
+    $reflection = new ReflectionMethod(LiveController::class, $method);
+    $reflection->setAccessible(true);
+
+    return $reflection->invokeArgs(new LiveController(), $arguments);
+}
+
+test('live viewport bounds are normalized for stable cache keys', function () {
+    $request = new Request([
+        'bounds' => ['1.234567', '103.876543', '1.345678', '103.987654'],
+    ]);
+
+    expect(callLiveControllerMethod('normalizeLiveBounds', [$request]))
+        ->toBe([1.2346, 103.8765, 1.3457, 103.9877]);
+});
+
+test('invalid live viewport bounds fall back to unbounded queries', function ($bounds) {
+    $request = new Request(['bounds' => $bounds]);
+
+    expect(callLiveControllerMethod('normalizeLiveBounds', [$request]))->toBeNull();
+})->with([
+    'missing coordinate' => [[1, 2, 3]],
+    'non numeric'        => [[1, 'west', 3, 4]],
+    'invalid latitude'   => [[-91, 103, 1, 104]],
+    'invalid longitude'  => [[1, -181, 2, 104]],
+    'inverted latitude'  => [[2, 103, 1, 104]],
+    'inverted longitude' => [[1, 104, 2, 103]],
+]);
+
+test('live viewport limit defaults and clamps', function () {
+    expect(callLiveControllerMethod('normalizeLiveLimit', [new Request()]))->toBe(500)
+        ->and(callLiveControllerMethod('normalizeLiveLimit', [new Request(['limit' => 25])]))->toBe(25)
+        ->and(callLiveControllerMethod('normalizeLiveLimit', [new Request(['limit' => 0])]))->toBe(500)
+        ->and(callLiveControllerMethod('normalizeLiveLimit', [new Request(['limit' => 5000])]))->toBe(1000);
+});
+
+test('live viewport query avoids spatial constructors with fixed srids', function () {
+    $query = Driver::query();
+
+    callLiveControllerMethod('applyLiveLocationGuards', [$query]);
+    callLiveControllerMethod('applyLiveViewportBounds', [$query, [1.2, 103.8, 1.4, 104.0]]);
+    $query->orderByDesc('updated_at')->orderByDesc('id')->limit(25);
+
+    $sql = $query->toSql();
+
+    expect($sql)->toContain('ST_Y(location) BETWEEN ? AND ?')
+        ->and($sql)->toContain('ST_X(location) BETWEEN ? AND ?')
+        ->and($sql)->toContain('limit 25')
+        ->and($sql)->not->toContain('ST_MakeEnvelope')
+        ->and($sql)->not->toContain('ST_GeomFromText');
+
+    expect($query->getBindings())->toContain(1.2, 1.4, 103.8, 104.0);
+});


### PR DESCRIPTION
## Summary
- replace live-map viewport filtering with SRID-safe coordinate predicates instead of ST_MakeEnvelope/ST_GeomFromText envelopes
- normalize bounds cache keys, validate viewport bounds, and cap live drivers/vehicles/places results
- debounce live-map viewport reloads and pass an explicit resource limit from the frontend

## Testing
- php -l server/src/Http/Controllers/Internal/v1/LiveController.php
- php -l server/tests/LiveControllerViewportTest.php
- npx eslint addon/components/map/leaflet-live-map.js
- npx prettier --check addon/components/map/leaflet-live-map.js
- git diff --check

Note: ./server_vendor/bin/pest server/tests/LiveControllerViewportTest.php could not run locally because server_vendor/pestphp/pest/vendor/autoload.php is missing in this checkout.