### PR TITLE
Read GeoJSON fallback coordinates in GeoJSON order

### DIFF
--- a/server/src/Support/Utils.php
+++ b/server/src/Support/Utils.php
@@ -271,12 +271,20 @@ class Utils extends FleetbaseUtils
                 try {
                     $coordinates = Point::fromJson($coordinatesJson);
                 } catch (\Throwable $e) {
+                    // Both fallbacks carry a GeoJSON coordinate value, so they are
+                    // read as GeoJSON first: pointFromGeoJson() maps [lng, lat],
+                    // whereas recursing hands the pair to the positional array
+                    // reader below, which takes index 0 as the latitude. Nested
+                    // values (a Polygon or LineString ring rather than a single
+                    // pair) yield null there and still fall through to it.
                     if ($coordinatesInGeoJson) {
-                        return static::getPointFromMixed($coordinatesInGeoJson);
+                        return static::pointFromGeoJsonCoordinates($coordinatesInGeoJson)
+                            ?? static::getPointFromMixed($coordinatesInGeoJson);
                     }
 
                     if ($coordinatesInGeoJsonFeature) {
-                        return static::getPointFromMixed($coordinatesInGeoJsonFeature);
+                        return static::pointFromGeoJsonCoordinates($coordinatesInGeoJsonFeature)
+                            ?? static::getPointFromMixed($coordinatesInGeoJsonFeature);
                     }
                 }
             }
@@ -699,6 +707,19 @@ class Utils extends FleetbaseUtils
         }
 
         return new Point((float) $latitude, (float) $longitude);
