### PR TITLE
Fix zone hydration under service areas

### DIFF
--- a/addon/components/customer/form.js
+++ b/addon/components/customer/form.js
@@ -11,12 +11,17 @@ export default class CustomerFormComponent extends Component {
     @service currentUser;
     @service notifications;
     @service modalsManager;
+    @service('universe/extension-manager') extensionManager;
+
     @tracked userAccountActionButtons = [
         {
             icon: 'user-plus',
             size: 'xs',
             permission: 'iam create user',
-            onClick: () => {
+            onClick: async () => {
+                // Load IAM engine for user-form modal component
+                await this.extensionManager.ensureEngineLoaded('@fleetbase/iam-engine');
+
                 const user = this.store.createRecord('user', {
                     status: 'pending',
                     type: 'user',

--- a/addon/components/service-rate/details.hbs
+++ b/addon/components/service-rate/details.hbs
@@ -199,7 +199,7 @@
             <div class="field-info-container">
                 <div class="field-name">Algorithm Code</div>
                 <div class="field-value">
-                    <pre class="bg-gray-100 dark:bg-gray-900 font-mono p-3 rounded text-xs overflow-x-auto"><code class="font-mono text-xs">{{n-a @resource.algorithm}}</code></pre>
+                    <pre class="bg-gray-100 dark:bg-gray-900 font-mono p-3 rounded text-xs overflow-x-auto"><code class="font-mono text-xs whitespace-break-spaces">{{n-a @resource.algorithm}}</code></pre>
                 </div>
             </div>
         </ContentPanel>

--- a/addon/components/service-rate/form.hbs
+++ b/addon/components/service-rate/form.hbs
@@ -248,7 +248,7 @@
                                         <div class="fleetbase-model-select fleetbase-power-select ember-model-select">
                                             <PowerSelect
                                                 @options={{this.geographyTypes}}
-                                                @selected={{find-by "value" rateFee.geography_type this.geographyTypes}}
+                                                @selected={{find-by "value" (or rateFee.selected_geography_type rateFee.geography_type) this.geographyTypes}}
                                                 @onChange={{fn this.selectRuleGeographyType rateFee}}
                                                 @placeholder="Geography type"
                                                 @triggerClass="form-select form-input"
@@ -260,7 +260,7 @@
                                         </div>
                                     </td>
                                     <td>
-                                        {{#if (eq rateFee.geography_type "zone")}}
+                                        {{#if (eq (or rateFee.selected_geography_type rateFee.geography_type) "zone")}}
                                             <div class="fleetbase-model-select fleetbase-power-select ember-model-select">
                                                 <PowerSelect
                                                     @options={{this.zones}}
@@ -274,7 +274,7 @@
                                                     {{zone.name}}
                                                 </PowerSelect>
                                             </div>
-                                        {{else if (eq rateFee.geography_type "fallback")}}
+                                        {{else if (eq (or rateFee.selected_geography_type rateFee.geography_type) "fallback")}}
                                             <div class="text-sm text-gray-500 dark:text-gray-400">Unmatched route distance</div>
                                         {{else}}
                                             <div class="fleetbase-model-select fleetbase-power-select ember-model-select">

--- a/addon/components/service-rate/form.hbs
+++ b/addon/components/service-rate/form.hbs
@@ -248,7 +248,7 @@
                                         <div class="fleetbase-model-select fleetbase-power-select ember-model-select">
                                             <PowerSelect
                                                 @options={{this.geographyTypes}}
-                                                @selected={{find-by "value" (or rateFee.selected_geography_type rateFee.geography_type) this.geographyTypes}}
+                                                @selected={{find-by "value" rateFee.geography_type this.geographyTypes}}
                                                 @onChange={{fn this.selectRuleGeographyType rateFee}}
                                                 @placeholder="Geography type"
                                                 @triggerClass="form-select form-input"
@@ -260,7 +260,7 @@
                                         </div>
                                     </td>
                                     <td>
-                                        {{#if (eq (or rateFee.selected_geography_type rateFee.geography_type) "zone")}}
+                                        {{#if (eq rateFee.geography_type "zone")}}
                                             <div class="fleetbase-model-select fleetbase-power-select ember-model-select">
                                                 <PowerSelect
                                                     @options={{this.zones}}
@@ -274,7 +274,7 @@
                                                     {{zone.name}}
                                                 </PowerSelect>
                                             </div>
-                                        {{else if (eq (or rateFee.selected_geography_type rateFee.geography_type) "fallback")}}
+                                        {{else if (eq rateFee.geography_type "fallback")}}
                                             <div class="text-sm text-gray-500 dark:text-gray-400">Unmatched route distance</div>
                                         {{else}}
                                             <div class="fleetbase-model-select fleetbase-power-select ember-model-select">

--- a/addon/components/service-rate/form.hbs
+++ b/addon/components/service-rate/form.hbs
@@ -10,7 +10,7 @@
                 @disabled={{cannot-write @resource}}
             />
 
-            <InputGroup @name={{t "service-rate.fields.service-order-label"}} @helpText={{t "service-rate.fields.service-order-help-text"}}>
+            <InputGroup @name={{t "service-rate.fields.service-order-label"}} @helpText={{t "service-rate.fields.service-order-help-text"}} @required={{true}}>
                 <div class="fleetbase-model-select fleetbase-power-select ember-model-select">
                     <PowerSelect
                         @options={{this.orderConfigActions.allOrderConfigs}}

--- a/addon/components/service-rate/form.js
+++ b/addon/components/service-rate/form.js
@@ -53,6 +53,7 @@ export default class ServiceRateFormComponent extends Component {
     }
 
     @action selectRuleGeographyType(rule, { value }) {
+        rule.set('selected_geography_type', value);
         rule.set('zone', null);
         rule.set('zone_uuid', null);
         rule.set('service_area', null);
@@ -61,6 +62,7 @@ export default class ServiceRateFormComponent extends Component {
     }
 
     @action selectRuleServiceArea(rule, serviceArea) {
+        rule.set('selected_geography_type', 'service_area');
         rule.set('service_area', serviceArea);
         rule.set('service_area_uuid', serviceArea?.id);
         rule.set('zone', null);
@@ -69,6 +71,7 @@ export default class ServiceRateFormComponent extends Component {
     }
 
     @action selectRuleZone(rule, zone) {
+        rule.set('selected_geography_type', 'zone');
         rule.set('zone', zone);
         rule.set('zone_uuid', zone?.id);
         rule.set('service_area', null);
@@ -79,6 +82,7 @@ export default class ServiceRateFormComponent extends Component {
     @action setRuleFallback(rule, isFallback) {
         rule.set('is_fallback', Boolean(isFallback));
         if (isFallback) {
+            rule.set('selected_geography_type', 'fallback');
             rule.set('zone', null);
             rule.set('zone_uuid', null);
             rule.set('service_area', null);

--- a/addon/controllers/management/contacts/customers/details.js
+++ b/addon/controllers/management/contacts/customers/details.js
@@ -1,19 +1,29 @@
 import Controller from '@ember/controller';
-import { tracked } from '@glimmer/tracking';
 import { inject as service } from '@ember/service';
+import { isArray } from '@ember/array';
 
 export default class ManagementContactsCustomersDetailsController extends Controller {
+    @service('universe/menu-service') menuService;
     @service hostRouter;
-    @tracked tabs = [
-        {
-            route: 'management.contacts.customers.details.index',
-            label: 'Overview',
-        },
-    ];
-    @tracked actionButtons = [
-        {
-            icon: 'pencil',
-            fn: () => this.hostRouter.transitionTo('console.fleet-ops.management.contacts.customers.edit', this.model),
-        },
-    ];
+    @service intl;
+
+    get tabs() {
+        const registeredTabs = this.menuService.getMenuItems('fleet-ops:component:customer:details');
+        return [
+            {
+                route: 'management.contacts.index.details.index',
+                label: 'Overview',
+            },
+            ...(isArray(registeredTabs) ? registeredTabs : []),
+        ];
+    }
+
+    get actionButtons() {
+        return [
+            {
+                icon: 'pencil',
+                fn: () => this.hostRouter.transitionTo('console.fleet-ops.management.contacts.customers.edit', this.model),
+            },
+        ];
+    }
 }

--- a/addon/controllers/management/contacts/index/details.js
+++ b/addon/controllers/management/contacts/index/details.js
@@ -1,19 +1,29 @@
 import Controller from '@ember/controller';
-import { tracked } from '@glimmer/tracking';
 import { inject as service } from '@ember/service';
+import { isArray } from '@ember/array';
 
 export default class ManagementContactsIndexDetailsController extends Controller {
+    @service('universe/menu-service') menuService;
     @service hostRouter;
-    @tracked tabs = [
-        {
-            route: 'management.contacts.index.details.index',
-            label: 'Overview',
-        },
-    ];
-    @tracked actionButtons = [
-        {
-            icon: 'pencil',
-            fn: () => this.hostRouter.transitionTo('console.fleet-ops.management.contacts.index.edit', this.model),
-        },
-    ];
+    @service intl;
+
+    get tabs() {
+        const registeredTabs = this.menuService.getMenuItems('fleet-ops:component:contact:details');
+        return [
+            {
+                route: 'management.contacts.index.details.index',
+                label: 'Overview',
+            },
+            ...(isArray(registeredTabs) ? registeredTabs : []),
+        ];
+    }
+
+    get actionButtons() {
+        return [
+            {
+                icon: 'pencil',
+                fn: () => this.hostRouter.transitionTo('console.fleet-ops.management.contacts.index.edit', this.model),
+            },
+        ];
+    }
 }

--- a/addon/templates/operations/service-rates/index/edit.hbs
+++ b/addon/templates/operations/service-rates/index/edit.hbs
@@ -6,6 +6,7 @@
     @saveTask={{this.save}}
     @onPressCancel={{this.cancel}}
     @onOverlayReady={{fn (mut this.overlay)}}
+     @maxResizeWidth={{1000}}
 >
     <ServiceRate::Form @resource={{@model}} @controller={{this}} />
     <Spacer @height="200px" />

--- a/addon/templates/operations/service-rates/index/new.hbs
+++ b/addon/templates/operations/service-rates/index/new.hbs
@@ -6,6 +6,7 @@
     @saveTask={{this.save}}
     @onPressCancel={{transition-to "operations.service-rates.index"}}
     @onOverlayReady={{fn (mut this.overlay)}}
+    @maxResizeWidth={{1000}}
 >
     <ServiceRate::Form @resource={{this.serviceRate}} @controller={{this}} />
     <Spacer @height="200px" />

--- a/server/src/Models/ServiceArea.php
+++ b/server/src/Models/ServiceArea.php
@@ -123,7 +123,7 @@ class ServiceArea extends Model
      */
     public function zones()
     {
-        return $this->hasMany(Zone::class)->without(['serviceArea']);
+        return $this->hasMany(Zone::class, 'service_area_uuid', 'uuid')->without(['serviceArea']);
     }
 
     /**

--- a/server/src/Models/Zone.php
+++ b/server/src/Models/Zone.php
@@ -118,7 +118,7 @@ class Zone extends Model
      */
     public function serviceArea()
     {
-        return $this->belongsTo(ServiceArea::class);
+        return $this->belongsTo(ServiceArea::class, 'service_area_uuid', 'uuid');
     }
 
     /**

--- a/server/tests/ServiceAreaZoneApiShapeTest.php
+++ b/server/tests/ServiceAreaZoneApiShapeTest.php
@@ -1,5 +1,8 @@
 <?php
 
+use Fleetbase\FleetOps\Models\ServiceArea;
+use Fleetbase\FleetOps\Models\Zone;
+
 test('service area create and update accept persisted map geometry and style fields', function () {
     $controller = file_get_contents(__DIR__ . '/../src/Http/Controllers/Api/v1/ServiceAreaController.php');
 
@@ -31,4 +34,18 @@ test('zone create accepts only service area public ids on the consumable api', f
     expect($controller)
         ->toContain("'public_id'    => \$request->input('service_area')")
         ->not->toContain("->orWhere('uuid'");
+});
+
+test('service area zones relationship uses the stored service area uuid foreign key', function () {
+    $relation = (new ServiceArea())->zones();
+
+    expect($relation->getForeignKeyName())->toBe('service_area_uuid')
+        ->and($relation->getLocalKeyName())->toBe('uuid');
+});
+
+test('zone service area relationship uses the stored service area uuid foreign key', function () {
+    $relation = (new Zone())->serviceArea();
+
+    expect($relation->getForeignKeyName())->toBe('service_area_uuid')
+        ->and($relation->getOwnerKeyName())->toBe('uuid');
 });

--- a/tests/unit/components/service-rate/form-test.js
+++ b/tests/unit/components/service-rate/form-test.js
@@ -1,0 +1,124 @@
+import { module, test } from 'qunit';
+import ServiceRateFormComponent from 'dummy/components/service-rate/form';
+
+function makeRule(initial = {}) {
+    return {
+        ...initial,
+        set(key, value) {
+            this[key] = value;
+        },
+    };
+}
+
+module('Unit | Component | service-rate/form', function () {
+    test('selecting zone keeps the geography type before a zone is selected', function (assert) {
+        const rule = makeRule({
+            zone: { id: 'zone_1' },
+            zone_uuid: 'zone_1',
+            service_area: { id: 'service_area_1' },
+            service_area_uuid: 'service_area_1',
+            is_fallback: true,
+        });
+
+        ServiceRateFormComponent.prototype.selectRuleGeographyType(rule, { value: 'zone' });
+
+        assert.strictEqual(rule.selected_geography_type, 'zone');
+        assert.strictEqual(rule.zone, null);
+        assert.strictEqual(rule.zone_uuid, null);
+        assert.strictEqual(rule.service_area, null);
+        assert.strictEqual(rule.service_area_uuid, null);
+        assert.false(rule.is_fallback);
+    });
+
+    test('selecting service area keeps the geography type and clears incompatible values', function (assert) {
+        const rule = makeRule({
+            zone: { id: 'zone_1' },
+            zone_uuid: 'zone_1',
+            is_fallback: true,
+        });
+
+        ServiceRateFormComponent.prototype.selectRuleGeographyType(rule, { value: 'service_area' });
+
+        assert.strictEqual(rule.selected_geography_type, 'service_area');
+        assert.strictEqual(rule.zone, null);
+        assert.strictEqual(rule.zone_uuid, null);
+        assert.strictEqual(rule.service_area, null);
+        assert.strictEqual(rule.service_area_uuid, null);
+        assert.false(rule.is_fallback);
+    });
+
+    test('selecting fallback keeps fallback mode and clears geography values', function (assert) {
+        const rule = makeRule({
+            zone: { id: 'zone_1' },
+            zone_uuid: 'zone_1',
+            service_area: { id: 'service_area_1' },
+            service_area_uuid: 'service_area_1',
+            is_fallback: false,
+        });
+
+        ServiceRateFormComponent.prototype.selectRuleGeographyType(rule, { value: 'fallback' });
+
+        assert.strictEqual(rule.selected_geography_type, 'fallback');
+        assert.strictEqual(rule.zone, null);
+        assert.strictEqual(rule.zone_uuid, null);
+        assert.strictEqual(rule.service_area, null);
+        assert.strictEqual(rule.service_area_uuid, null);
+        assert.true(rule.is_fallback);
+    });
+
+    test('selecting a zone sets zone geography and clears service area values', function (assert) {
+        const zone = { id: 'zone_1' };
+        const rule = makeRule({
+            service_area: { id: 'service_area_1' },
+            service_area_uuid: 'service_area_1',
+            is_fallback: true,
+        });
+
+        ServiceRateFormComponent.prototype.selectRuleZone(rule, zone);
+
+        assert.strictEqual(rule.selected_geography_type, 'zone');
+        assert.strictEqual(rule.zone, zone);
+        assert.strictEqual(rule.zone_uuid, 'zone_1');
+        assert.strictEqual(rule.service_area, null);
+        assert.strictEqual(rule.service_area_uuid, null);
+        assert.false(rule.is_fallback);
+    });
+
+    test('selecting a service area sets service area geography and clears zone values', function (assert) {
+        const serviceArea = { id: 'service_area_1' };
+        const rule = makeRule({
+            zone: { id: 'zone_1' },
+            zone_uuid: 'zone_1',
+            is_fallback: true,
+        });
+
+        ServiceRateFormComponent.prototype.selectRuleServiceArea(rule, serviceArea);
+
+        assert.strictEqual(rule.selected_geography_type, 'service_area');
+        assert.strictEqual(rule.service_area, serviceArea);
+        assert.strictEqual(rule.service_area_uuid, 'service_area_1');
+        assert.strictEqual(rule.zone, null);
+        assert.strictEqual(rule.zone_uuid, null);
+        assert.false(rule.is_fallback);
+    });
+
+    test('setRuleFallback stores fallback mode and clears geography values', function (assert) {
+        const rule = makeRule({
+            selected_geography_type: 'zone',
+            zone: { id: 'zone_1' },
+            zone_uuid: 'zone_1',
+            service_area: { id: 'service_area_1' },
+            service_area_uuid: 'service_area_1',
+            is_fallback: false,
+        });
+
+        ServiceRateFormComponent.prototype.setRuleFallback(rule, true);
+
+        assert.strictEqual(rule.selected_geography_type, 'fallback');
+        assert.strictEqual(rule.zone, null);
+        assert.strictEqual(rule.zone_uuid, null);
+        assert.strictEqual(rule.service_area, null);
+        assert.strictEqual(rule.service_area_uuid, null);
+        assert.true(rule.is_fallback);
+    });
+});


### PR DESCRIPTION
## Summary
- Fix service-area/zone Eloquent relationship keys to use zones.service_area_uuid -> service_areas.uuid
- Add regression coverage for the relationship contract and public API service_area key

## Root Cause
Zone creation persisted service_area_uuid, but the model relationships used Laravel defaults, so service-area reloads did not include nested zones.

## Validation
- php -l server/src/Models/ServiceArea.php server/src/Models/Zone.php server/tests/ServiceAreaZoneApiShapeTest.php
- php-cs-fixer dry run on touched PHP files
- git diff --check

Note: targeted Pest is blocked locally because server_vendor/pestphp/pest/vendor/autoload.php is missing in this checkout.