### PR TITLE
Remove unreachable backend code and fix two defects it was hiding

### DIFF
--- a/server/src/Casts/MultiPolygon.php
+++ b/server/src/Casts/MultiPolygon.php
@@ -5,7 +5,6 @@ namespace Fleetbase\FleetOps\Casts;
 use Fleetbase\FleetOps\Support\Utils;
 use Fleetbase\LaravelMysqlSpatial\Eloquent\SpatialExpression;
 use Fleetbase\LaravelMysqlSpatial\Types\GeometryInterface;
-use Fleetbase\LaravelMysqlSpatial\Types\MultiPolygon as SpatialMultiPolygon;
 use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
 
 class MultiPolygon implements CastsAttributes
@@ -35,12 +34,6 @@ class MultiPolygon implements CastsAttributes
             $model->geometries[$key] = $value;
 
             return new SpatialExpression($value);
-        }
-
-        if ($value instanceof SpatialMultiPolygon) {
-            $model->geometries[$key] = $value;
-
-            return $value;
         }
 
         if (Utils::isGeoJson($value)) {

--- a/server/src/Casts/MultiPolygon.php
+++ b/server/src/Casts/MultiPolygon.php
@@ -5,6 +5,7 @@ namespace Fleetbase\FleetOps\Casts;
 use Fleetbase\FleetOps\Support\Utils;
 use Fleetbase\LaravelMysqlSpatial\Eloquent\SpatialExpression;
 use Fleetbase\LaravelMysqlSpatial\Types\GeometryInterface;
+use Fleetbase\LaravelMysqlSpatial\Types\MultiPolygon as SpatialMultiPolygon;
 use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
 
 class MultiPolygon implements CastsAttributes
@@ -30,6 +31,17 @@ class MultiPolygon implements CastsAttributes
      */
     public function set($model, $key, $value, $attributes)
     {
+        // Checked before the broader GeometryInterface guard below, which a
+        // SpatialMultiPolygon also satisfies — otherwise this arm never fires.
+        // It must wrap in a SpatialExpression exactly as that guard does:
+        // returning the bare geometry here would change what is bound on writes
+        // that skip SpatialTrait::performInsert().
+        if ($value instanceof SpatialMultiPolygon) {
+            $model->geometries[$key] = $value;
+
+            return new SpatialExpression($value);
+        }
+
         if ($value instanceof GeometryInterface) {
             $model->geometries[$key] = $value;
 

--- a/server/src/Casts/Point.php
+++ b/server/src/Casts/Point.php
@@ -63,11 +63,22 @@ class Point implements CastsAttributes
             return $point;
         }
 
+        // Unreachable today: SpatialExpression extends Expression, so the guard
+        // above returns first. Deliberately kept rather than deleted, because
+        // that earlier guard returns WITHOUT recording $model->geometries[$key],
+        // and this block documents that a spatial expression is meant to be
+        // recorded. Note the recording would currently be a no-op anyway —
+        // SpatialTrait::performInsert restores the attribute from geometries[],
+        // which would assign the same expression back. Restoring it to a usable
+        // Point would mean recording the geometry behind the expression, which
+        // is a behaviour change and out of scope here.
+        // @codeCoverageIgnoreStart
         if ($value instanceof SpatialExpression) {
             $model->geometries[$key] = $value;
 
             return $value;
         }
+        // @codeCoverageIgnoreEnd
 
         return static::createEmptySpatialExpression();
     }

--- a/server/src/Casts/Point.php
+++ b/server/src/Casts/Point.php
@@ -39,6 +39,16 @@ class Point implements CastsAttributes
      */
     public function set($model, $key, $value, $attributes)
     {
+        // Checked before the generic Expression guard below, which SpatialExpression
+        // also satisfies — otherwise this arm never fires and the geometry is never
+        // recorded on the model. Both arms return the value untouched, so ordering
+        // only affects the bookkeeping.
+        if ($value instanceof SpatialExpression) {
+            $model->geometries[$key] = $value;
+
+            return $value;
+        }
+
         if ($value instanceof Expression) {
             return $value;
         }
@@ -62,23 +72,6 @@ class Point implements CastsAttributes
 
             return $point;
         }
-
-        // Unreachable today: SpatialExpression extends Expression, so the guard
-        // above returns first. Deliberately kept rather than deleted, because
-        // that earlier guard returns WITHOUT recording $model->geometries[$key],
-        // and this block documents that a spatial expression is meant to be
-        // recorded. Note the recording would currently be a no-op anyway —
-        // SpatialTrait::performInsert restores the attribute from geometries[],
-        // which would assign the same expression back. Restoring it to a usable
-        // Point would mean recording the geometry behind the expression, which
-        // is a behaviour change and out of scope here.
-        // @codeCoverageIgnoreStart
-        if ($value instanceof SpatialExpression) {
-            $model->geometries[$key] = $value;
-
-            return $value;
-        }
-        // @codeCoverageIgnoreEnd
 
         return static::createEmptySpatialExpression();
     }

--- a/server/src/Casts/Polygon.php
+++ b/server/src/Casts/Polygon.php
@@ -5,7 +5,6 @@ namespace Fleetbase\FleetOps\Casts;
 use Fleetbase\FleetOps\Support\Utils;
 use Fleetbase\LaravelMysqlSpatial\Eloquent\SpatialExpression;
 use Fleetbase\LaravelMysqlSpatial\Types\GeometryInterface;
-use Fleetbase\LaravelMysqlSpatial\Types\Polygon as SpatialPolygon;
 use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
 
 class Polygon implements CastsAttributes
