### PR TITLE
fix(place): update PhoneInput onInput handler to mutate place phone

### DIFF
--- a/addon/components/place/form.hbs
+++ b/addon/components/place/form.hbs
@@ -37,7 +37,7 @@
                 <ModelCoordinatesInput @model={{@resource}} @disabled={{cannot-write @resource}} @autocomplete="all" @onInputReady={{fn (mut this.coordinatesInput)}} />
             </InputGroup>
             <InputGroup @name={{t "place.fields.phone"}} @wrapperClass="col-span-2">
-                <PhoneInput @value={{@resource.phone}} @autocomplete="nope" @onInput={{this.phone}} disabled={{cannot-write @resource}} class="form-input w-full" />
+                <PhoneInput @value={{@resource.phone}} @autocomplete="nope" @onInput={{fn (mut @resource.phone)}} disabled={{cannot-write @resource}} class="form-input w-full" />
             </InputGroup>
         </div>
     </ContentPanel>


### PR DESCRIPTION
## PR Description:

### Summary

Fixes an issue where saving or updating a **Place** entity stored phone numbers without the international country dial code (E.164  format).

### Cause of the Issue

    In `addon/components/place/form.hbs`, the `<PhoneInput />` component was configured with `@onInput={{this.phone}}`. However,
  `this.phone` is not defined in `PlaceFormComponent`, resolving `@onInput` to `undefined`.

    Because `@onInput` was `undefined`, `PhoneInput`'s `intl-tel-input` event handler was never triggered to format the number with
  the country dial code prefix, causing only raw input text to be saved instead of the formatted E.164 phone string.

### Solution

    Replaced `@onInput={{this.phone}}` with `@onInput={{fn (mut @resource.phone)}}`. This aligns `Place` form behavior with all other
  forms across the codebase (such as `contact/form.hbs`, `driver/form.hbs`, `customer/form.hbs`, and `vendor/form.hbs`), ensuring
  phone numbers are correctly mutated and stored in standard E.164 format (e.g. `+1...`, `+7...`).

### Changes
    - **`addon/components/place/form.hbs`**: Updated `<PhoneInput />` `@onInput` action to `{{fn (mut @resource.phone)}}`.