### PR TITLE
Emit order completed event after status update

### DIFF
--- a/server/src/Models/Order.php
+++ b/server/src/Models/Order.php
@@ -1379,8 +1379,9 @@ class Order extends Model
      *
      * The process involves the following steps:
      * 1. Creating a new Activity instance with the 'completed' code and relevant details.
-     * 2. Notifying that the order has been completed via `notifyCompleted`.
-     * 3. Updating the order's activity with the new 'completed' activity through `updateActivity`.
+     * 2. Updating the order's activity with the new 'completed' activity through `updateActivity`,
+     *    which applies and persists the 'completed' status.
+     * 3. Notifying that the order has been completed via `notifyCompleted`.
      *
      * @param Proof|null $proof Optional. Additional proof or details for the activity update.
      *
@@ -1388,14 +1389,14 @@ class Order extends Model
      */
     public function complete(?Proof $proof = null): self
     {
-        $this->notifyCompleted();
-
         $doesntHaveCompletedActivity = TrackingStatus::where(['tracking_number_uuid' => $this->tracking_number_uuid, 'code' => 'COMPLETED'])->doesntExist();
         if ($doesntHaveCompletedActivity) {
             $activity = $this->config()->getCompletedActivity();
 
-            return $this->updateActivity($activity, $proof);
+            $this->updateActivity($activity, $proof);
         }
+
+        $this->notifyCompleted();
 
         return $this;
     }


### PR DESCRIPTION
## Summary

This PR updates `Order::complete()` so the `order.completed` lifecycle event is emitted only after the order has been updated to the completed state.

Previously, `notifyCompleted()` was called before the completed activity/status was applied. As a result, lifecycle event consumers could receive an `order.completed` event while the order still exposed its previous status.

## Background

Downstream listeners build lifecycle payloads from the order state at the time the completion event is emitted.

The previous order of operations was:

1. Emit the order completed event
2. Apply the completed activity/status

This could cause stale order data to be captured by event listeners and included in webhook payloads.

## Changes

* Move `notifyCompleted()` after the completed activity update in `Order::complete()`
* Keep `notifyCompleted()` outside the completed-activity guard so callers that already applied the completed activity still emit the completion event
* Update the method docblock to reflect the actual order of operations

## Related PRs

* fleetbase/core-api#218