@@ -34,13 +33,7 @@ class Polygon implements CastsAttributes
         if ($value instanceof GeometryInterface) {
             $model->geometries[$key] = $value;
 
-            return $value;
-        }
-
-        if ($value instanceof SpatialPolygon) {
-            $model->geometries[$key] = $value;
-
-            return $value;
+            return new SpatialExpression($value);
         }
 
         if (Utils::isGeoJson($value)) {

--- a/server/src/Casts/Polygon.php
+++ b/server/src/Casts/Polygon.php
@@ -5,6 +5,7 @@ namespace Fleetbase\FleetOps\Casts;
 use Fleetbase\FleetOps\Support\Utils;
 use Fleetbase\LaravelMysqlSpatial\Eloquent\SpatialExpression;
 use Fleetbase\LaravelMysqlSpatial\Types\GeometryInterface;
+use Fleetbase\LaravelMysqlSpatial\Types\Polygon as SpatialPolygon;
 use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
 
 class Polygon implements CastsAttributes
@@ -30,10 +31,19 @@ class Polygon implements CastsAttributes
      */
     public function set($model, $key, $value, $attributes)
     {
+        // Checked before the broader GeometryInterface guard below, which a
+        // SpatialPolygon also satisfies — otherwise this arm never fires. Both
+        // arms behave identically, so ordering does not change what is stored.
+        if ($value instanceof SpatialPolygon) {
+            $model->geometries[$key] = $value;
+
+            return $value;
+        }
+
         if ($value instanceof GeometryInterface) {
             $model->geometries[$key] = $value;
 
-            return new SpatialExpression($value);
+            return $value;
         }
 
         if (Utils::isGeoJson($value)) {

--- a/server/src/Http/Controllers/Api/v1/DriverController.php
+++ b/server/src/Http/Controllers/Api/v1/DriverController.php
@@ -72,14 +72,8 @@ class DriverController extends Controller
         // create user account for driver
         $user = $this->createUser($userDetails);
 
-        // Assign company
-        if ($company) {
-            $user->assignCompany($company);
-        } else {
-            $user->deleteQuietly();
-
-            return $this->apiError('Unable to assign driver to company.');
-        }
+        // Assign company — already guaranteed non-null by the guard above
+        $user->assignCompany($company);
 
         // Set user type
         $user->setUserType('driver');

--- a/server/src/Http/Controllers/Api/v1/DriverController.php
+++ b/server/src/Http/Controllers/Api/v1/DriverController.php
@@ -72,7 +72,7 @@ class DriverController extends Controller
         // create user account for driver
         $user = $this->createUser($userDetails);
 
-        // Assign company — already guaranteed non-null by the guard above
+        // Assign company — the early return above guarantees $company is set
         $user->assignCompany($company);
 
         // Set user type

--- a/server/src/Http/Controllers/Api/v1/OrderController.php
+++ b/server/src/Http/Controllers/Api/v1/OrderController.php
@@ -1077,13 +1077,10 @@ class OrderController extends Controller
 
         // if no order found
         //
-        // Currently unreachable: findOrder() above is typed `: Order` and throws
-        // rather than returning null. The catch it sits behind is itself dead
-        // because of an upstream defect — Fleetbase\Models\Model::findByIdOrFail()
-        // in core-api calls a getModelNotFoundException() method that does not
-        // exist on Eloquent's builder, so it raises BadMethodCallException
-        // instead of ModelNotFoundException and a missing order surfaces as a 500
-        // rather than this 404. Remove this annotation once core-api is patched.
+        // Unreachable: findOrder() above is typed `: Order`, so it either returns
+        // an order or throws — it never yields null. This is independent of the
+        // upstream findByIdOrFail defect and stays unreachable after that is
+        // fixed; the catch above is what becomes live then, not this guard.
         // @codeCoverageIgnoreStart
         if (!$order) {
             return response()->apiError('Order resource not found.', 404);

--- a/server/src/Http/Controllers/Api/v1/OrderController.php
+++ b/server/src/Http/Controllers/Api/v1/OrderController.php
@@ -69,7 +69,7 @@ class OrderController extends Controller
 
         // Set order config to input
         $input['order_config_uuid'] = $orderConfig->uuid;
-        $input['type']              = $orderConfig->key;
+        $input['type']              = $orderConfig->key ?? 'transport';
 
         // make sure company is set
         $input['company_uuid'] = $this->sessionCompany();
@@ -281,11 +281,6 @@ class OrderController extends Controller
                     $input['customer_type'] = $this->getModelClassName($customer);
                 }
             }
-        }
-
-        // if no type is set its default to transport
-        if (!isset($input['type'])) {
-            $input['type'] = 'transport';
         }
 
         // if no status is set its default to `created`
@@ -1081,9 +1076,19 @@ class OrderController extends Controller
         }
 
         // if no order found
+        //
+        // Currently unreachable: findOrder() above is typed `: Order` and throws
+        // rather than returning null. The catch it sits behind is itself dead
+        // because of an upstream defect — Fleetbase\Models\Model::findByIdOrFail()
+        // in core-api calls a getModelNotFoundException() method that does not
+        // exist on Eloquent's builder, so it raises BadMethodCallException
+        // instead of ModelNotFoundException and a missing order surfaces as a 500
+        // rather than this 404. Remove this annotation once core-api is patched.
+        // @codeCoverageIgnoreStart
         if (!$order) {
             return response()->apiError('Order resource not found.', 404);
         }
+        // @codeCoverageIgnoreEnd
 
         // if order is still status of `created` trigger started flag
         if ($order->status === 'created') {
@@ -1614,9 +1619,15 @@ class OrderController extends Controller
         // Normalize into one array
         $incoming = array_merge($rawInputs, $base64Inputs);
 
+        // Defensive only: the validate() above already requires `photos` to be a
+        // non-empty array whose every element is an upload or a decodable base64
+        // string, and each of those survives the filter, so this cannot be empty.
+        // Kept in case those rules are relaxed.
+        // @codeCoverageIgnoreStart
         if (empty($incoming)) {
             return $this->apiError('No photo data to capture.');
         }
+        // @codeCoverageIgnoreEnd
 
         // Load Order
         try {

--- a/server/src/Http/Controllers/Internal/v1/GeocoderController.php
+++ b/server/src/Http/Controllers/Internal/v1/GeocoderController.php
@@ -22,8 +22,11 @@ class GeocoderController extends Controller
         $query  = $request->or(['coordinates', 'query']);
         $single = $request->boolean('single');
 
-        /** @var \Fleetbase\LaravelMysqlSpatial\Types\Point $coordinates */
-        $coordinates = Utils::getPointFromCoordinates($query);
+        // Resolve strictly: getPointFromCoordinates() is typed `: Point` and
+        // falls back to Point(0, 0) for unusable input, which would silently
+        // reverse-geocode Null Island instead of reporting the bad request
+        /** @var \Fleetbase\LaravelMysqlSpatial\Types\Point|null $coordinates */
+        $coordinates = Utils::getPointFromCoordinatesStrict($query);
 
         // if not a valid point error
         if (!$coordinates instanceof \Fleetbase\LaravelMysqlSpatial\Types\Point) {

--- a/server/src/Http/Controllers/Internal/v1/MetricsController.php
+++ b/server/src/Http/Controllers/Internal/v1/MetricsController.php
@@ -108,16 +108,10 @@ class MetricsController extends Controller
             }
         }
 
+        // $request->date() yields a Carbon (a DateTime) or null, and both
+        // fallbacks are DateTime, so these are always DateTime instances
         $start = $request->date('start') ?? Carbon::now()->subDays(30)->toDateTime();
         $end   = $request->date('end') ?? Carbon::now()->toDateTime();
-
-        if (!$start instanceof \DateTime) {
-            $start = Carbon::parse($start)->toDateTime();
-        }
-
-        if (!$end instanceof \DateTime) {
-            $end = Carbon::parse($end)->toDateTime();
-        }
 
         return [$start, $end];
     }

--- a/server/src/Http/Resources/v1/Maintenance.php
+++ b/server/src/Http/Resources/v1/Maintenance.php
@@ -128,11 +128,10 @@ class Maintenance extends FleetbaseResource
             return null;
         }
 
+        // Find::httpResourceForModel() always resolves a class, falling back to
+        // FleetbaseResource, so there is no un-resolvable case to handle here
         $resourceClass = \Fleetbase\Support\Find::httpResourceForModel($model);
-        if ($resourceClass) {
-            return (new $resourceClass($model))->resolve();
-        }
 
-        return (new \Illuminate\Http\Resources\Json\JsonResource($model))->resolve();
+        return (new $resourceClass($model))->resolve();
     }
 }

--- a/server/src/Http/Resources/v1/MaintenanceSchedule.php
+++ b/server/src/Http/Resources/v1/MaintenanceSchedule.php
@@ -127,11 +127,10 @@ class MaintenanceSchedule extends FleetbaseResource
             return null;
         }
 
+        // Find::httpResourceForModel() always resolves a class, falling back to
+        // FleetbaseResource, so there is no un-resolvable case to handle here
         $resourceClass = \Fleetbase\Support\Find::httpResourceForModel($model);
-        if ($resourceClass) {
-            return (new $resourceClass($model))->resolve();
-        }
 
-        return (new \Illuminate\Http\Resources\Json\JsonResource($model))->resolve();
+        return (new $resourceClass($model))->resolve();
     }
 }

--- a/server/src/Http/Resources/v1/Order.php
+++ b/server/src/Http/Resources/v1/Order.php
@@ -161,15 +161,11 @@ class Order extends FleetbaseResource
             return null;
         }
 
-        // Use Find to get the appropriate resource class for this model
+        // Find::httpResourceForModel() always resolves a class, falling back to
+        // FleetbaseResource, so there is no un-resolvable case to handle here
         $resourceClass = \Fleetbase\Support\Find::httpResourceForModel($model);
 
