### PR TITLE
Add native telematics provider parity

### DIFF
--- a/server/src/Console/Commands/SyncTelematics.php
+++ b/server/src/Console/Commands/SyncTelematics.php
@@ -13,7 +13,7 @@ class SyncTelematics extends Command
     protected $signature = 'fleetops:sync-telematics
         {--provider=* : Limit polling to one or more provider keys}
         {--limit=500 : Maximum provider units to fetch per page}
-        {--sync-webhook-providers : Include providers that support webhooks}
+        {--exclude-webhook-providers : Skip providers that support webhooks}
         {--no-lock : Skip process locking}';
 
     protected $description = 'Poll active telematics providers for device snapshots and positional telemetry.';
@@ -68,10 +68,10 @@ class SyncTelematics extends Command
     protected function pollableProviderKeys(TelematicProviderRegistry $registry): array
     {
         $requestedProviders      = array_filter((array) $this->option('provider'));
-        $includeWebhookProviders = (bool) $this->option('sync-webhook-providers');
+        $excludeWebhookProviders = (bool) $this->option('exclude-webhook-providers');
 
         return $registry->all()
-            ->filter(function ($descriptor) use ($requestedProviders, $includeWebhookProviders) {
+            ->filter(function ($descriptor) use ($requestedProviders, $excludeWebhookProviders) {
                 if (!empty($requestedProviders) && !in_array($descriptor->key, $requestedProviders, true)) {
                     return false;
                 }
@@ -80,7 +80,7 @@ class SyncTelematics extends Command
                     return false;
                 }
 
-                return $includeWebhookProviders || !$descriptor->supportsWebhooks;
+                return !$excludeWebhookProviders || !$descriptor->supportsWebhooks;
             })
             ->keys()
             ->values()

--- a/server/src/Support/Telematics/Providers/AfaqyProvider.php
+++ b/server/src/Support/Telematics/Providers/AfaqyProvider.php
@@ -151,6 +151,7 @@ class AfaqyProvider extends AbstractProvider
 
         return [
             'device_id'    => $payload['_id'] ?? $payload['id'] ?? null,
+            'external_id'  => $payload['_id'] ?? $payload['id'] ?? null,
             'name'         => $payload['name'] ?? data_get($payload, 'profile.plate_number') ?? 'Unknown Unit',
             'provider'     => 'afaqy',
             'model'        => data_get($payload, 'profile.model') ?? $payload['device'] ?? null,

--- a/server/src/Support/Telematics/Providers/FlespiProvider.php
+++ b/server/src/Support/Telematics/Providers/FlespiProvider.php
@@ -2,6 +2,8 @@
 
 namespace Fleetbase\FleetOps\Support\Telematics\Providers;
 
+use Illuminate\Support\Carbon;
+
 /**
  * Class FlespiProvider.
  *
@@ -77,34 +79,71 @@ class FlespiProvider extends AbstractProvider
 
     public function normalizeDevice(array $payload): array
     {
+        $telemetry  = $payload['telemetry'] ?? $payload;
+        $externalId = $payload['id'] ?? $payload['device.id'] ?? null;
+        $occurredAt = $this->parseTimestamp($telemetry['timestamp'] ?? $payload['last_active'] ?? null);
+
         return [
-            'external_id'     => $payload['id'],
-            'device_name'     => $payload['name'] ?? 'Unknown Device',
-            'device_provider' => 'flespi',
-            'device_model'    => $payload['device_type_id'] ?? null,
-            'imei'            => $payload['configuration']['ident'] ?? null,
-            'phone'           => $payload['configuration']['phone'] ?? null,
-            'status'          => isset($payload['telemetry']) ? 'active' : 'inactive',
-            'location'        => [
-                'lat' => $payload['telemetry']['position.latitude'] ?? null,
-                'lng' => $payload['telemetry']['position.longitude'] ?? null,
+            'device_id'     => $externalId,
+            'external_id'   => $externalId,
+            'name'          => $payload['name'] ?? $telemetry['device.name'] ?? 'Unknown Device',
+            'provider'      => 'flespi',
+            'model'         => $payload['device_type_id'] ?? $payload['device_type_name'] ?? null,
+            'imei'          => $payload['configuration']['ident'] ?? $payload['ident'] ?? $telemetry['ident'] ?? null,
+            'serial_number' => $payload['configuration']['serial'] ?? $payload['serial'] ?? null,
+            'phone'         => $payload['configuration']['phone'] ?? null,
+            'status'        => isset($payload['telemetry']) ? 'active' : 'inactive',
+            'online'        => $this->resolveOnline($telemetry),
+            'last_seen_at'  => $occurredAt,
+            'location'      => [
+                'lat' => $telemetry['position.latitude'] ?? null,
+                'lng' => $telemetry['position.longitude'] ?? null,
             ],
-            'meta' => $payload,
+            'speed'      => $telemetry['position.speed'] ?? $telemetry['vehicle.speed'] ?? null,
+            'heading'    => $telemetry['position.direction'] ?? $telemetry['position.heading'] ?? null,
+            'altitude'   => $telemetry['position.altitude'] ?? null,
+            'odometer'   => $telemetry['vehicle.mileage'] ?? $telemetry['vehicle.odometer'] ?? null,
+            'ignition'   => $this->extractIgnition($telemetry),
+            'fuel_level' => $telemetry['fuel.level'] ?? $telemetry['can.fuel.level'] ?? null,
+            'meta'       => [
+                'raw'             => $payload,
+                'provider_status' => array_filter([
+                    'status'    => $payload['status'] ?? $telemetry['status'] ?? null,
+                    'online'    => $telemetry['online'] ?? null,
+                    'connected' => $telemetry['device.connected'] ?? $telemetry['connected'] ?? null,
+                ], fn ($value) => $value !== null),
+            ],
         ];
     }
 
     public function normalizeEvent(array $payload): array
     {
+        $deviceId = $payload['device.id'] ?? $payload['id'] ?? null;
+
         return [
-            'external_id' => $payload['id'] ?? null,
-            'device_id'   => $payload['device.id'] ?? null,
+            'external_id' => $payload['id'] ?? $deviceId,
+            'device_id'   => $deviceId,
             'event_type'  => $payload['event.enum'] ?? 'telemetry_update',
-            'occurred_at' => isset($payload['timestamp']) ? date('Y-m-d H:i:s', $payload['timestamp']) : now(),
+            'occurred_at' => $this->parseTimestamp($payload['timestamp'] ?? null) ?? now(),
+            'online'      => $this->resolveOnline($payload),
             'location'    => [
                 'lat' => $payload['position.latitude'] ?? null,
                 'lng' => $payload['position.longitude'] ?? null,
             ],
-            'meta' => $payload,
+            'speed'      => $payload['position.speed'] ?? $payload['vehicle.speed'] ?? null,
+            'heading'    => $payload['position.direction'] ?? $payload['position.heading'] ?? null,
+            'altitude'   => $payload['position.altitude'] ?? null,
+            'odometer'   => $payload['vehicle.mileage'] ?? $payload['vehicle.odometer'] ?? null,
+            'ignition'   => $this->extractIgnition($payload),
+            'fuel_level' => $payload['fuel.level'] ?? $payload['can.fuel.level'] ?? null,
+            'meta'       => [
+                'raw'             => $payload,
+                'provider_status' => array_filter([
+                    'status'    => $payload['status'] ?? null,
+                    'online'    => $payload['online'] ?? null,
+                    'connected' => $payload['device.connected'] ?? $payload['connected'] ?? null,
+                ], fn ($value) => $value !== null),
+            ],
         ];
     }
 
@@ -179,5 +218,40 @@ class FlespiProvider extends AbstractProvider
     public function supportsWebhooks(): bool
     {
         return true;
+    }
+
+    protected function parseTimestamp($value): ?string
+    {
+        if (!$value) {
+            return null;
+        }
+
+        if (is_numeric($value)) {
+            return Carbon::createFromTimestamp((float) $value)->toDateTimeString();
+        }
+
+        return Carbon::parse($value)->toDateTimeString();
+    }
+
+    protected function resolveOnline(array $payload): ?bool
+    {
+        $value = $payload['online'] ?? $payload['device.connected'] ?? $payload['connected'] ?? null;
+
+        if ($value === null) {
+            return isset($payload['timestamp']);
+        }
+
+        return filter_var($value, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE) ?? (bool) $value;
+    }
+
+    protected function extractIgnition(array $payload): ?bool
+    {
+        $value = $payload['engine.ignition.status'] ?? $payload['ignition.status'] ?? null;
+
+        if ($value === null) {
+            return null;
+        }
+
+        return filter_var($value, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE) ?? (bool) $value;
     }
 }

--- a/server/src/Support/Telematics/Providers/GeotabProvider.php
+++ b/server/src/Support/Telematics/Providers/GeotabProvider.php
@@ -2,6 +2,7 @@
 
 namespace Fleetbase\FleetOps\Support\Telematics\Providers;
 
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Http;
 
 /**
@@ -75,19 +76,21 @@ class GeotabProvider extends AbstractProvider
     {
         $limit = $options['limit'] ?? 100;
 
-        $response = Http::post($this->baseUrl, [
-            'method' => 'Get',
-            'params' => [
-                'credentials' => [
-                    'database'  => $this->credentials['database'],
-                    'sessionId' => $this->sessionId,
-                ],
-                'typeName'     => 'Device',
-                'resultsLimit' => $limit,
-            ],
-        ])->json();
+        $response = $this->apiCall('Get', [
+            'typeName'     => 'Device',
+            'resultsLimit' => $limit,
+        ]);
 
-        $devices = $response['result'] ?? [];
+        $devices      = $response['result'] ?? [];
+        $logsByDevice = $this->fetchLatestLogRecords($devices, $options);
+        $devices      = array_map(function ($device) use ($logsByDevice) {
+            $deviceId = $device['id'] ?? null;
+            if ($deviceId && isset($logsByDevice[$deviceId])) {
+                $device['latest_log_record'] = $logsByDevice[$deviceId];
+            }
+
+            return $device;
+        }, $devices);
 
         return [
             'devices'     => $devices,
@@ -98,43 +101,76 @@ class GeotabProvider extends AbstractProvider
 
     public function fetchDeviceDetails(string $externalId): array
     {
-        $response = Http::post($this->baseUrl, [
-            'method' => 'Get',
-            'params' => [
-                'credentials' => [
-                    'database'  => $this->credentials['database'],
-                    'sessionId' => $this->sessionId,
-                ],
-                'typeName' => 'Device',
-                'search'   => ['id' => $externalId],
-            ],
-        ])->json();
+        $response = $this->apiCall('Get', [
+            'typeName' => 'Device',
+            'search'   => ['id' => $externalId],
+        ]);
 
         return $response['result'][0] ?? [];
     }
 
     public function normalizeDevice(array $payload): array
     {
+        $latestLog    = $payload['latest_log_record'] ?? [];
+        $hasTelemetry = isset($latestLog['dateTime']) || isset($latestLog['latitude'], $latestLog['longitude']);
+
         return [
-            'external_id'     => $payload['id'],
-            'device_name'     => $payload['name'] ?? 'Unknown Device',
-            'device_provider' => 'geotab',
-            'device_model'    => $payload['deviceType'] ?? null,
-            'imei'            => $payload['serialNumber'] ?? null,
-            'vin'             => $payload['vehicleIdentificationNumber'] ?? null,
-            'status'          => 'active',
-            'meta'            => $payload,
+            'device_id'     => $payload['id'] ?? null,
+            'external_id'   => $payload['id'] ?? null,
+            'name'          => $payload['name'] ?? 'Unknown Device',
+            'provider'      => 'geotab',
+            'model'         => $payload['deviceType'] ?? null,
+            'imei'          => $payload['serialNumber'] ?? null,
+            'vin'           => $payload['vehicleIdentificationNumber'] ?? null,
+            'serial_number' => $payload['serialNumber'] ?? null,
+            'status'        => 'active',
+            'online'        => $hasTelemetry ? true : null,
+            'last_seen_at'  => $latestLog ? $this->parseTimestamp($latestLog['dateTime'] ?? null) : null,
+            'location'      => [
+                'lat' => $latestLog['latitude'] ?? null,
+                'lng' => $latestLog['longitude'] ?? null,
+            ],
+            'speed'    => $latestLog['speed'] ?? null,
+            'heading'  => $latestLog['bearing'] ?? $latestLog['heading'] ?? null,
+            'altitude' => $latestLog['altitude'] ?? null,
+            'meta'     => [
+                'raw'             => $payload,
+                'provider_status' => array_filter([
+                    'active_from' => $payload['activeFrom'] ?? null,
+                    'active_to'   => $payload['activeTo'] ?? null,
+                    'groups'      => $payload['groups'] ?? null,
+                    'has_log'     => $hasTelemetry,
+                ], fn ($value) => $value !== null),
+            ],
         ];
     }
 
     public function normalizeEvent(array $payload): array
     {
+        $latestLog    = $payload['latest_log_record'] ?? $payload;
+        $deviceId     = data_get($latestLog, 'device.id') ?? $payload['deviceId'] ?? $payload['id'] ?? null;
+        $hasTelemetry = isset($latestLog['dateTime']) || isset($latestLog['latitude'], $latestLog['longitude']);
+
         return [
-            'external_id' => $payload['id'] ?? null,
-            'device_id'   => $payload['device']['id'] ?? $payload['deviceId'] ?? null,
+            'external_id' => $latestLog['id'] ?? $payload['id'] ?? null,
+            'device_id'   => $deviceId,
             'event_type'  => $payload['type'] ?? 'status_data',
-            'occurred_at' => $payload['dateTime'] ?? now(),
-            'meta'        => $payload,
+            'occurred_at' => $this->parseTimestamp($latestLog['dateTime'] ?? null) ?? now(),
+            'online'      => $hasTelemetry ? true : null,
+            'location'    => [
+                'lat' => $latestLog['latitude'] ?? null,
+                'lng' => $latestLog['longitude'] ?? null,
+            ],
+            'speed'    => $latestLog['speed'] ?? null,
+            'heading'  => $latestLog['bearing'] ?? $latestLog['heading'] ?? null,
+            'altitude' => $latestLog['altitude'] ?? null,
+            'meta'     => [
+                'raw'             => $payload,
+                'provider_status' => array_filter([
+                    'has_log' => $hasTelemetry,
+                    'device'  => data_get($latestLog, 'device.id'),
+                ], fn ($value) => $value !== null),
+            ],
         ];
     }
 
@@ -178,5 +214,57 @@ class GeotabProvider extends AbstractProvider
     public function supportsWebhooks(): bool
     {
         return false;
+    }
+
+    protected function apiCall(string $method, array $params): array
+    {
+        $params['credentials'] = [
+            'database'  => $this->credentials['database'],
+            'sessionId' => $this->sessionId,
+        ];
+
+        return Http::post($this->baseUrl, [
+            'method' => $method,
+            'params' => $params,
+        ])->json() ?? [];
+    }
+
+    protected function fetchLatestLogRecords(array $devices, array $options = []): array
+    {
+        $deviceIds = array_values(array_filter(array_map(fn ($device) => $device['id'] ?? null, $devices)));
+        if (empty($deviceIds)) {
+            return [];
+        }
+
+        $fromDate = $options['from_date'] ?? Carbon::now()->subHours(24)->toIso8601String();
+        $response = $this->apiCall('Get', [
+            'typeName'     => 'LogRecord',
+            'search'       => ['fromDate' => $fromDate],
+            'resultsLimit' => max(count($deviceIds) * 5, 100),
+        ]);
+
+        $logsByDevice = [];
+        foreach ($response['result'] ?? [] as $record) {
+            $deviceId = data_get($record, 'device.id');
+            if (!$deviceId || !in_array($deviceId, $deviceIds, true)) {
+                continue;
+            }
+
+            $current = $logsByDevice[$deviceId] ?? null;
+            if (!$current || Carbon::parse($record['dateTime'] ?? now())->greaterThan(Carbon::parse($current['dateTime'] ?? now()))) {
+                $logsByDevice[$deviceId] = $record;
+            }
+        }
+
+        return $logsByDevice;
+    }
+
+    protected function parseTimestamp($value): ?string
+    {
+        if (!$value) {
+            return null;
+        }
+
+        return Carbon::parse($value)->toDateTimeString();
     }
 }

--- a/server/src/Support/Telematics/Providers/SafeeProvider.php
+++ b/server/src/Support/Telematics/Providers/SafeeProvider.php
@@ -110,8 +110,19 @@ class SafeeProvider extends AbstractProvider
                 'lat' => $position['lat'] ?? null,
                 'lng' => $position['lng'] ?? null,
             ],
-            'meta' => [
-                'raw'          => $payload,
+            'speed'      => $payload['speed'] ?? $payload['lastSpeed'] ?? null,
+            'heading'    => $payload['heading'] ?? $payload['angle'] ?? null,
+            'altitude'   => $payload['altitude'] ?? $payload['alt'] ?? null,
+            'odometer'   => $this->extractOdometer($payload),
+            'ignition'   => $this->extractIgnition($payload),
+            'fuel_level' => $this->extractFuelLevel($payload),
+            'meta'       => [
+                'raw'             => $payload,
+                'provider_status' => array_filter([
+                    'status'        => $rawStatus,
+                    'normalized'    => $status,
+                    'vehicleStatus' => $payload['vehicleStatus'] ?? null,
+                ], fn ($value) => $value !== null),
                 'plate_number' => $payload['plateNumber'] ?? $payload['plate_number'] ?? null,
                 'door_number'  => $payload['doorNumber'] ?? null,
                 'driver'       => $payload['driver'] ?? null,
@@ -136,12 +147,14 @@ class SafeeProvider extends AbstractProvider
             'event_type'  => data_get($payload, 'event.code') ?? data_get($payload, 'event.name') ?? 'telemetry_update',
             'message'     => data_get($payload, 'event.name') ?? data_get($payload, 'event.message') ?? null,
             'occurred_at' => $this->parseTimestamp($payload['date'] ?? $payload['deviceTime'] ?? $payload['time'] ?? null),
+            'online'      => $this->resolveOnline($payload),
             'location'    => [
                 'lat' => $position['lat'] ?? null,
                 'lng' => $position['lng'] ?? null,
             ],
             'speed'      => $payload['speed'] ?? $payload['lastSpeed'] ?? null,
             'heading'    => $payload['heading'] ?? $payload['angle'] ?? null,
+            'altitude'   => $payload['altitude'] ?? $payload['alt'] ?? null,
             'odometer'   => $this->extractOdometer($payload),
             'ignition'   => $this->extractIgnition($payload),
             'fuel_level' => $this->extractFuelLevel($payload),
@@ -345,6 +358,17 @@ class SafeeProvider extends AbstractProvider
         }
 
         return in_array(strtolower($status), ['offline', 'inactive', 'deleted', 'expired'], true) ? 'inactive' : 'active';
+    }
+
+    protected function resolveOnline(array $payload): ?bool
+    {
+        if (array_key_exists('online', $payload)) {
+            return filter_var($payload['online'], FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE) ?? (bool) $payload['online'];
+        }
+
+        $status = $payload['status'] ?? $payload['vehicleStatus'] ?? null;
+
+        return $status ? $this->normalizeVehicleStatus($status) === 'active' : null;
     }
 
     protected function extractOdometer(array $payload): mixed

--- a/server/src/Support/Telematics/Providers/SamsaraProvider.php
+++ b/server/src/Support/Telematics/Providers/SamsaraProvider.php
@@ -2,6 +2,8 @@
 
 namespace Fleetbase\FleetOps\Support\Telematics\Providers;
 
+use Illuminate\Support\Carbon;
+
 /**
  * Class SamsaraProvider.
  *
@@ -78,30 +80,68 @@ class SamsaraProvider extends AbstractProvider
 
     public function normalizeDevice(array $payload): array
     {
+        $position = $this->extractPosition($payload);
+
         return [
-            'external_id'     => $payload['id'],
-            'device_name'     => $payload['name'] ?? 'Unknown Device',
-            'device_provider' => 'samsara',
-            'device_model'    => $payload['make'] ?? null,
-            'vin'             => $payload['vin'] ?? null,
-            'license_plate'   => $payload['licensePlate'] ?? null,
-            'status'          => 'active',
-            'meta'            => $payload,
+            'device_id'      => $payload['id'] ?? null,
+            'external_id'    => $payload['id'] ?? null,
+            'name'           => $payload['name'] ?? 'Unknown Device',
+            'provider'       => 'samsara',
+            'model'          => $payload['make'] ?? $payload['model'] ?? null,
+            'vin'            => $payload['vin'] ?? null,
+            'serial_number'  => $payload['serial'] ?? $payload['serialNumber'] ?? null,
+            'license_plate'  => $payload['licensePlate'] ?? null,
+            'status'         => $this->normalizeStatus($payload),
+            'online'         => $this->resolveOnline($payload),
+            'last_seen_at'   => $this->parseTimestamp($payload['time'] ?? data_get($payload, 'location.time') ?? data_get($payload, 'gps.time') ?? null),
+            'location'       => [
+                'lat' => $position['lat'] ?? null,
+                'lng' => $position['lng'] ?? null,
+            ],
+            'speed'      => $this->extractSpeed($payload),
+            'heading'    => $this->extractHeading($payload),
+            'altitude'   => $this->extractAltitude($payload),
+            'odometer'   => data_get($payload, 'odometerMeters') ?? data_get($payload, 'obdOdometerMeters.value'),
+            'fuel_level' => data_get($payload, 'fuelPercent.value') ?? data_get($payload, 'fuelPercent'),
+            'meta'       => [
+                'raw'             => $payload,
+                'provider_status' => array_filter([
+                    'status'         => $payload['status'] ?? null,
+                    'gateway_status' => data_get($payload, 'gateway.status'),
+                    'online'         => $payload['online'] ?? $payload['isOnline'] ?? data_get($payload, 'gateway.online'),
+                ], fn ($value) => $value !== null),
+            ],
         ];
     }
 
     public function normalizeEvent(array $payload): array
     {
+        $position = $this->extractPosition($payload);
+        $deviceId = data_get($payload, 'vehicle.id') ?? $payload['vehicleId'] ?? $payload['id'] ?? null;
+
         return [
-            'external_id' => $payload['id'] ?? null,
-            'device_id'   => $payload['vehicle']['id'] ?? $payload['vehicleId'] ?? null,
+            'external_id' => $payload['id'] ?? $deviceId,
+            'device_id'   => $deviceId,
             'event_type'  => $payload['eventType'] ?? 'vehicle_update',
-            'occurred_at' => $payload['time'] ?? now(),
+            'occurred_at' => $this->parseTimestamp($payload['time'] ?? data_get($payload, 'location.time') ?? data_get($payload, 'gps.time') ?? null) ?? now(),
+            'online'      => $this->resolveOnline($payload),
             'location'    => [
-                'lat' => $payload['location']['latitude'] ?? null,
-                'lng' => $payload['location']['longitude'] ?? null,
+                'lat' => $position['lat'] ?? null,
+                'lng' => $position['lng'] ?? null,
             ],
-            'meta' => $payload,
+            'speed'      => $this->extractSpeed($payload),
+            'heading'    => $this->extractHeading($payload),
+            'altitude'   => $this->extractAltitude($payload),
+            'odometer'   => data_get($payload, 'odometerMeters') ?? data_get($payload, 'obdOdometerMeters.value'),
+            'fuel_level' => data_get($payload, 'fuelPercent.value') ?? data_get($payload, 'fuelPercent'),
+            'meta'       => [
+                'raw'             => $payload,
+                'provider_status' => array_filter([
+                    'status'         => $payload['status'] ?? null,
+                    'gateway_status' => data_get($payload, 'gateway.status'),
+                    'online'         => $payload['online'] ?? $payload['isOnline'] ?? data_get($payload, 'gateway.online'),
+                ], fn ($value) => $value !== null),
+            ],
         ];
     }
 
@@ -175,5 +215,73 @@ class SamsaraProvider extends AbstractProvider
     public function supportsWebhooks(): bool
     {
         return true;
+    }
+
+    protected function extractPosition(array $payload): array
+    {
+        $position = $payload['location']
+            ?? $payload['gps']
+            ?? $payload['currentLocation']
+            ?? $payload['lastKnownLocation']
+            ?? data_get($payload, 'vehicle.location')
+            ?? [];
+
+        return [
+            'lat' => $position['latitude'] ?? $position['lat'] ?? null,
+            'lng' => $position['longitude'] ?? $position['lng'] ?? null,
+        ];
+    }
+
+    protected function extractSpeed(array $payload): mixed
+    {
+        return data_get($payload, 'location.speedMilesPerHour')
+            ?? data_get($payload, 'location.speed')
+            ?? data_get($payload, 'gps.speedMilesPerHour')
+            ?? data_get($payload, 'speedMilesPerHour')
+            ?? data_get($payload, 'speed');
+    }
+
+    protected function extractHeading(array $payload): mixed
+    {
+        return data_get($payload, 'location.headingDegrees')
+            ?? data_get($payload, 'location.heading')
+            ?? data_get($payload, 'gps.headingDegrees')
+            ?? data_get($payload, 'headingDegrees')
+            ?? data_get($payload, 'heading');
+    }
+
+    protected function extractAltitude(array $payload): mixed
+    {
+        return data_get($payload, 'location.altitudeMeters')
+            ?? data_get($payload, 'gps.altitudeMeters')
+            ?? data_get($payload, 'altitudeMeters')
+            ?? data_get($payload, 'altitude');
+    }
+
+    protected function parseTimestamp($value): ?string
+    {
+        if (!$value) {
+            return null;
+        }
+
+        return Carbon::parse($value)->toDateTimeString();
+    }
+
+    protected function resolveOnline(array $payload): ?bool
+    {
+        $value = $payload['online'] ?? $payload['isOnline'] ?? data_get($payload, 'gateway.online') ?? null;
+
+        if ($value === null) {
+            return $this->extractPosition($payload)['lat'] !== null;
+        }
+
+        return filter_var($value, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE) ?? (bool) $value;
+    }
+
+    protected function normalizeStatus(array $payload): string
+    {
+        $status = strtolower((string) ($payload['status'] ?? data_get($payload, 'gateway.status') ?? 'active'));
+
+        return in_array($status, ['inactive', 'offline', 'deactivated'], true) ? 'inactive' : 'active';
     }
 }

--- a/server/tests/TelematicsHardeningTest.php
+++ b/server/tests/TelematicsHardeningTest.php
@@ -2,7 +2,10 @@
 
 use Fleetbase\FleetOps\Contracts\TelematicProviderDescriptor;
 use Fleetbase\FleetOps\Support\Telematics\Providers\AfaqyProvider;
+use Fleetbase\FleetOps\Support\Telematics\Providers\FlespiProvider;
+use Fleetbase\FleetOps\Support\Telematics\Providers\GeotabProvider;
 use Fleetbase\FleetOps\Support\Telematics\Providers\SafeeProvider;
+use Fleetbase\FleetOps\Support\Telematics\Providers\SamsaraProvider;
 use Illuminate\Http\Client\ConnectionException;
 use Illuminate\Support\Facades\Http;
 
@@ -79,18 +82,238 @@ test('device details render consistent telematics connection state and timestamp
 });
 
 test('native providers normalize device payloads to canonical FleetOps keys', function () {
-    $afaqy = file_get_contents(__DIR__ . '/../src/Support/Telematics/Providers/AfaqyProvider.php');
-    $safee = file_get_contents(__DIR__ . '/../src/Support/Telematics/Providers/SafeeProvider.php');
+    $providers = [
+        file_get_contents(__DIR__ . '/../src/Support/Telematics/Providers/AfaqyProvider.php'),
+        file_get_contents(__DIR__ . '/../src/Support/Telematics/Providers/FlespiProvider.php'),
+        file_get_contents(__DIR__ . '/../src/Support/Telematics/Providers/GeotabProvider.php'),
+        file_get_contents(__DIR__ . '/../src/Support/Telematics/Providers/SafeeProvider.php'),
+        file_get_contents(__DIR__ . '/../src/Support/Telematics/Providers/SamsaraProvider.php'),
+    ];
 
-    foreach ([$afaqy, $safee] as $provider) {
+    foreach ($providers as $provider) {
         expect($provider)
             ->toContain("'device_id'")
+            ->toContain("'external_id'")
             ->toContain("'name'")
             ->toContain("'provider'")
             ->toContain("'model'")
             ->toContain("'online'")
-            ->toContain("'last_seen_at'");
+            ->toContain("'last_seen_at'")
+            ->toContain("'location'")
+            ->toContain("'speed'")
+            ->toContain("'heading'")
+            ->toContain("'altitude'");
     }
+});
+
+test('flespi telemetry normalizes positional event fields', function () {
+    $event = (new FlespiProvider())->normalizeEvent([
+        'id'                     => 'message-1',
+        'device.id'              => 'device-1',
+        'timestamp'              => 1781769600,
+        'position.latitude'      => 25.2048,
+        'position.longitude'     => 55.2708,
+        'position.speed'         => 42,
+        'position.direction'     => 91,
+        'position.altitude'      => 12,
+        'vehicle.mileage'        => 12345,
+        'engine.ignition.status' => true,
+        'fuel.level'             => 67,
+    ]);
+
+    expect($event)->toMatchArray([
+        'external_id' => 'message-1',
+        'device_id'   => 'device-1',
+        'event_type'  => 'telemetry_update',
+        'online'      => true,
+        'location'    => ['lat' => 25.2048, 'lng' => 55.2708],
+        'speed'       => 42,
+        'heading'     => 91,
+        'altitude'    => 12,
+        'odometer'    => 12345,
+        'ignition'    => true,
+        'fuel_level'  => 67,
+    ]);
+    expect($event['meta'])->toHaveKeys(['raw', 'provider_status']);
+});
+
+test('samsara telemetry variants normalize positional event fields', function () {
+    $event = (new SamsaraProvider())->normalizeEvent([
+        'id'                 => 'event-1',
+        'vehicle'            => ['id' => 'vehicle-1'],
+        'time'               => '2026-06-18T08:00:00Z',
+        'location'           => [
+            'latitude'          => 25.2048,
+            'longitude'         => 55.2708,
+            'speedMilesPerHour' => 30,
+            'headingDegrees'    => 180,
+            'altitudeMeters'    => 16,
+        ],
+        'odometerMeters'     => 1000,
+        'fuelPercent'        => 50,
+        'gateway'            => ['status' => 'connected', 'online' => true],
+    ]);
+
+    expect($event)->toMatchArray([
+        'external_id' => 'event-1',
+        'device_id'   => 'vehicle-1',
+        'event_type'  => 'vehicle_update',
+        'online'      => true,
+        'location'    => ['lat' => 25.2048, 'lng' => 55.2708],
+        'speed'       => 30,
+        'heading'     => 180,
+        'altitude'    => 16,
+        'odometer'    => 1000,
+        'fuel_level'  => 50,
+    ]);
+    expect($event['meta']['provider_status'])->toMatchArray([
+        'gateway_status' => 'connected',
+        'online'         => true,
+    ]);
+});
+
+test('safee telemetry includes online and altitude event fields', function () {
+    $event = (new SafeeProvider())->normalizeEvent([
+        'id'            => 'event-1',
+        'deviceId'      => 'device-1',
+        'status'        => 'online',
+        'date'          => '2026-06-18T08:00:00Z',
+        'lat'           => 25.2048,
+        'lon'           => 55.2708,
+        'speed'         => 30,
+        'heading'       => 100,
+        'altitude'      => 15,
+    ]);
+
+    expect($event)->toMatchArray([
+        'external_id' => 'event-1',
+        'device_id'   => 'device-1',
+        'online'      => true,
+        'location'    => ['lat' => 25.2048, 'lng' => 55.2708],
+        'speed'       => 30,
+        'heading'     => 100,
+        'altitude'    => 15,
+    ]);
+});
+
+test('geotab latest log record drives device and event telemetry', function () {
+    $payload = [
+        'id'                          => 'device-1',
+        'name'                        => 'Truck 1',
+        'deviceType'                  => 'GO9',
+        'serialNumber'                => 'serial-1',
+        'vehicleIdentificationNumber' => 'VIN123',
+        'latest_log_record'           => [
+            'id'        => 'log-1',
+            'dateTime'  => '2026-06-18T08:00:00Z',
+            'latitude'  => 25.2048,
+            'longitude' => 55.2708,
+            'speed'     => 55,
+            'bearing'   => 90,
+            'altitude'  => 20,
+            'device'    => ['id' => 'device-1'],
+        ],
+    ];
+
+    $provider = new GeotabProvider();
+    $device   = $provider->normalizeDevice($payload);
+    $event    = $provider->normalizeEvent($payload);
+
+    expect($device)->toMatchArray([
+        'device_id'     => 'device-1',
+        'external_id'   => 'device-1',
+        'name'          => 'Truck 1',
+        'provider'      => 'geotab',
+        'model'         => 'GO9',
+        'imei'          => 'serial-1',
+        'vin'           => 'VIN123',
+        'serial_number' => 'serial-1',
+        'online'        => true,
+        'location'      => ['lat' => 25.2048, 'lng' => 55.2708],
+        'speed'         => 55,
+        'heading'       => 90,
+        'altitude'      => 20,
+    ]);
+
+    expect($event)->toMatchArray([
+        'external_id' => 'log-1',
+        'device_id'   => 'device-1',
+        'event_type'  => 'status_data',
+        'online'      => true,
+        'location'    => ['lat' => 25.2048, 'lng' => 55.2708],
+        'speed'       => 55,
+        'heading'     => 90,
+        'altitude'    => 20,
+    ]);
+});
+
+test('geotab polling fetches recent log records and merges latest record into device snapshots', function () {
+    $requests = [];
+
+    Http::fake(function ($request) use (&$requests) {
+        $requests[] = $request;
+        $body       = json_decode($request->body(), true);
+        $typeName   = data_get($body, 'params.typeName');
+
+        if ($typeName === 'Device') {
+            return Http::response([
+                'result' => [
+                    ['id' => 'device-1', 'name' => 'Truck 1'],
+                    ['id' => 'device-2', 'name' => 'Truck 2'],
+                ],
+            ], 200);
+        }
+
+        if ($typeName === 'LogRecord') {
+            return Http::response([
+                'result' => [
+                    ['id' => 'old-log', 'device' => ['id' => 'device-1'], 'dateTime' => '2026-06-18T07:00:00Z', 'latitude' => 1, 'longitude' => 2],
+                    ['id' => 'new-log', 'device' => ['id' => 'device-1'], 'dateTime' => '2026-06-18T08:00:00Z', 'latitude' => 3, 'longitude' => 4],
+                    ['id' => 'other-log', 'device' => ['id' => 'other-device'], 'dateTime' => '2026-06-18T08:00:00Z', 'latitude' => 5, 'longitude' => 6],
+                ],
+            ], 200);
+        }
+
+        return Http::response(['result' => []], 200);
+    });
+
+    $provider = new class extends GeotabProvider {
+        public function fetchDevicesForTest(): array
+        {
+            $this->credentials = [
+                'database' => 'testing-db',
+            ];
+            $this->sessionId = 'testing-session';
+
+            return $this->fetchDevices(['limit' => 2, 'from_date' => '2026-06-18T00:00:00Z']);
+        }
+    };
+
+    $result = $provider->fetchDevicesForTest();
+
+    expect($result['devices'])->toHaveCount(2);
+    expect($result['devices'][0]['latest_log_record'])->toMatchArray([
+        'id'        => 'new-log',
+        'latitude'  => 3,
+        'longitude' => 4,
+    ]);
+    expect($result['devices'][1])->not->toHaveKey('latest_log_record');
+    expect($requests)->toHaveCount(2);
+    expect($requests[0]->data())->toMatchArray([
+        'method' => 'Get',
+        'params' => [
+            'typeName'     => 'Device',
+            'resultsLimit' => 2,
+        ],
+    ]);
+    expect($requests[1]->data())->toMatchArray([
+        'method' => 'Get',
+        'params' => [
+            'typeName'     => 'LogRecord',
+            'search'       => ['fromDate' => '2026-06-18T00:00:00Z'],
+            'resultsLimit' => 100,
+        ],
+    ]);
 });
 
 test('telematics details use public id for consumer webhook URLs and do not read ember uuid', function () {
@@ -444,17 +667,20 @@ test('telematics device sync records provider pagination and skipped device coun
         ->toContain("method_exists(\$e, 'context') ? \$e->context() : []");
 });
 
-test('telematics polling command is registered and scheduled for no webhook providers', function () {
+test('telematics polling command is registered and scheduled for discovery providers by default', function () {
     $command  = file_get_contents(__DIR__ . '/../src/Console/Commands/SyncTelematics.php');
     $provider = file_get_contents(__DIR__ . '/../src/Providers/FleetOpsServiceProvider.php');
     $details  = file_get_contents(__DIR__ . '/../../addon/components/telematic/details.hbs');
 
     expect($command)
         ->toContain("protected \$signature = 'fleetops:sync-telematics")
+        ->toContain('{--exclude-webhook-providers : Skip providers that support webhooks}')
         ->toContain('SyncTelematicDevicesJob::dispatch($telematic')
-        ->toContain('!$descriptor->supportsWebhooks')
+        ->toContain('$excludeWebhookProviders = (bool) $this->option(\'exclude-webhook-providers\')')
+        ->toContain('!$excludeWebhookProviders || !$descriptor->supportsWebhooks')
         ->toContain('$descriptor->supportsDiscovery')
-        ->toContain("whereIn('status', ['active', 'connected'])");
+        ->toContain("whereIn('status', ['active', 'connected'])")
+        ->not->toContain('sync-webhook-providers');
 
     expect($provider)
         ->toContain('Console\\Commands\\SyncTelematics::class')


### PR DESCRIPTION
## Summary

- Normalize Flespi, Geotab, Samsara, Safee, and AFAQY telemetry into the shared FleetOps ingestion contract.
- Merge recent Geotab LogRecord data into device snapshots so polling can drive device and vehicle movement.
- Poll all discovery-capable providers by default, with an opt-out flag for webhook-capable providers.
- Add hardening coverage for provider normalization, Geotab latest-log polling, and polling command behavior.

## Why

FleetOps already centralizes downstream telematics ingestion for devices, events, positions, and attached vehicle movement. Native providers needed parity in their normalized payloads so polling and webhook ingestion produce the same visible Live Fleet behavior: online state, location, speed, heading, altitude, and current telemetry metadata.

## Validation

- php -l on touched provider, command, and test files.
- php-cs-fixer on touched PHP files with .php-cs-fixer.php.
- git diff --check.
- Direct provider normalization smoke check.

## Notes

The focused Pest run is currently blocked by the local dependency layout: server_vendor/pestphp/pest/vendor/autoload.php is missing, so Pest exits before executing tests.