### PR TITLE
fix(labels): correct entity label to use entity data instead of stale waypoint/order fallbacks

### DIFF
--- a/server/resources/views/labels/entity-label.php
+++ b/server/resources/views/labels/entity-label.php
@@ -8,7 +8,7 @@ use Fleetbase\Support\Utils;
 <head>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title><?= $company->name ?? ($waypoint->internal_id ?? $waypoint->public_id) ?> Waypoint Label</title>
+    <title><?= $company->name ?? ($entity->internal_id ?? $entity->public_id) ?> Item Label</title>
 </head>
 
 <style>
@@ -45,7 +45,7 @@ use Fleetbase\Support\Utils;
     <div style="width: 420px; border: 2px #414141 solid; margin: auto;">
         <div class="group" style="border-bottom: 1px #414141 solid; overflow: hidden;">
             <div style="float: left; width: 130px; height: 120px; border-right: 1px #414141 solid; text-align: center; padding: 10px; box-sizing: border-box;">
-                <img src="data:image/png;base64,<?= Utils::notEmpty($trackingNumber) ? $trackingNumber->qr_code : $order->trackingNumber->qr_code ?>" style="width: 100%; height: 100%; object-fit: cover;">
+                <img src="data:image/png;base64,<?= Utils::notEmpty($trackingNumber) ? $trackingNumber->qr_code : $entity->qr_code ?>" style="width: 100%; height: 100%; object-fit: cover;">
             </div>
             <div style="margin-top: 10px;">
                 <span style="padding-left: 10px; font-size: 18px; font-weight: bold;"><?= strtoupper($company->name) ?></span>
@@ -114,8 +114,8 @@ use Fleetbase\Support\Utils;
         <?php } ?>
         <div class="group">
             <div style="text-align: center; padding: 15px 0px; border-top: 1px #414141 solid;">
-                <img src="data:image/png;base64,<?= isset($trackingNumber) ? $trackingNumber->barcode : $order->trackingNumber->barcode ?>" style="height: 90px; margin-top: 10px;">
-                <div><?= strtoupper(isset($trackingNumber) ? $trackingNumber->tracking_number : $order->trackingNumber->tracking_number) ?></div>
+                <img src="data:image/png;base64,<?= isset($trackingNumber) ? $trackingNumber->barcode : $entity->barcode ?>" style="height: 90px; margin-top: 10px;">
+                <div><?= strtoupper(isset($trackingNumber) ? $trackingNumber->tracking_number : $entity->public_id) ?></div>
             </div>
         </div>
     </div>


### PR DESCRIPTION
## What
Fixes the entity label template ('entity-label.php'), which was copy-pasted from 'waypoint-label.php' and still referenced '$waypoint'/'$order', variables that are never passed to 'Entity::label()'.

## Why
Related to #182 - while investigating single-entity label generation, found that the existing 'type=entity' label endpoint renders a broken title ("Waypoint Label" instead of the correct label) and contains dead/unreachable fallback code ('$order->trackingNumber') that would throw if '$trackingNumber' were never empty.

## Changes
- Title now correctly reflects the entity instead of a waypoint
- QR code and barcode fallbacks use '$entity->qr_code' / '$entity->barcode' instead of the undefined '$order'
- Tracking number fallback uses '$entity->public_id'

## Testing
- Verified locally by rendering 'Entity::label()' via Tinker - title now shows correctly
- Existing test 'LabelIdPdfRenderingTest' still passes

Related to #182 