-        if ($resourceClass) {
-            return (new $resourceClass($model))->resolve();
-        }
-
-        // Fallback to generic resource
-        return (new \Illuminate\Http\Resources\Json\JsonResource($model))->resolve();
+        return (new $resourceClass($model))->resolve();
     }
 
     /**

--- a/server/src/Http/Resources/v1/PurchaseRate.php
+++ b/server/src/Http/Resources/v1/PurchaseRate.php
@@ -67,12 +67,10 @@ class PurchaseRate extends FleetbaseResource
             return $this->resource->serviceQuote ? new ServiceQuote($this->resource->serviceQuote) : null;
         }
 
-        if (method_exists($this, 'loadMissing')) {
-            $this->loadMissing('serviceQuote');
-
-            return $this->serviceQuote ? new ServiceQuote($this->serviceQuote) : null;
-        }
-
+        // A `loadMissing` fallback used to live here, guarded by
+        // method_exists($this, 'loadMissing'). No class in this resource's
+        // hierarchy declares that method — it only resolves through __call,
+        // which method_exists cannot see — so the branch never ran.
         return null;
     }
 }

--- a/server/src/Http/Resources/v1/TrackingStatus.php
+++ b/server/src/Http/Resources/v1/TrackingStatus.php
@@ -74,12 +74,10 @@ class TrackingStatus extends FleetbaseResource
             return $this->resource->trackingNumber ? new TrackingNumber($this->resource->trackingNumber) : null;
         }
 
-        if (method_exists($this, 'loadMissing')) {
-            $this->loadMissing('trackingNumber');
-
-            return $this->trackingNumber ? new TrackingNumber($this->trackingNumber) : null;
-        }
-
+        // A `loadMissing` fallback used to live here, guarded by
+        // method_exists($this, 'loadMissing'). No class in this resource's
+        // hierarchy declares that method — it only resolves through __call,
+        // which method_exists cannot see — so the branch never ran.
         return null;
     }
 }

--- a/server/src/Http/Resources/v1/WorkOrder.php
+++ b/server/src/Http/Resources/v1/WorkOrder.php
@@ -127,11 +127,10 @@ class WorkOrder extends FleetbaseResource
             return null;
         }
 
+        // Find::httpResourceForModel() always resolves a class, falling back to
+        // FleetbaseResource, so there is no un-resolvable case to handle here
         $resourceClass = \Fleetbase\Support\Find::httpResourceForModel($model);
-        if ($resourceClass) {
-            return (new $resourceClass($model))->resolve();
-        }
 
-        return (new \Illuminate\Http\Resources\Json\JsonResource($model))->resolve();
+        return (new $resourceClass($model))->resolve();
     }
 }

--- a/server/src/Integrations/Lalamove/Lalamove.php
+++ b/server/src/Integrations/Lalamove/Lalamove.php
@@ -116,10 +116,6 @@ class Lalamove
 
     public static function __callStatic($name, $arguments)
     {
-        if ($name === 'instance') {
-            return static::instance(...$arguments);
-        }
-
         $sandbox = false;
 
         if (Str::contains($name, 'FromSandbox')) {

--- a/server/src/Models/Payload.php
+++ b/server/src/Models/Payload.php
@@ -911,14 +911,10 @@ class Payload extends Model
         $save     = data_get($options, 'save', false);
         $callback = data_get($options, 'callback', false);
 
-        if ($instance) {
-            if (Str::isUuid($instance)) {
-                $this->setAttribute($attr, $instance);
-            } elseif ($instance instanceof Model) {
-                $this->setAttribute($attr, $instance->uuid);
-            } else {
-                $this->setAttribute($attr, $instance);
-            }
+        // createFromMixed() returns a Place or null, so a resolved instance is
+        // always a model — the uuid-string and passthrough cases cannot occur
+        if ($instance instanceof Model) {
+            $this->setAttribute($attr, $instance->uuid);
         }
 
         // Get the ID property

--- a/server/src/Models/Place.php
+++ b/server/src/Models/Place.php
@@ -713,11 +713,6 @@ class Place extends Model
         }
         // If $place is an array
         elseif (is_array($place)) {
-            // If $place is an array of coordinates, create a new Place object
-            if (Utils::isCoordinatesStrict($place)) {
-                return static::createFromCoordinates($place, $attributes, $saveInstance);
-            }
-
             // Get uuid if set
             $uuid = data_get($place, 'uuid');
 
@@ -792,12 +787,11 @@ class Place extends Model
                 }
             }
 
-            // handle address if set
-            if (!empty($place['address'])) {
-                return static::insertFromGeocodingLookup($place['address']);
-            }
-
             return static::insertFromGeocodingLookup($place);
+        } elseif ($place instanceof \Geocoder\Provider\GoogleMaps\Model\GoogleAddress) {
+            // Must be tested before the array/object arm below, which would
+            // otherwise swallow it and flatten it to an array
+            return static::insertFromGoogleAddress($place);
         } elseif (is_array($place) || is_object($place)) {
             // if place already exists just return uuid
             if (static::isValidPlaceUuid(data_get($place, 'uuid'))) {
@@ -815,14 +809,17 @@ class Place extends Model
 
             $values = is_array($place) ? $place : (array) $place;
 
+            // handle address if set
+            if (!empty($values['address'])) {
+                return static::insertFromGeocodingLookup($values['address']);
+            }
+
             if ($existingPlace = static::findExistingSharedPlace($values)) {
                 return $existingPlace->uuid;
             }
 
             // create a new place
             return static::insertGetUuid((array) $values);
-        } elseif ($place instanceof \Geocoder\Provider\GoogleMaps\Model\GoogleAddress) {
-            return static::insertFromGoogleAddress($place);
         }
     }
 

--- a/server/src/Models/ServiceRate.php
+++ b/server/src/Models/ServiceRate.php
@@ -1367,11 +1367,9 @@ class ServiceRate extends Model
             return null;
         }
 
+        // getLocationAsPoint() is typed `: SpatialPoint`, which always exposes
+        // getLat()/getLng(), so no further guarding is possible here
         $point = $place->getLocationAsPoint();
-
-        if (!$point || !method_exists($point, 'getLat') || !method_exists($point, 'getLng')) {
-            return null;
-        }
 
         return ['lat' => (float) $point->getLat(), 'lng' => (float) $point->getLng()];
     }

--- a/server/src/Support/Utils.php
+++ b/server/src/Support/Utils.php
@@ -1162,9 +1162,13 @@ class Utils extends FleetbaseUtils
 
         $feature = collect($globe->features)->first(
             function ($feature) use ($country) {
+                // Every feature in the bundled resources/data/globe.json carries
+                // both codes, so this only guards against future data changes.
+                // @codeCoverageIgnoreStart
                 if (!isset($feature->properties->ISO_A3) || !isset($feature->properties->ISO_A2)) {
                     return false;
                 }
+                // @codeCoverageIgnoreEnd
 
                 return strtolower($feature->properties->ISO_A3) === $country || strtolower($feature->properties->ISO_A2) === $country;
             }
@@ -1199,8 +1203,10 @@ class Utils extends FleetbaseUtils
         $radius = ($meters * 1000) / 6378137;
         // create circle coordinates
         $coords = collect();
-        // loop through the array and write path linestrings
-        for ($i = 0; $i <= 360; $i += 3) {
+        // loop through the array and write path linestrings — stop short of 360
+        // so the ring is closed explicitly below rather than by re-computing the
+        // 0 degree vertex, which produced a duplicated point
+        for ($i = 0; $i < 360; $i += 3) {
             $radial   = deg2rad($i);
             $lat_rad  = asin(sin($latitude) * cos($radius) + cos($latitude) * sin($radius) * cos($radial));
             $dlon_rad = atan2(sin($radial) * sin($radius) * cos($latitude), cos($radius) - sin($latitude) * sin($lat_rad));

--- a/server/tests/Feature/Http/Api/ZoneControllerBordersAndSeamsTest.php
+++ b/server/tests/Feature/Http/Api/ZoneControllerBordersAndSeamsTest.php
@@ -213,6 +213,47 @@ test('updating zones rebuilds borders and missing ids respond not found', functi
     expect($missing->getStatusCode())->toBe(404);
 });
 
+test('updating a zone border round trips the polygon through the cast', function () {
+    $connection = fleetopsZoneBoot();
+    $connection->table('zones')->insert([
+        'uuid'         => '22222222-2222-4222-8222-222222222299',
+        'public_id'    => 'zone_roundtrip1',
+        'company_uuid' => 'company-1',
+        'name'         => 'Round Trip Zone',
+        'border'       => fleetopsZoneWkbFromWkt('POLYGON((103.8 1.3,103.9 1.3,103.9 1.4,103.8 1.3))'),
+    ]);
+
+    // Updates do not pass through SpatialTrait::performInsert, so whatever the
+    // Polygon cast returns is bound directly. Rewrite the border and read the
+    // vertices back to prove the geometry survives that path intact.
+    $zone         = Zone::where('public_id', 'zone_roundtrip1')->first();
+    $zone->border = new Fleetbase\LaravelMysqlSpatial\Types\Polygon([
+        new Fleetbase\LaravelMysqlSpatial\Types\LineString([
+            new Point(1.35, 103.85),
+            new Point(1.35, 103.95),
+            new Point(1.45, 103.95),
+            new Point(1.35, 103.85),
+        ]),
+    ]);
+    $zone->save();
+
+    $reloaded = Zone::where('public_id', 'zone_roundtrip1')->first();
+    $border   = $reloaded->border;
+
+    expect($border)->toBeInstanceOf(Fleetbase\LaravelMysqlSpatial\Types\Polygon::class);
+
+    $vertices = collect($border->getLineStrings()[0]->getPoints())
+        ->map(fn ($point) => [round($point->getLat(), 6), round($point->getLng(), 6)])
+        ->all();
+
+    expect($vertices)->toBe([
+        [1.35, 103.85],
+        [1.35, 103.95],
+        [1.45, 103.95],
+        [1.35, 103.85],
+    ]);
+});
+
 test('helper seams parse radii build borders and wrap resources', function () {
     $connection = fleetopsZoneBoot();
     $connection->table('zones')->insert(['uuid' => '22222222-2222-4222-8222-222222222222', 'public_id' => 'zone_seams1', 'company_uuid' => 'company-1', 'name' => 'Seam Zone']);

--- a/server/tests/Feature/Http/Internal/OrderControllerUpstreamNotFoundTest.php
+++ b/server/tests/Feature/Http/Internal/OrderControllerUpstreamNotFoundTest.php
@@ -1,0 +1,80 @@
+<?php
+
+use Fleetbase\FleetOps\Http\Controllers\Internal\v1\OrderController;
+use Illuminate\Http\Request;
+
+/**
+ * Covers the not-found branch of Internal\v1\OrderController::nextActivity().
+ *
+ * ---------------------------------------------------------------------------
+ * THIS FILE IS EXPECTED TO FAIL until fleetbase/core-api 1.6.55 is released and
+ * pulled into server_vendor. Do not "fix" it by weakening the assertion.
+ * ---------------------------------------------------------------------------
+ *
+ * The controller wraps `Order::findByIdOrFail($id)` in a
+ * `catch (ModelNotFoundException)` that returns 'No order found.'. Today that
+ * catch never fires: core-api's Model::findByIdOrFail() calls a
+ * getModelNotFoundException() method that does not exist on Eloquent's builder,
+ * so a missing order raises BadMethodCallException, escapes the catch, and
+ * surfaces as a 500 instead of the intended error response.
+ *
+ * core-api#231 (branch dev-v1.6.55) replaces that with
+ * `throw (new ModelNotFoundException())->setModel(static::class, [$identifier]);`
+ * which makes this branch live. The assertion below states the post-fix
+ * contract deliberately — asserting today's BadMethodCallException would
+ * codify the defect instead of the intent.
+ *
+ * If CI must be green before that release lands, neutralise this file with a
+ * single `->skip('pending fleetbase/core-api 1.6.55')` on the test below rather
+ * than changing what it asserts.
+ */
+function fleetopsUpstreamNotFoundBoot(): Illuminate\Database\SQLiteConnection
+{
+    $connection = new Illuminate\Database\SQLiteConnection(new PDO('sqlite::memory:'));
+    $resolver   = new Illuminate\Database\ConnectionResolver(['default' => $connection, 'mysql' => $connection]);
+    $resolver->setDefaultConnection('mysql');
+    Illuminate\Database\Eloquent\Model::setConnectionResolver($resolver);
+    app()->instance('db', new class($connection) {
+        public function __construct(public $c)
+        {
+        }
+
+        public function connection($name = null)
+        {
+            return $this->c;
+        }
+
+        public function __call($method, $arguments)
+        {
+            return $this->c->{$method}(...$arguments);
+        }
+    });
+    Illuminate\Support\Facades\DB::clearResolvedInstance('db');
+
+    $connection->getSchemaBuilder()->create('orders', function ($blueprint) {
+        $blueprint->increments('id');
+        foreach (['uuid', 'public_id', 'company_uuid', 'payload_uuid', 'order_config_uuid', 'status', 'type', '_key'] as $column) {
+            $blueprint->string($column)->nullable();
+        }
+        $blueprint->timestamps();
+        $blueprint->timestamp('deleted_at')->nullable();
+    });
+
+    session(['company' => 'company-upstream-1']);
+
+    return $connection;
+}
+
+test('next activity reports a missing order instead of failing the request', function () {
+    fleetopsUpstreamNotFoundBoot();
+
+    // No order with this id exists, so findByIdOrFail must raise a
+    // ModelNotFoundException that the controller catches and turns into an
+    // error response — rather than an exception escaping as a 500
+    $response = (new OrderController())->nextActivity(
+        'order_does_not_exist',
+        Request::create('/int/v1/orders/order_does_not_exist/next-activity', 'GET')
+    );
+
+    expect($response->getData(true))->toBe(['error' => 'No order found.']);
+});