+    }
+
+    /**
+     * Resolve a bare GeoJSON `coordinates` value — an `[longitude, latitude]`
+     * pair — into a Point, without the surrounding envelope.
+     *
+     * Returns null for anything that is not a usable pair, including the nested
+     * rings a Polygon or LineString carries, so callers can fall through to
+     * their own handling.
+     */
+    protected static function pointFromGeoJsonCoordinates($coordinates): ?Point
+    {
+        return static::pointFromGeoJson(['type' => 'Point', 'coordinates' => $coordinates]);
     }
 
     /**

--- a/server/tests/PointResolutionTest.php
+++ b/server/tests/PointResolutionTest.php
@@ -53,13 +53,44 @@ test('point resolution falls back to nested geometry coordinates', function () {
         ],
     ]);
 
-    // NOTE: this fallback recurses with the bare coordinate pair, which the
-    // array reader interprets positionally as [lat, lng] — the reverse of
-    // GeoJSON's [lng, lat]. The pair therefore comes back transposed. This
-    // asserts the behaviour as it stands rather than the intent; changing it
-    // affects every location write path and belongs in its own change.
-    expect($point->getLat())->toBe(103.851)
-        ->and($point->getLng())->toBe(1.2816);
+    // The nested pair is GeoJSON, so it is read as [lng, lat]
+    expect($point->getLat())->toBe(1.2816)
+        ->and($point->getLng())->toBe(103.851);
+});
+
+test('point resolution falls back to top level coordinates before nested geometry', function () {
+    // The top-level `coordinates` arm is preferred, and is read in the same
+    // GeoJSON order. Point::fromJson rejects the envelope because of the extra
+    // member, which is what pushes resolution into the fallback at all.
+    $point = Utils::getPointFromMixed([
+        'type'        => 'Point',
+        'coordinates' => [103.851, 1.2816],
+        'geometry'    => [
+            'type'        => 'Point',
+            'coordinates' => [1.0, 2.0],
+        ],
+    ]);
+
+    expect($point->getLat())->toBe(1.2816)
+        ->and($point->getLng())->toBe(103.851);
+});
+
+test('point resolution still hands nested rings to the positional reader', function () {
+    // A Polygon ring is not a coordinate pair, so the GeoJSON read declines and
+    // resolution falls through to the existing recursion unchanged.
+    $point = Utils::getPointFromMixed([
+        'type'        => 'Polygon',
+        'coordinates' => [
+            [
+                [103.0, 1.0],
+                [104.0, 1.0],
+                [104.0, 2.0],
+                [103.0, 1.0],
+            ],
+        ],
+    ]);
+
+    expect($point)->toBeInstanceOf(Fleetbase\LaravelMysqlSpatial\Types\Point::class);
 });
 
 test('coordinate helper does not collapse bbox GeoJSON point to zero', function () {


### PR DESCRIPTION
## Summary

`Utils::getPointFromMixed()` returned latitude and longitude the wrong way round for one class of GeoJSON input. This corrects it and pins the behaviour with tests.

Found while writing coverage for the two fallback arms on `dev-v0.6.59`; split out into its own PR because it is a behaviour change on the location write path rather than a coverage commit.

## The defect

`Support/Utils.php` resolves a GeoJSON envelope in two passes. The first, `pointFromGeoJson()`, handles well-formed `Point` and `Feature`-wrapped `Point` values and maps them correctly — `coordinates[0]` to longitude, `coordinates[1]` to latitude.

Anything it declines falls through to `Point::fromJson()`, and when *that* throws, two fallback arms recursed with the bare coordinate value:

```php
if ($coordinatesInGeoJson) {
    return static::getPointFromMixed($coordinatesInGeoJson);
}

if ($coordinatesInGeoJsonFeature) {
    return static::getPointFromMixed($coordinatesInGeoJsonFeature);
}
```

Recursing hands the pair to the positional array reader further down the same method:

```php
$latitude  = static::or($coordinates, ['_lat', 'lat', '_latitude', 'latitude', 'x', '0']);
$longitude = static::or($coordinates, ['lon', '_lon', 'long', 'lng', '_lng', '_longitude', 'longitude', 'y', '1']);
```

Index `0` is read as the latitude and `1` as the longitude — the reverse of GeoJSON's `[lng, lat]`. So a pair reaching either arm came back **transposed**.

## Which inputs were affected

Narrower than it first looks, because well-formed points never reach the fallback — `pointFromGeoJson()` returns early for them. Reaching it requires an envelope that `isGeoJson()` accepts but `Point::fromJson()` rejects, with a coordinate value that is still a single pair. In practice:

- a `Point` envelope carrying extra members that `Point::fromJson()` will not parse
- a multi-coordinate type (`LineString`, `MultiPoint`, …) whose `coordinates` is a flat `[lng, lat]` pair rather than an array of pairs — malformed, but the kind of thing hand-built payloads and looser API clients produce

Polygon and LineString rings — nested arrays — were *not* affected and are not affected now; they fall through to the same positional reader as before.

## The fix

Read the fallback value as GeoJSON before falling back to positional interpretation, reusing the mapping that is already correct:

```php
if ($coordinatesInGeoJson) {
    return static::pointFromGeoJsonCoordinates($coordinatesInGeoJson)
        ?? static::getPointFromMixed($coordinatesInGeoJson);
}
```

`pointFromGeoJsonCoordinates()` is a thin wrapper over the existing `pointFromGeoJson()`, which already declines anything that is not a usable numeric pair. So nested rings return `null` there and still reach the old recursion untouched — only the bare-pair case changes, which is the defective one.

## Tests

`server/tests/PointResolutionTest.php` previously asserted the transposed result, with a comment recording that it was documenting the defect rather than the intent. That expectation is flipped here, deliberately — this is a behaviour change, so the test moves with it.

Two cases are added alongside: the top-level `coordinates` arm is preferred over nested `geometry.coordinates` and read in the same order, and a Polygon ring still routes to the positional reader.

## Verification

Both fallback arms and both sides of the `??` are covered — confirmed by slice coverage, not just passing assertions. The full suite runs clean apart from `OrderControllerUpstreamNotFoundTest`, which fails by design on `dev-v0.6.59` until [core-api 1.6.55](https://github.com/fleetbase/core-api/pull/231) ships.

**Worth a manual MySQL pass before this merges.** It sits on the location write path, so zones, service areas, waypoint and place location save/update, and reverse geocoding are the things to exercise. The in-memory SQLite suite proves the branch logic, not real-database behaviour.
