### PR TITLE
Add required indicators to order form

### DIFF
--- a/addon/components/order/form/details.hbs
+++ b/addon/components/order/form/details.hbs
@@ -1,6 +1,6 @@
 <ContentPanel @title="Details" @open={{true}} @wrapperClass="bordered-top">
     <div class="grid grid-cols-1 lg:grid-cols-2 gap-2">
-        <InputGroup @name={{t "order.fields.order-type"}} @helpText={{t "order.fields.order-type-help-text"}}>
+        <InputGroup @name={{t "order.fields.order-type"}} @helpText={{t "order.fields.order-type-help-text"}} @required={{true}}>
             <div class="fleetbase-model-select fleetbase-power-select ember-model-select">
                 <PowerSelect
                     @options={{this.orderConfigActions.allOrderConfigs}}
@@ -160,7 +160,7 @@
         </InputGroup>
 
         {{#if (and @resource.pod_required (not @resource.facilitator.isIntegratedVendor))}}
-            <InputGroup @name={{t "order.fields.proof-delivery"}} @helpText={{t "order.fields.proof-delivery-help-text"}}>
+            <InputGroup @name={{t "order.fields.proof-delivery"}} @helpText={{t "order.fields.proof-delivery-help-text"}} @required={{true}}>
                 <div class="fleetbase-model-select fleetbase-power-select ember-model-select">
                     <PowerSelect
                         @options={{get-fleet-ops-options "podOptions"}}

--- a/addon/components/order/form/route.hbs
+++ b/addon/components/order/form/route.hbs
@@ -27,6 +27,7 @@
                     @onClick={{fn this.addWaypoint (hash)}}
                     @helpText={{t "order.fields.add-waypoint-help-text"}}
                     @permission={{cannot-write @resource}}
+                    data-test-waypoint-add
                 />
             {{/if}}
         </div>
@@ -34,118 +35,123 @@
 
     {{#if this.multipleWaypoints}}
         <DragSortList class="multi-drop-select-container overflow-visible" @items={{@resource.payload.waypoints}} @dragEndAction={{this.sortWaypoints}} as |waypoint index|>
-            <div id={{concat "waypoint_" (add index 1)}} class="border rounded-md px-3 py-2 shadow-sm border-gray-300 dark:border-gray-900 mb-3">
-                <div class="flex items-start justify-between">
-                    <div class="flex items-center justify-between grip-cursor">
-                        <FaIcon @icon="grip-lines" @prefix="fas" class="mr-3 text-gray-100" />
-                        <label class="waypoint-label dark:text-gray-100 text-sm">
-                            {{waypoint-label (add index 1)}}
-                        </label>
-                    </div>
+            {{#let (get this.waypointRouteStops index) as |stop|}}
+                <div
+                    id={{concat "waypoint_" (add index 1)}}
+                    class="fleetops-order-form-waypoint {{if stop.required 'fleetops-order-form-waypoint--required'}} border rounded-md px-3 py-2 shadow-sm border-gray-300 dark:border-gray-900 mb-3"
+                    data-test-waypoint-row={{add index 1}}
+                >
+                    {{#if stop.required}}
+                        <div class="fleetops-order-form-waypoint__required-tab" data-test-required-waypoint-tab>Required</div>
+                    {{/if}}
+                    <div class="flex items-start justify-between">
+                        <div class="fleetops-order-form-waypoint__marker grip-cursor">
+                            <FaIcon @icon="grip-lines" @prefix="fas" class="text-gray-400" />
+                            <span class="index-count fleetops-route-stop-badge fleetops-order-form-waypoint__badge" style={{stop.badgeStyle}}>{{stop.label}}</span>
+                        </div>
 
-                    <div class="flex-1 flex-col px-3">
-                        <div class="mb-2">
-                            <ModelSelect
-                                @modelName="place"
-                                @selectedModel={{waypoint.place}}
-                                @placeholder={{concat (t "order.fields.select-waypoint") " " (add index 1)}}
-                                @triggerClass="form-select form-input truncate max-w-300px"
-                                @infiniteScroll={{false}}
-                                @customSearchEndpoint="places/search"
-                                @query={{hash geo=true latitude=this.location.latitude longitude=this.location.longitude}}
-                                @renderInPlace={{true}}
-                                @onChange={{fn this.setWaypointPlace index}}
-                                @permission={{cannot-write @resource}}
-                                as |place|
-                            >
-                                <Place::Address @place={{place}} />
-                            </ModelSelect>
-                            {{#if (and @resource.facilitator.isIntegratedVendor (is-not-facilitator-supported-place @resource.facilitator waypoint.place))}}
-                                <InfoBlock
-                                    class="my-2 px-4 py-1.5 danger"
-                                    @blockClass="flex flex-row items-center"
-                                    @text={{concat @resource.facilitator.name (t "order.fields.infoblock-text")}}
-                                />
-                            {{/if}}
-                            {{#if waypoint.place.hasInvalidCoordinates}}
-                                <div class="leading-5 text-sm text-red-400 mt-2">
-                                    <FaIcon @icon="exclamation-triangle" class="mr-1" />
-                                    {{t "order.fields.invalid-coordinates"}}
-                                </div>
-                            {{/if}}
-                        </div>
-                        <div>
-                            <ModelSelect
-                                @modelName="customer"
-                                @selectedModel={{waypoint.customer}}
-                                @placeholder={{t "order.fields.customer-placeholder"}}
-                                @triggerClass="form-select form-input truncate max-w-300px"
-                                @infiniteScroll={{false}}
-                                @renderInPlace={{true}}
-                                @allowClear={{true}}
-                                @onChange={{fn this.setWaypointCustomer waypoint}}
-                                @permission={{cannot-write @resource}}
-                                as |model|
-                            >
-                                <div class="flex items-center">
-                                    <div class="w-7">
-                                        <FaIcon @icon={{if model.isVendor "warehouse" "user"}} />
+                        <div class="flex-1 flex-col px-3">
+                            <div class="mb-2">
+                                <ModelSelect
+                                    @modelName="place"
+                                    @selectedModel={{waypoint.place}}
+                                    @placeholder={{concat (t "order.fields.select-waypoint") " " (add index 1)}}
+                                    @triggerClass="form-select form-input truncate max-w-300px"
+                                    @infiniteScroll={{false}}
+                                    @customSearchEndpoint="places/search"
+                                    @query={{hash geo=true latitude=this.location.latitude longitude=this.location.longitude}}
+                                    @renderInPlace={{true}}
+                                    @onChange={{fn this.setWaypointPlace index}}
+                                    @permission={{cannot-write @resource}}
+                                    as |place|
+                                >
+                                    <Place::Address @place={{place}} />
+                                </ModelSelect>
+                                {{#if (and @resource.facilitator.isIntegratedVendor (is-not-facilitator-supported-place @resource.facilitator waypoint.place))}}
+                                    <InfoBlock
+                                        class="my-2 px-4 py-1.5 danger"
+                                        @blockClass="flex flex-row items-center"
+                                        @text={{concat @resource.facilitator.name (t "order.fields.infoblock-text")}}
+                                    />
+                                {{/if}}
+                                {{#if waypoint.place.hasInvalidCoordinates}}
+                                    <div class="leading-5 text-sm text-red-400 mt-2">
+                                        <FaIcon @icon="exclamation-triangle" class="mr-1" />
+                                        {{t "order.fields.invalid-coordinates"}}
                                     </div>
-                                    <span class="uppercase">
-                                        {{model.name}}
-                                    </span>
-                                </div>
-                            </ModelSelect>
-                        </div>
-                        <div>
-                            <div class="flex flex-row items-center space-x-4 text-sm mt-2">
-                                <div class={{if (eq waypoint.type "dropoff") "is-checked"}}>
-                                    <div class="flex flex-row items-center">
-                                        <RadioButton
-                                            @radioClass="focus:ring-blue-500 h-4 w-4 text-blue-500"
-                                            @radioId={{concat "waypoint_" index "_dropoff"}}
-                                            @value="dropoff"
-                                            @groupValue={{waypoint.type}}
-                                            @name={{concat "waypoint_" index "_dropoff"}}
-                                            @changed={{fn (mut waypoint.type)}}
-                                        />
-                                        <label for={{concat "waypoint_" index "_dropoff"}} class="ml-2">Dropoff</label>
+                                {{/if}}
+                            </div>
+                            <div>
+                                <ModelSelect
+                                    @modelName="customer"
+                                    @selectedModel={{waypoint.customer}}
+                                    @placeholder={{t "order.fields.customer-placeholder"}}
+                                    @triggerClass="form-select form-input truncate max-w-300px"
+                                    @infiniteScroll={{false}}
+                                    @renderInPlace={{true}}
+                                    @allowClear={{true}}
+                                    @onChange={{fn this.setWaypointCustomer waypoint}}
+                                    @permission={{cannot-write @resource}}
+                                    as |model|
+                                >
+                                    <div class="flex items-center">
+                                        <div class="w-7">
+                                            <FaIcon @icon={{if model.isVendor "warehouse" "user"}} />
+                                        </div>
+                                        <span class="uppercase">
+                                            {{model.name}}
+                                        </span>
                                     </div>
-                                </div>
-                                <div class={{if (eq waypoint.type "pickup") "is-checked"}}>
-                                    <div class="flex flex-row items-center">
-                                        <RadioButton
-                                            @radioClass="focus:ring-blue-500 h-4 w-4 text-blue-500"
-                                            @radioId={{concat "waypoint_" index "_pickup"}}
-                                            @value="pickup"
-                                            @groupValue={{waypoint.type}}
-                                            @name={{concat "waypoint_" index "_pickup"}}
-                                            @changed={{fn (mut waypoint.type)}}
-                                        />
-                                        <label for={{concat "waypoint_" index "_pickup"}} class="ml-2">Pickup</label>
+                                </ModelSelect>
+                            </div>
+                            <div>
+                                <div class="flex flex-row items-center space-x-4 text-sm mt-2">
+                                    <div class={{if (eq waypoint.type "dropoff") "is-checked"}}>
+                                        <div class="flex flex-row items-center">
+                                            <RadioButton
+                                                @radioClass="focus:ring-blue-500 h-4 w-4 text-blue-500"
+                                                @radioId={{concat "waypoint_" index "_dropoff"}}
+                                                @value="dropoff"
+                                                @groupValue={{waypoint.type}}
+                                                @name={{concat "waypoint_" index "_dropoff"}}
+                                                @changed={{fn (mut waypoint.type)}}
+                                            />
+                                            <label for={{concat "waypoint_" index "_dropoff"}} class="ml-2">Dropoff</label>
+                                        </div>
+                                    </div>
+                                    <div class={{if (eq waypoint.type "pickup") "is-checked"}}>
+                                        <div class="flex flex-row items-center">
+                                            <RadioButton
+                                                @radioClass="focus:ring-blue-500 h-4 w-4 text-blue-500"
+                                                @radioId={{concat "waypoint_" index "_pickup"}}
+                                                @value="pickup"
+                                                @groupValue={{waypoint.type}}
+                                                @name={{concat "waypoint_" index "_pickup"}}
+                                                @changed={{fn (mut waypoint.type)}}
+                                            />
+                                            <label for={{concat "waypoint_" index "_pickup"}} class="ml-2">Pickup</label>
+                                        </div>
                                     </div>
                                 </div>
                             </div>
                         </div>
-                    </div>
 
-                    <div class="flex items-center space-x-2">
-                        {{#if waypoint.place}}
-                            <Button @icon="edit" @size="sm" @onClick={{fn this.editPlace waypoint.place}} @disabled={{cannot-write waypoint.place}} />
-                        {{/if}}
-                        {{#unless (eq index 0)}}
-                            <Button @type="danger" @icon="trash" @size="sm" @onClick={{fn this.removeWaypoint waypoint}} />
-                        {{/unless}}
+                        <div class="flex items-center space-x-2">
+                            {{#if waypoint.place}}
+                                <Button @icon="edit" @size="sm" @onClick={{fn this.editPlace waypoint.place}} @disabled={{cannot-write waypoint.place}} />
+                            {{/if}}
+                            {{#unless (eq index 0)}}
+                                <Button @type="danger" @icon="trash" @size="sm" @onClick={{fn this.removeWaypoint waypoint}} />
+                            {{/unless}}
+                        </div>
                     </div>
                 </div>
-            </div>
+            {{/let}}
         </DragSortList>
     {{else}}
         <div class="grid grid-cols-1 lg:grid-cols-2 gap-2 text-xs dark:text-gray-100">
-            <InputGroup>
-                <div class="flex items-center justify-between">
-                    <label>{{t "order.fields.pickup"}}</label>
-
+            <InputGroup @name={{t "order.fields.pickup"}} @required={{true}}>
+                <div class="flex items-center justify-end">
                     <div class="flex-row space-x-1 pr-0.5">
                         {{#if @resource.payload.pickup}}
                             <a href="javascript:;" {{on "click" (fn this.editPlace @resource.payload.pickup)}}>
@@ -186,10 +192,8 @@
                 {{/if}}
             </InputGroup>
 
-            <InputGroup>
-                <div class="flex items-center justify-between">
-                    <label>{{t "order.fields.dropoff"}}</label>
-
+            <InputGroup @name={{t "order.fields.dropoff"}} @required={{true}}>
+                <div class="flex items-center justify-end">
                     <div class="flex-row space-x-2 pr-0.5">
                         {{#if @resource.payload.dropoff}}
                             <a href="javascript:;" {{on "click" (fn this.editPlace @resource.payload.dropoff)}} disaled={{cannot "fleet-ops update place"}}>

--- a/addon/components/order/form/route.js
+++ b/addon/components/order/form/route.js
@@ -4,7 +4,7 @@ import { inject as service } from '@ember/service';
 import { action, get } from '@ember/object';
 import { task } from 'ember-concurrency';
 import { colorForId, routeColorForStatus, routeStyleForStatus } from '../../../utils/route-colors';
-import { buildRoutePointMarkerPresentation, buildRoutePointsFromPayload } from '../../../utils/route-visualization';
+import { buildRoutePointMarkerPresentation, buildRoutePointsFromPayload, describeRoutePoint } from '../../../utils/route-visualization';
 
 const ORDER_ROUTE_PREVIEW_PADDING_BOTTOM_RIGHT = [420, 0];
 const ORDER_ROUTE_PREVIEW_MAX_ZOOM_TWO_POINTS = 13;
@@ -43,6 +43,42 @@ export default class OrderFormRouteComponent extends Component {
 
     get routePoints() {
         return buildRoutePointsFromPayload(this.args.resource.payload);
+    }
+
+    get routeColor() {
+        const order = this.args.resource;
+
+        return colorForId(order?.public_id ?? order?.id ?? 'new-order');
+    }
+
+    get waypointRouteStops() {
+        const waypoints = this.args.resource.payload?.waypoints ?? [];
+
+        return waypoints.map((_waypoint, index) => {
+            const routePoint = {
+                role: 'waypoint',
+                stopNumber: index + 1,
+            };
+
+            return {
+                ...describeRoutePoint(routePoint, this.routeColor),
+                badgeStyle: this.badgeStyleForWaypoint(index),
+                required: this.isRequiredWaypoint(index),
+            };
+        });
+    }
+
+    badgeStyleForWaypoint(index) {
+        const { markerColor } = describeRoutePoint({ role: 'waypoint', stopNumber: index + 1 }, this.routeColor);
+        const normalizedColor = markerColor?.toLowerCase?.();
+        const isYellow = normalizedColor === '#facc15' || normalizedColor === '#ca8a04';
+        const textColor = isYellow ? '#111827' : '#ffffff';
+
+        return `background-color: ${markerColor}; color: ${textColor};`;
+    }
+
+    isRequiredWaypoint(index) {
+        return index < 2;
     }
 
     willDestroy() {

--- a/addon/styles/fleetops-engine.css
+++ b/addon/styles/fleetops-engine.css
@@ -345,6 +345,51 @@ body.fleetbase-console .next-content-overlay > .next-content-overlay-panel-conta
     gap: 0.5rem;
 }
 
+.fleetops-order-form-waypoint {
+    position: relative;
+}
+
+.fleetops-order-form-waypoint--required {
+    border-color: #f97316 !important;
+    padding-top: 1.25rem;
+    box-shadow:
+        0 1px 3px 0 rgb(249 115 22 / 15%),
+        0 0 0 1px rgb(249 115 22 / 10%);
+}
+
+.fleetops-order-form-waypoint__required-tab {
+    position: absolute;
+    top: -1px;
+    right: -1px;
+    border-top-right-radius: 0.375rem;
+    border-bottom-left-radius: 0.375rem;
+    background-color: #f97316;
+    color: #fff7ed;
+    padding: 0.15rem 0.5rem;
+    font-size: 0.62rem;
+    font-weight: 700;
+    line-height: 1.2;
+    text-transform: uppercase;
+    letter-spacing: 0.02em;
+}
+
+.fleetops-order-form-waypoint__marker {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    gap: 0.6rem;
+    min-width: 3.25rem;
+    padding-top: 0.15rem;
+}
+
+.fleetops-order-form-waypoint__badge {
+    min-width: 1.65rem;
+    width: 1.65rem;
+    height: 1.65rem;
+    font-size: 0.75rem;
+    flex-shrink: 0;
+}
+
 .fleetops-route-editor-empty-state {
     border: 1px dashed rgb(75 85 99 / 75%);
     border-radius: 0.5rem;

--- a/tests/integration/components/order/form/details-test.js
+++ b/tests/integration/components/order/form/details-test.js
@@ -1,4 +1,5 @@
 import { module, test } from 'qunit';
+import Service from '@ember/service';
 import { setupRenderingTest } from 'dummy/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
@@ -6,21 +7,34 @@ import { hbs } from 'ember-cli-htmlbars';
 module('Integration | Component | order/form/details', function (hooks) {
     setupRenderingTest(hooks);
 
-    test('it renders', async function (assert) {
-        // Set any properties with this.set('myProperty', 'value');
-        // Handle any actions with this.set('myAction', function(val) { ... });
+    hooks.beforeEach(function () {
+        class OrderConfigActionsStub extends Service {
+            allOrderConfigs = [];
+            loadAll = {
+                perform() {},
+            };
+        }
 
-        await render(hbs`<Order::Form::Details />`);
+        this.owner.register('service:order-config-actions', OrderConfigActionsStub);
+    });
 
-        assert.dom().hasText('');
+    test('it marks required create-order detail fields', async function (assert) {
+        this.set('resource', {
+            facilitator: {
+                isIntegratedVendor: false,
+            },
+            order_config: null,
+            payload: {},
+            pod_required: true,
+            required_skills: [],
+        });
 
-        // Template block usage:
-        await render(hbs`
-      <Order::Form::Details>
-        template block text
-      </Order::Form::Details>
-    `);
+        await render(hbs`<Order::Form::Details @resource={{this.resource}} />`);
 
-        assert.dom().hasText('template block text');
+        const requiredLabels = [...this.element.querySelectorAll('label.required')].map((label) => label.textContent.trim());
+
+        assert.dom('label.required').exists({ count: 2 });
+        assert.true(requiredLabels.includes('Order Type'));
+        assert.true(requiredLabels.includes('Proof of Delivery'));
     });
 });

--- a/tests/integration/components/order/form/route-test.js
+++ b/tests/integration/components/order/form/route-test.js
@@ -1,26 +1,65 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'dummy/tests/helpers';
-import { render } from '@ember/test-helpers';
+import { click, render, settled } from '@ember/test-helpers';
+import { A } from '@ember/array';
 import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Component | order/form/route', function (hooks) {
     setupRenderingTest(hooks);
 
-    test('it renders', async function (assert) {
-        // Set any properties with this.set('myProperty', 'value');
-        // Handle any actions with this.set('myAction', function(val) { ... });
+    test('it marks pickup and dropoff as required in single-route mode', async function (assert) {
+        this.set('resource', {
+            facilitator: {
+                isIntegratedVendor: false,
+            },
+            payload: {
+                pickup: null,
+                dropoff: null,
+                return: null,
+                waypoints: A([]),
+            },
+        });
 
-        await render(hbs`<Order::Form::Route />`);
+        await render(hbs`<Order::Form::Route @resource={{this.resource}} />`);
 
-        assert.dom().hasText('');
+        const requiredLabels = [...this.element.querySelectorAll('label.required')].map((label) => label.textContent.trim());
 
-        // Template block usage:
-        await render(hbs`
-      <Order::Form::Route>
-        template block text
-      </Order::Form::Route>
-    `);
+        assert.dom('label.required').exists({ count: 2 });
+        assert.true(requiredLabels.includes('Pickup'));
+        assert.true(requiredLabels.includes('Dropoff'));
+    });
 
-        assert.dom().hasText('template block text');
+    test('it renders route-list style waypoint badges and required tabs for the first two waypoints', async function (assert) {
+        this.set('resource', {
+            customer: null,
+            driver_assigned: null,
+            id: 'test-order',
+            facilitator: {
+                isIntegratedVendor: false,
+            },
+            payload: {
+                pickup: null,
+                dropoff: null,
+                return: null,
+                waypoints: A([]),
+                setProperties(properties) {
+                    Object.assign(this, properties);
+                },
+            },
+        });
+
+        await render(hbs`<Order::Form::Route @resource={{this.resource}} />`);
+        await click('[role="checkbox"]');
+        this.resource.payload.waypoints.pushObject({ type: 'dropoff' });
+        this.resource.payload.waypoints.pushObject({ type: 'dropoff' });
+        await settled();
+
+        assert.dom('[data-test-waypoint-row="1"] .fleetops-route-stop-badge').hasText('1');
+        assert.dom('[data-test-waypoint-row="2"] .fleetops-route-stop-badge').hasText('2');
+        assert.dom('[data-test-waypoint-row="3"] .fleetops-route-stop-badge').hasText('3');
+        assert.dom('[data-test-waypoint-row="1"]').hasClass('fleetops-order-form-waypoint--required');
+        assert.dom('[data-test-waypoint-row="2"]').hasClass('fleetops-order-form-waypoint--required');
+        assert.dom('[data-test-waypoint-row="3"]').doesNotHaveClass('fleetops-order-form-waypoint--required');
+        assert.dom('[data-test-required-waypoint-tab]').exists({ count: 2 });
     });
 });


### PR DESCRIPTION
## Summary
- add required indicators to new order form fields backed by create-order validation
- update multi-waypoint route rows to use RouteList-style markers
- show required tab/border only on the first two multi-waypoint rows

## Testing
- npm run lint:hbs
- npx eslint addon/components/order/form/route.js tests/integration/components/order/form/route-test.js tests/integration/components/order/form/details-test.js
- npx stylelint addon/styles/fleetops-engine.css

Note: targeted Ember test build succeeds, but Testem fails before execution due the existing CommonJS require of ESM-only execa@9.