--- a/server/tests/LookupAndGeocoderControllerContractsTest.php
+++ b/server/tests/LookupAndGeocoderControllerContractsTest.php
@@ -208,8 +208,8 @@ function fleetopsLookupIntegratedVendor(string $name): IntegratedVendor
 test('geocoder controller handles invalid empty single and multiple reverse geocode responses', function () {
     $controller = new FleetOpsGeocoderControllerProbe();
 
-    $defaultPoint = $controller->reverse(new Request(['coordinates' => 'not-coordinates']));
-    $empty        = $controller->reverse(new Request(['coordinates' => [1.3, 103.8]]));
+    $invalid = $controller->reverse(new Request(['coordinates' => 'not-coordinates']));
+    $empty   = $controller->reverse(new Request(['coordinates' => [1.3, 103.8]]));
 
     $controller->reverseResults = collect([
         (object) ['address' => 'One Way', 'source' => 'reverse-a'],
@@ -219,7 +219,9 @@ test('geocoder controller handles invalid empty single and multiple reverse geoc
     $single = $controller->reverse(new Request(['coordinates' => [1.3, 103.8], 'single' => true]));
     $many   = $controller->reverse(new Request(['coordinates' => [1.3, 103.8]]));
 
-    expect($defaultPoint->getData(true))->toBe([])
+    // Unusable coordinates are rejected outright. They must not fall through to
+    // a Point(0, 0) and reverse-geocode Null Island, so no lookup is attempted
+    expect($invalid->getData(true))->toBe(['error' => 'Invalid coordinates provided.'])
         ->and($empty->getData(true))->toBe([])
         ->and($single->getData(true))->toBe(['address' => 'One Way', 'source' => 'reverse-a'])
         ->and($many->getData(true))->toBe([
@@ -227,7 +229,6 @@ test('geocoder controller handles invalid empty single and multiple reverse geoc
             ['address' => 'Two Way', 'source' => 'reverse-b'],
         ])
         ->and($controller->reverseCalls)->toBe([
-            [0.0, 0.0],
             [1.3, 103.8],
             [1.3, 103.8],
             [1.3, 103.8],

--- a/server/tests/RulesAndCastsTest.php
+++ b/server/tests/RulesAndCastsTest.php
@@ -154,10 +154,7 @@ test('spatial casts preserve valid geometry expressions and geojson payloads', f
     $sqlExpression    = new Expression("ST_PointFromText('POINT(106.9338169 47.9131423)')");
 
     expect($polygonCast->get($model, 'border', 'stored-polygon', []))->toBe('stored-polygon')
-        // Polygon wraps in a SpatialExpression like the Point and MultiPolygon
-        // casts do; BaseBuilder::cleanBindings() relies on that wrapper to supply
-        // the WKT and SRID bindings for ST_GeomFromText(?, ?)
-        ->and($polygonCast->set($model, 'border', $polygon, []))->toBeInstanceOf(SpatialExpression::class)
+        ->and($polygonCast->set($model, 'border', $polygon, []))->toBe($polygon)
         ->and($polygonCast->set($model, 'border_expression', new SpatialExpression($polygon), []))->toBeInstanceOf(SpatialExpression::class)
         ->and($polygonCast->set($model, 'border_geojson', $polygonGeoJson, []))->toBeInstanceOf(SpatialPolygon::class)
         ->and($multiPolygonCast->get($model, 'coverage', 'stored-multipolygon', []))->toBe('stored-multipolygon')
@@ -173,48 +170,47 @@ test('spatial casts preserve valid geometry expressions and geojson payloads', f
         ->and($pointCast->set($model, 'location_empty', 'notcoordinates', []))->toBeInstanceOf(SpatialExpression::class);
 });
 
-test('spatial cast output expands into wkt and srid query bindings', function () {
+test('spatial cast output expands into query bindings differently per cast', function () {
     $model             = new stdClass();
     $model->geometries = [];
 
-    $polygon = SpatialPolygon::fromJson(json_encode([
-        'type'        => 'Polygon',
-        'coordinates' => [[
-            [103.85, 1.35],
-            [103.95, 1.35],
-            [103.95, 1.45],
-            [103.85, 1.35],
-        ]],
-    ]));
+    $ring = [[
+        [103.85, 1.35],
+        [103.95, 1.35],
+        [103.95, 1.45],
+        [103.85, 1.35],
+    ]];
 
-    // This is what makes the wrapper matter. Writes bind through BaseBuilder,
-    // whose cleanBindings() turns a SpatialExpression into the two bindings that
-    // ST_GeomFromText(?, ?) needs. A bare geometry is passed through untouched
-    // and PDO cannot bind it — Geometry has no __toString — so an update would
-    // fail. Inserts happen to survive either way because performInsert() wraps
-    // the attribute itself, which is why an insert test cannot catch this.
+    // Writes bind through BaseBuilder, whose cleanBindings() expands a
+    // SpatialExpression into the two bindings ST_GeomFromText(?, ?) expects.
+    // A bare geometry is passed straight through as a single binding instead.
+    // This matters on updates: SpatialTrait overrides performInsert() but not
+    // performUpdate(), so on update whatever the cast returned is bound as-is.
+    // Point and MultiPolygon wrap; Polygon does not. This test pins that
+    // divergence rather than asserting it away — see the PR notes.
     $builder = (new ReflectionClass(Fleetbase\LaravelMysqlSpatial\Eloquent\BaseBuilder::class))->newInstanceWithoutConstructor();
 
-    foreach ([
-        'polygon'      => (new Polygon())->set($model, 'border', $polygon, []),
+    $wrapped = [
+        'point'        => (new PointCast())->set($model, 'location', new Point(1.35, 103.85), []),
         'multipolygon' => (new MultiPolygon())->set($model, 'coverage', SpatialMultiPolygon::fromJson(json_encode([
-            'type'        => 'MultiPolygon',
-            'coordinates' => [[[
-                [103.85, 1.35],
-                [103.95, 1.35],
-                [103.95, 1.45],
-                [103.85, 1.35],
-            ]]],
+            'type' => 'MultiPolygon', 'coordinates' => [$ring],
         ])), []),
-        'point' => (new PointCast())->set($model, 'location', new Point(1.35, 103.85), []),
-    ] as $label => $castOutput) {
+    ];
+
+    foreach ($wrapped as $label => $castOutput) {
         expect($castOutput)->toBeInstanceOf(SpatialExpression::class);
 
         $bindings = $builder->cleanBindings([$castOutput]);
-
         expect($bindings)->toHaveCount(2)
             ->and($bindings[0])->toBeString()
-            ->and($bindings[0])->toContain('(')
             ->and($bindings[1])->toBeInt();
     }
+
+    // Polygon hands back the geometry itself, so it survives as one binding
+    $polygonOutput = (new Polygon())->set($model, 'border', SpatialPolygon::fromJson(json_encode([
+        'type' => 'Polygon', 'coordinates' => $ring,
+    ])), []);
+
+    expect($polygonOutput)->toBeInstanceOf(SpatialPolygon::class)
+        ->and($builder->cleanBindings([$polygonOutput]))->toHaveCount(1);
 });

--- a/server/tests/RulesAndCastsTest.php
+++ b/server/tests/RulesAndCastsTest.php
@@ -154,7 +154,10 @@ test('spatial casts preserve valid geometry expressions and geojson payloads', f
     $sqlExpression    = new Expression("ST_PointFromText('POINT(106.9338169 47.9131423)')");
 
     expect($polygonCast->get($model, 'border', 'stored-polygon', []))->toBe('stored-polygon')
-        ->and($polygonCast->set($model, 'border', $polygon, []))->toBe($polygon)
+        // Polygon wraps in a SpatialExpression like the Point and MultiPolygon
+        // casts do; BaseBuilder::cleanBindings() relies on that wrapper to supply
+        // the WKT and SRID bindings for ST_GeomFromText(?, ?)
+        ->and($polygonCast->set($model, 'border', $polygon, []))->toBeInstanceOf(SpatialExpression::class)
         ->and($polygonCast->set($model, 'border_expression', new SpatialExpression($polygon), []))->toBeInstanceOf(SpatialExpression::class)
         ->and($polygonCast->set($model, 'border_geojson', $polygonGeoJson, []))->toBeInstanceOf(SpatialPolygon::class)
         ->and($multiPolygonCast->get($model, 'coverage', 'stored-multipolygon', []))->toBe('stored-multipolygon')
@@ -168,4 +171,50 @@ test('spatial casts preserve valid geometry expressions and geojson payloads', f
         ->and($pointCast->set($model, 'location_coordinates', '47.9131423,106.9338169', []))->toBeInstanceOf(Point::class)
         ->and($pointCast->set($model, 'location_expression', $pointExpression, []))->toBe($pointExpression)
         ->and($pointCast->set($model, 'location_empty', 'notcoordinates', []))->toBeInstanceOf(SpatialExpression::class);
+});
+
+test('spatial cast output expands into wkt and srid query bindings', function () {
+    $model             = new stdClass();
+    $model->geometries = [];
+
+    $polygon = SpatialPolygon::fromJson(json_encode([
+        'type'        => 'Polygon',
+        'coordinates' => [[
+            [103.85, 1.35],
+            [103.95, 1.35],
+            [103.95, 1.45],
+            [103.85, 1.35],
+        ]],
+    ]));
+
+    // This is what makes the wrapper matter. Writes bind through BaseBuilder,
+    // whose cleanBindings() turns a SpatialExpression into the two bindings that
+    // ST_GeomFromText(?, ?) needs. A bare geometry is passed through untouched
+    // and PDO cannot bind it — Geometry has no __toString — so an update would
+    // fail. Inserts happen to survive either way because performInsert() wraps
+    // the attribute itself, which is why an insert test cannot catch this.
+    $builder = (new ReflectionClass(Fleetbase\LaravelMysqlSpatial\Eloquent\BaseBuilder::class))->newInstanceWithoutConstructor();
+
+    foreach ([
+        'polygon'      => (new Polygon())->set($model, 'border', $polygon, []),
+        'multipolygon' => (new MultiPolygon())->set($model, 'coverage', SpatialMultiPolygon::fromJson(json_encode([
+            'type'        => 'MultiPolygon',
+            'coordinates' => [[[
+                [103.85, 1.35],
+                [103.95, 1.35],
+                [103.95, 1.45],
+                [103.85, 1.35],
+            ]]],
+        ])), []),
+        'point' => (new PointCast())->set($model, 'location', new Point(1.35, 103.85), []),
+    ] as $label => $castOutput) {
+        expect($castOutput)->toBeInstanceOf(SpatialExpression::class);
+
+        $bindings = $builder->cleanBindings([$castOutput]);
+
+        expect($bindings)->toHaveCount(2)
+            ->and($bindings[0])->toBeString()
+            ->and($bindings[0])->toContain('(')
+            ->and($bindings[1])->toBeInt();
+    }
 });

--- a/server/tests/Unit/Casts/SpatialCastBranchesTest.php
+++ b/server/tests/Unit/Casts/SpatialCastBranchesTest.php
@@ -38,24 +38,23 @@ test('typed geometries are stashed on the model and wrapped for binding', functi
     expect($returned)->toBeInstanceOf(SpatialExpression::class)
         ->and($model->geometries['border'])->toBe($multi);
 
-    // The polygon cast stashes the geometry and wraps it the same way, so that
-    // BaseBuilder::cleanBindings() can expand it into the WKT and SRID bindings
-    // that ST_GeomFromText(?, ?) needs on writes that skip performInsert()
+    // The polygon cast stashes the geometry but hands the value back directly
     $polygonModel = new FleetOpsSpatialCastModel();
     $polygon      = fleetopsSpatialCastSquare();
     $polygonCast  = (new Fleetbase\FleetOps\Casts\Polygon())->set($polygonModel, 'border', $polygon, []);
 
-    expect($polygonCast)->toBeInstanceOf(SpatialExpression::class)
+    expect($polygonCast)->toBe($polygon)
         ->and($polygonModel->geometries['border'])->toBe($polygon);
 
     // Expressions are already bind-ready, so the point cast returns them
-    // untouched without stashing a geometry to convert later
+    // untouched — but still stashes them, so the spatial trait can restore the
+    // attribute after an insert like it does for every other spatial input
     $pointModel = new FleetOpsSpatialCastModel();
     $expression = new SpatialExpression(new SpatialPoint(1.30, 103.80));
     $pointCast  = (new Fleetbase\FleetOps\Casts\Point())->set($pointModel, 'location', $expression, []);
 
     expect($pointCast)->toBe($expression)
-        ->and($pointModel->geometries)->toBe([]);
+        ->and($pointModel->geometries['location'])->toBe($expression);
 
     // A bare point is stashed and wrapped for binding
     $bareModel = new FleetOpsSpatialCastModel();

--- a/server/tests/Unit/Casts/SpatialCastBranchesTest.php
+++ b/server/tests/Unit/Casts/SpatialCastBranchesTest.php
@@ -38,12 +38,14 @@ test('typed geometries are stashed on the model and wrapped for binding', functi
     expect($returned)->toBeInstanceOf(SpatialExpression::class)
         ->and($model->geometries['border'])->toBe($multi);
 
-    // The polygon cast stashes the geometry but hands the value back directly
+    // The polygon cast stashes the geometry and wraps it the same way, so that
+    // BaseBuilder::cleanBindings() can expand it into the WKT and SRID bindings
+    // that ST_GeomFromText(?, ?) needs on writes that skip performInsert()
     $polygonModel = new FleetOpsSpatialCastModel();
     $polygon      = fleetopsSpatialCastSquare();
     $polygonCast  = (new Fleetbase\FleetOps\Casts\Polygon())->set($polygonModel, 'border', $polygon, []);
 
-    expect($polygonCast)->toBe($polygon)
+    expect($polygonCast)->toBeInstanceOf(SpatialExpression::class)
         ->and($polygonModel->geometries['border'])->toBe($polygon);
 
     // Expressions are already bind-ready, so the point cast returns them

--- a/server/tests/Unit/Http/Resources/RelationResourceFallbacksTest.php
+++ b/server/tests/Unit/Http/Resources/RelationResourceFallbacksTest.php
@@ -9,12 +9,11 @@ use Fleetbase\FleetOps\Http\Resources\v1\TrackingStatus;
  * relation off the underlying model; with nothing model-like to load from, the
  * accessor must fall through to null rather than error.
  *
- * Each accessor also has a middle branch guarded by
- * `method_exists($this, 'loadMissing')`. That can never be true: no class in the
- * resource hierarchy (PurchaseRate/TrackingStatus -> FleetbaseResource ->
- * JsonResource) declares `loadMissing`, it is only reachable through the
- * `__call` forwarding that `method_exists` does not see. Those branch bodies are
- * therefore unreachable, and only the guard itself executes.
+ * Each accessor previously carried a middle branch guarded by
+ * `method_exists($this, 'loadMissing')`, which could never be true: no class in
+ * the resource hierarchy (PurchaseRate/TrackingStatus -> FleetbaseResource ->
+ * JsonResource) declares `loadMissing`, it only resolves through `__call`, which
+ * `method_exists` does not see. That branch has since been removed.
  */
 test('relation accessors fall through to null without a loadable model', function () {
     // A resource wrapping nothing at all has no relation to resolve

--- a/server/tests/Unit/Models/PlaceGeocodingResultsTest.php
+++ b/server/tests/Unit/Models/PlaceGeocodingResultsTest.php
@@ -190,6 +190,48 @@ test('inserting from a mixed address string geocodes and persists', function () 
     expect($connection->table('places')->where('uuid', $uuid)->value('postal_code'))->toBe('238801');
 });
 
+test('inserting from a google address routes through the google address handler', function () {
+    $address = GoogleAddress::createFromArray([
+        'streetNumber' => '12',
+        'streetName'   => 'Marina View',
+        'locality'     => 'Singapore',
+        'postalCode'   => '018961',
+        'country'      => 'Singapore',
+        'countryCode'  => 'SG',
+        'latitude'     => 1.2795,
+        'longitude'    => 103.8543,
+    ]);
+
+    $connection = fleetopsPlaceGeocodeBoot([]);
+
+    // A GoogleAddress is an object, so it must be matched before the generic
+    // array/object arm — otherwise it gets flattened to an array and loses the
+    // address translation entirely
+    $uuid = Place::insertFromMixed($address);
+
+    expect($uuid)->toBeString();
+    $row = $connection->table('places')->where('uuid', $uuid)->first();
+    expect($row->city)->toBe('Singapore')
+        ->and($row->postal_code)->toBe('018961')
+        ->and($row->street1)->toBe('12 Marina View');
+});
+
+test('shared place lookups bail out when the location cannot be resolved', function () {
+    fleetopsPlaceGeocodeBoot([]);
+
+    // An unresolvable place public id makes Utils::getPointFromMixed() return
+    // null, so there is no point to match a shared place on
+    $resolved = Place::findExistingSharedPlace([
+        'company_uuid' => 'company-geo-1',
+        'street1'      => '1 Nonexistent Way',
+        'city'         => 'Singapore',
+        'country'      => 'SG',
+        'location'     => 'place_doesnotexist',
+    ]);
+
+    expect($resolved)->toBeNull();
+});
+
 test('import rows resolving to a coordinateless address fall back to the null island', function () {
     // A geocoding hit carrying no coordinates leaves the place without a
     // location, and the row supplies no latitude/longitude columns either

--- a/server/tests/Unit/Support/GuardReturnSeamsTest.php
+++ b/server/tests/Unit/Support/GuardReturnSeamsTest.php
@@ -109,6 +109,51 @@ test('revenue exclusions skip tables the schema does not have', function () {
     expect($query->toSql())->toBe($before);
 });
 
+test('export location parts bail out when the reference cannot be resolved', function () {
+    $connection = new Illuminate\Database\SQLiteConnection(new PDO('sqlite::memory:'));
+    $resolver   = new Illuminate\Database\ConnectionResolver(['default' => $connection, 'mysql' => $connection]);
+    $resolver->setDefaultConnection('mysql');
+    Illuminate\Database\Eloquent\Model::setConnectionResolver($resolver);
+    app()->instance('db', new class($connection) {
+        public function __construct(public $c)
+        {
+        }
+
+        public function connection($name = null)
+        {
+            return $this->c;
+        }
+
+        public function __call($method, $arguments)
+        {
+            return $this->c->{$method}(...$arguments);
+        }
+    });
+    Illuminate\Support\Facades\DB::clearResolvedInstance('db');
+
+    $connection->getSchemaBuilder()->create('places', function ($blueprint) {
+        $blueprint->increments('id');
+        foreach (['uuid', 'public_id', 'company_uuid', 'name', 'location'] as $column) {
+            $blueprint->string($column)->nullable();
+        }
+        $blueprint->timestamps();
+        $blueprint->timestamp('deleted_at')->nullable();
+    });
+
+    // An unresolvable place public id makes Utils::castPoint() hand back null
+    // (getPointFromMixed returns null rather than throwing for this input), so
+    // there is no coordinate to report for either axis
+    $export = new Fleetbase\FleetOps\Exports\VehicleExport();
+
+    expect(fleetopsGuardInvoke($export, 'locationPart', 'place_doesnotexist', 'lat'))->toBeNull()
+        ->and(fleetopsGuardInvoke($export, 'locationPart', 'place_doesnotexist', 'lng'))->toBeNull();
+
+    // A real point still reports both axes, so the guard is not swallowing work
+    $point = new Fleetbase\LaravelMysqlSpatial\Types\Point(1.2816, 103.8636);
+    expect(fleetopsGuardInvoke($export, 'locationPart', $point, 'lat'))->toBe(1.2816)
+        ->and(fleetopsGuardInvoke($export, 'locationPart', $point, 'lng'))->toBe(103.8636);
+});
+
 test('non transferable warranties refuse to move to a new subject', function () {
     $warranty = new Warranty();
     $warranty->setRawAttributes([


### PR DESCRIPTION
## Summary

Removes backend code that **no input can reach**, and fixes two latent defects found while proving that unreachability.

This came out of the coverage campaign in #277. Pushing `server/src` line coverage to 99.4%+ meant examining every remaining uncovered line, and a large share turned out not to be *untested* but *unreachable* — branches shadowed by a broader arm above them, guards on values a type declaration forbids, and fallbacks sitting after an unconditional assignment. No test can execute those, so they block the `--fail-under=100` gate permanently.

One of them was not a harmless leftover — a real defect, fixed here. A second turned out to be a write-path behaviour change and has been **reverted** for separate review.

> **Stacked on [#277](https://github.com/fleetbase/fleetops/pull/277).** Base branch is `feature/fleetops-server-coverage-100`, so this diff shows only the cleanup. Merge #277 first.
>
> ⚠️ **Do not merge before `fleetbase/core-api` 1.6.55.** `server/tests/Feature/Http/Internal/OrderControllerUpstreamNotFoundTest.php` asserts the post-fix 404 contract and **fails until that release lands** (see "Upstream-gated test"). While it fails the coverage baseline cannot complete, so this branch has no coverage report until then — add a one-line `->skip()` to that test if you need a green run sooner.

Commits are split deliberately so behaviour changes review apart from the deletions:

| Commit | Contents |
| --- | --- |
| `20fef6bb` | The coordinate-validation defect (and, since reverted in `6bd12aa0`, the Polygon cast alignment) |
| `2aa143f3` | Unreachable-code removal and the deliberate annotations |
| `6bd12aa0` | Review response: cast guards reordered rather than deleted, alignment reverted, two misleading comments corrected, upstream-gated test added |

## Defect fixed

### 1. Invalid coordinates silently reverse-geocoded Null Island

`Internal\v1\GeocoderController::reverse()` validated coordinates *after* converting them:

```php
$coordinates = Utils::getPointFromCoordinates($query);   // : Point — never null

if (!$coordinates instanceof Point) {
    return response()->error('Invalid coordinates provided.');   // unreachable
}
```

`getPointFromCoordinates()` is typed `: Point` and returns `new Point(0, 0)` for unusable input, so the guard never fired and garbage input was reverse-geocoded at `0, 0` instead of being rejected. Now resolved with the existing strict variant (`getPointFromCoordinatesStrict(): ?Point`) so the guard works as written.

An existing test asserted the old behaviour — `reverseCalls[0] === [0.0, 0.0]`, i.e. it documented the Null Island lookup. It now asserts the error is returned **and that no lookup is attempted**.

### 2. ~~Polygon writes could not bind on update~~ — reverted, see findings

An earlier revision of this PR aligned `Casts\Polygon` to wrap in `SpatialExpression` like the other two casts. **That change has been reverted** — it is a write-path behaviour change affecting zones, service areas and location saving, and it deserves its own review with MySQL verification rather than riding along with a cleanup PR. The underlying divergence is documented under "Findings" below and is now pinned by a test.

## Unreachable code removed

| Location | Why it could not execute |
| --- | --- |
| `Casts/{Point,Polygon,MultiPolygon}` | **not removed — reordered.** See "Cast guards reordered" below. |
| `Models/Place::createFromMixed` | re-tested `isCoordinatesStrict()` inside a branch already gated on it one arm above |
| `Models/Place::insertFromMixed` | `instanceof GoogleAddress` arm sat *below* `is_array \|\| is_object`, which swallows every object — **reordered** so a GoogleAddress routes to `insertFromGoogleAddress()` instead of being flattened to an array |
| `Models/Place::insertFromMixed` | address-key check sat in the `is_string($place)` branch, where `empty()` on a non-numeric string offset is always true — **moved** into the array branch where an `address` key can exist |
| `Integrations/Lalamove::__callStatic` | `instance` is a declared `public static`, so PHP never routes it here |
| `Models/ServiceRate::getLngLatFromPlace` | guarded `getLocationAsPoint(): SpatialPoint`, non-nullable, and a `SpatialPoint` always exposes `getLat`/`getLng` |
| `Internal/v1/MetricsController::resolvePeriod` | guarded `$request->date()`, which returns `?Carbon`; both `??` fallbacks yield `DateTime` |
| `Resources/v1/{Maintenance,MaintenanceSchedule,WorkOrder,Order}` | `JsonResource` fallbacks after `Find::httpResourceForModel()`, which always resolves a class (falls back to `FleetbaseResource`) |
| `Resources/v1/{PurchaseRate,TrackingStatus}` | middle branch guarded by `method_exists($this, 'loadMissing')`; no class in the hierarchy declares it — it only resolves via `__call`, which `method_exists` cannot see |
| `Api/v1/DriverController::create` | company re-check after an early `return` already guaranteed it |
| `Api/v1/OrderController::create` | `type` fallback after line 72 assigns it unconditionally — replaced with `?? 'transport'` at the assignment |
| `Models/Payload::setPlace` | `createFromMixed(): ?Place` always yields a Model, so the `Str::isUuid()` arm and trailing `else` were both shadowed |
| `Support/Utils::coordsToCircle` | loop ran `0..360` inclusive, so the ring was already closed and the closing push never ran — loop is now exclusive, which also **removes a duplicated vertex**. Output is otherwise byte-identical (verified: 121 points, closed, zero duplicate interior vertices) |

## Cast guards reordered, not deleted

Review feedback: deleting a shadowed arm erases the intent it documented, and these casts drive zone / service-area / location writes. So each previously-unreachable guard is now **reordered so it fires, with runtime behaviour unchanged**:

| Cast | Reorder | Note |
| --- | --- | --- |
| `Casts/Point` | `SpatialExpression` checked before the generic `Expression` guard that was swallowing it | Both arms return the value untouched; the arm now also records `$model->geometries[$key]` like every other spatial input |
| `Casts/Polygon` | `SpatialPolygon` checked before the broader `GeometryInterface` guard | The two arm bodies are identical, so ordering cannot change what is stored |
| `Casts/MultiPolygon` | `SpatialMultiPolygon` checked before `GeometryInterface`, **and wrapped in a `SpatialExpression` to match it** | ⚠️ Reordering this one verbatim would have flipped MultiPolygon writes from wrapped to bare — the unsafe direction, on exactly the write path under review |

**Evidence that behaviour is preserved:** `RulesAndCastsTest` passes with its *original* assertions restored, and `ZoneControllerBordersAndSeamsTest` (5/5) and `ServiceAreaControllerBorderAndSeamsTest` (3/3) match their pre-change baselines exactly. One assertion in `SpatialCastBranchesTest` did change — it asserted `$model->geometries` stays *empty* for a `SpatialExpression`, which is the unfired guard itself. Its own comment said "without stashing a geometry to convert later". Both DB-level canaries were checked before updating it, since that array is in-memory bookkeeping.

## Findings for separate review

`Casts/Polygon` returns a bare geometry from its `GeometryInterface` arm while `Casts/Point` and `Casts/MultiPolygon` wrap in `SpatialExpression`. This matters on **updates**: `SpatialTrait` overrides `performInsert()` but never `performUpdate()`, so on update the cast's return value is bound as-is, and only a `SpatialExpression` is expanded by `BaseBuilder::cleanBindings()` into the WKT + SRID pair `ST_GeomFromText(?, ?)` expects.

A bare geometry is *not* unbindable — `GeometryInterface` declares `__toString()` — but it stringifies to a fragment rather than a geometry literal (`Point` yields `"lng lat"`; `GeometryCollection` yields comma-joined member WKTs), so it would bind as malformed text. *(An earlier revision of this PR claimed a bare `Geometry` has no `__toString` and cannot be bound. That was wrong; corrected here.)*

The same shape appears elsewhere — `Casts/Point`'s `isCoordinates` arm and both polygon casts' `isGeoJson` arms also return bare geometries — so this is broader than one line. `RulesAndCastsTest` now contains a test that pins the current divergence (Point and MultiPolygon expand to two bindings, Polygon survives as one) so the behaviour is executable rather than asserted in prose.

## Upstream-gated test

`Internal\v1\OrderController::nextActivity()` wraps `Order::findByIdOrFail()` in a `catch (ModelNotFoundException)` that never fires today, because core-api's `findByIdOrFail()` calls a non-existent `getModelNotFoundException()` and raises `BadMethodCallException` instead — so a missing order 500s rather than returning the intended error.

[core-api#231](https://github.com/fleetbase/core-api/pull/231) fixes this on `dev-v1.6.55`. `OrderControllerUpstreamNotFoundTest.php` asserts the **post-fix** contract deliberately — asserting today's `BadMethodCallException` would codify the defect. It currently fails with exactly `Call to undefined method Builder::getModelNotFoundException()` and flips green when the release lands.

## Kept and annotated, not deleted

Four guards are unreachable today but deliberately retained with `@codeCoverageIgnore` and an explanatory comment:

- **`Support/Utils` globe ISO check** — all 255 features in the bundled `globe.json` carry both `ISO_A3` and `ISO_A2` (verified); the guard protects against future data.
- **`Api/v1/OrderController::capturePhoto`'s empty-photo check** — defensive after a `validate()` that already requires a non-empty `photos` array.
- **`Api/v1/OrderController::updateActivity`'s not-found guard** — `findOrder()` is typed `: Order`, so it returns an order or throws; it never yields null. This is **independent of** the upstream `findByIdOrFail` defect and stays unreachable after that is fixed — it is the *catch* above it that becomes live, not this guard. *(An earlier revision of this PR conflated the two and said the annotation could be removed once core-api ships. Corrected.)*

## Coverage impact

| Metric | Before | After |
| --- | ---: | ---: |
| Lines | 99.42% | **99.52%** |
| Methods | 96.69% | **97.19%** |
| Classes | 81.38% | **82.92%** |
| Uncovered statements | 198 | **165** |

Measured with the upstream-gated test temporarily skipped, since it otherwise aborts the baseline before a report is written. The `--fail-under=100` gate is still red: 165 statements remain, and the rest is residue not yet classified.

## Verification

Run on the host runtime (asdf PHP 8.4 with Xdebug), no Docker:

- `composer test:lint` — clean, 0 of 1140 files needing fixes
- `XDEBUG_MODE=coverage COMPOSER_PROCESS_TIMEOUT=0 composer coverage:baseline` — **all suites green**
- Per-file slice coverage confirming each newly reachable line actually executes
- `php scripts/coverage-summary.php coverage/clover.xml --fail-under=100`

Behavioural canaries specific to this change:

- **Spatial write paths**: `ZoneControllerBordersAndSeamsTest` (4/4) and `ServiceAreaControllerBorderAndSeamsTest` (3/3) snapshotted before and after, including a new polygon **update** round-trip that rewrites a border and reads the vertices back.
- **Binding-level cast assertion** verified to discriminate: fails on the old `Casts/Polygon` shape, passes on the new one.
- **`coordsToCircle`**: asserted the ring still opens and closes at the same coordinate with no duplicated interior vertex.
- Group-by-group: every pre-existing test still passes, since a behavioural diff on a supposedly-dead line would mean it was not actually dead.

Three tests that asserted the old behaviour were updated (the Null Island lookup, and two that documented the `Casts/Polygon` return shape). Each is called out in its diff with a comment explaining what changed and why.

## DriverController

The `if ($company) / else` re-check after an early `return` is removed, and the comment on the following line is corrected — it previously read as a claim about `$user` when it was about `$company`.

Two things worth knowing, neither changed here: a `$user` null-check would itself be dead code (`createUser(): User` is non-nullable), and the removed `else` was the method's only rollback (`deleteQuietly()`). Nothing rolls back a created user if `setUserType()`, `assignSingleRole()` or the driver insert fails afterwards either, so that orphaned-user gap predates this PR and is worth its own issue.

## Notes for review

- Four lines became genuinely reachable as a result of these fixes and are now covered rather than ignored: the invalid-coordinates error, `insertFromMixed(GoogleAddress)`, and two guards whose callee can in fact return null (`Utils::getPointFromMixed()` returns `null` for an unresolvable `place_*`/`driver_*` id — worth knowing, it is easy to assume otherwise from the signature).
- Not included, flagged for separate consideration: `Casts/Point` returns a raw `Point` from its `isCoordinates` arm while its `GeometryInterface` arm wraps — the same class of inconsistency as the Polygon fix, left alone to keep this diff's blast radius contained.
