### PR TITLE
Fix vendor filtering on the public vehicles endpoint

### DIFF
--- a/server/src/Http/Controllers/Api/v1/VehicleController.php
+++ b/server/src/Http/Controllers/Api/v1/VehicleController.php
@@ -410,13 +410,7 @@ class VehicleController extends Controller
 
     protected function queryVehicles(Request $request)
     {
-        return Vehicle::queryWithRequest($request, function (&$query, $request) {
-            if ($request->has('vendor')) {
-                $query->whereHas('vendor', function ($q) use ($request) {
-                    $q->where('public_id', $request->input('vendor'));
-                });
-            }
-        });
+        return Vehicle::queryWithRequest($request);
     }
 
     protected function vehicleResource(Vehicle $vehicle)

--- a/server/src/Http/Filter/VehicleFilter.php
+++ b/server/src/Http/Filter/VehicleFilter.php
@@ -3,8 +3,10 @@
 namespace Fleetbase\FleetOps\Http\Filter;
 
 use Fleetbase\FleetOps\Models\Vehicle;
+use Fleetbase\FleetOps\Models\Vendor;
 use Fleetbase\FleetOps\Support\Utils;
 use Fleetbase\Http\Filter\Filter;
+use Fleetbase\Support\Http;
 
 class VehicleFilter extends Filter
 {
@@ -74,14 +76,26 @@ class VehicleFilter extends Filter
         );
     }
 
-    public function vendor(?string $vendorId)
+    public function vendor(?string $vendor)
     {
-        $this->builder->whereHas(
-            'vendor',
-            function ($query) use ($vendorId) {
-                $query->where('uuid', $vendorId);
-            }
-        );
+        if (!$vendor) {
+            return;
+        }
+
+        $this->builder->whereIn('vendor_uuid', Vendor::query()
+            ->where('company_uuid', $this->session->get('company'))
+            ->where(function ($query) use ($vendor) {
+                $query->where('public_id', $vendor);
+
+                if (in_array('internal_id', (new Vendor())->getFillable())) {
+                    $query->orWhere('internal_id', $vendor);
+                }
+
+                if (Http::isInternalRequest($this->request)) {
+                    $query->orWhere('uuid', $vendor);
+                }
+            })
+            ->pluck('uuid'));
     }
 
     public function driverUuid(?string $driverId)

--- a/server/tests/ControllerFilterContractsTest.php
+++ b/server/tests/ControllerFilterContractsTest.php
@@ -470,7 +470,7 @@ test('vehicle filter records identity relationship fleet and telematic filters',
     $filter->vehicleModel('Sprinter');
     $filter->vehicleYear('2026');
     $filter->driver('unassigned');
-    $filter->vendor('vendor-uuid');
+    $filter->vendor(null);
     $filter->driverUuid('driver-uuid');
     $filter->fleet('fleet-uuid');
     $filter->assignedFleet('false');
@@ -490,7 +490,7 @@ test('vehicle filter records identity relationship fleet and telematic filters',
         ->and($query->calls)->toContain(['whereDoesntHave', 'driver'])
         ->and($query->calls)->toContain(['whereDoesntHave', 'fleets']);
 
-    expect(collect($query->calls)->where(0, 'whereHas')->pluck(1)->all())->toContain('vendor', 'driver', 'fleets', 'devices')
+    expect(collect($query->calls)->where(0, 'whereHas')->pluck(1)->all())->toContain('driver', 'fleets', 'devices')
         ->and(collect($query->calls)->where(0, 'whereBetween')->values())->toHaveCount(1)
         ->and(collect($query->calls)->where(0, 'whereDate')->values())->toHaveCount(1);
 });
@@ -1222,13 +1222,13 @@ test('place filter alternate date branches and spatial area scopes execute', fun
 });
 
 test('vehicle and fuel report filters cover alternate identity and date branches', function () {
-    // Vehicle filter: unassigned drivers, vendor scoping, inverse date branches,
-    // fleet unassignment and blank telematic early return
+    // Vehicle filter: unassigned drivers, blank vendor early return, inverse date
+    // branches, fleet unassignment and blank telematic early return
     $query  = new FleetOpsControllerFilterQuery();
     $filter = fleetopsFilterWithBuilder(VehicleFilter::class, $query);
     $filter->driver('unassigned');
     $filter->driver('c4c4c4c4-4444-4444-8444-444444444444');
-    $filter->vendor('vendor-uuid-1');
+    $filter->vendor(null);
     $filter->createdAt('2026-02-01');
     $filter->updatedAt(['2026-01-01', '2026-01-31']);
     $filter->assignedFleet('false');

--- a/server/tests/Feature/Http/Api/VehicleControllerTrackingTest.php
+++ b/server/tests/Feature/Http/Api/VehicleControllerTrackingTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Fleetbase\FleetOps\Http\Controllers\Api\v1\VehicleController;
+use Fleetbase\FleetOps\Http\Filter\VehicleFilter;
 use Fleetbase\FleetOps\Http\Resources\v1\DeletedResource;
 use Fleetbase\FleetOps\Http\Resources\v1\Vehicle as VehicleResource;
 use Fleetbase\FleetOps\Jobs\CheckGeofenceDwell;
@@ -137,7 +138,7 @@ function fleetopsApiVehicleTrackingBoot(): SQLiteConnection
         'vehicles'                => ['uuid', 'public_id', 'internal_id', 'company_uuid', 'driver_uuid', 'vendor_uuid', 'status', 'make', 'model', 'plate_number', 'location', 'latitude', 'longitude', 'altitude', 'heading', 'speed', 'avatar_url', 'type', 'year', 'trim', 'vin', 'online'],
         'drivers'                 => ['uuid', 'public_id', 'internal_id', 'company_uuid', 'user_uuid', 'vehicle_uuid', 'status'],
         'users'                   => ['uuid', 'public_id', 'company_uuid'],
-        'vendors'                 => ['uuid', 'public_id', 'company_uuid', 'name'],
+        'vendors'                 => ['uuid', 'public_id', 'internal_id', 'company_uuid', 'name'],
         'vehicle_geofence_states' => ['vehicle_uuid', 'geofence_uuid', 'geofence_type', 'is_inside', 'entered_at', 'exited_at', 'dwell_job_id'],
         'directives'              => ['uuid', 'company_uuid', 'permission_uuid', 'subject_type', 'subject_uuid', 'key', 'rules'],
     ];
@@ -341,42 +342,72 @@ test('lookup create and response helpers execute their real implementations', fu
 test('query vehicles helper filters by vendor through the request pipeline', function () {
     $connection = fleetopsApiVehicleTrackingBoot();
     $connection->table('vehicles')->insert(['uuid' => 'vehicle-1', 'public_id' => 'vehicle_test', 'company_uuid' => 'company-1', 'vendor_uuid' => 'vendor-1']);
-    $connection->table('vendors')->insert(['uuid' => 'vendor-1', 'public_id' => 'vendor_test', 'company_uuid' => 'company-1', 'name' => 'Acme']);
+    $connection->table('vehicles')->insert(['uuid' => 'vehicle-2', 'public_id' => 'vehicle_other', 'company_uuid' => 'company-1', 'vendor_uuid' => 'vendor-2']);
+    $connection->table('vendors')->insert(['uuid' => 'vendor-1', 'public_id' => 'vendor_test', 'internal_id' => 'ACME-1', 'company_uuid' => 'company-1', 'name' => 'Acme']);
+    $connection->table('vendors')->insert(['uuid' => 'vendor-2', 'public_id' => 'vendor_other', 'internal_id' => 'OTHER-1', 'company_uuid' => 'company-1', 'name' => 'Other']);
 
-    $request = Request::create('/v1/vehicles', 'GET');
-    $store   = app('session.store');
-    $store->put('company', 'company-1');
-    $request->setLaravelSession($store);
-    $request->setRouteResolver(fn () => new class {
-        public function getAction($key = null)
-        {
-            return VehicleController::class . '@query';
-        }
+    $probe   = new FleetOpsApiVehicleTrackingProbe();
+    $request = function (array $parameters, string $uri = 'v1/vehicles') {
+        $request = Request::create('/' . $uri, 'GET', $parameters);
+        $store   = app('session.store');
+        $store->put('company', 'company-1');
+        $request->setLaravelSession($store);
+        $request->setRouteResolver(fn () => new class($uri) {
+            public function __construct(private string $uri)
+            {
+            }
 
-        public function getActionMethod()
-        {
-            return 'query';
-        }
+            public function getAction($key = null)
+            {
+                return VehicleController::class . '@query';
+            }
 
-        public function uri()
-        {
-            return 'v1/vehicles';
-        }
+            public function getActionMethod()
+            {
+                return 'query';
+            }
 
-        public function getName()
-        {
-            return 'api.v1.vehicles.query';
-        }
+            public function uri()
+            {
+                return $this->uri;
+            }
 
-        public function parameters()
-        {
-            return [];
-        }
-    });
+            public function getName()
+            {
+                return 'api.v1.vehicles.query';
+            }
 
-    $results = (new FleetOpsApiVehicleTrackingProbe())->callProtected('queryVehicles', [$request]);
+            public function parameters()
+            {
+                return [];
+            }
+        });
 
-    expect($results->count())->toBe(1);
+        return $request;
+    };
+
+    $query = fn (array $parameters) => $probe->callProtected('queryVehicles', [$request($parameters)]);
+
+    // no vendor constraint returns every vehicle for the company
+    expect($query([])->count())->toBe(2);
+
+    // the public API identifies a vendor by its public id or internal id
+    expect($query(['vendor' => 'vendor_test'])->pluck('uuid')->all())->toBe(['vehicle-1'])
+        ->and($query(['vendor' => 'ACME-1'])->pluck('uuid')->all())->toBe(['vehicle-1'])
+        ->and($query(['vendor' => 'vendor_other'])->pluck('uuid')->all())->toBe(['vehicle-2']);
+
+    // a uuid is not a public identifier, and unknown identifiers match nothing
+    expect($query(['vendor' => 'vendor-1'])->count())->toBe(0)
+        ->and($query(['vendor' => 'nope'])->count())->toBe(0);
+
+    // internal routes keep accepting the uuid the management console sends
+    $internal = fn (string $vendor) => (new VehicleFilter($request(['vendor' => $vendor], 'int/v1/vehicles')))
+        ->apply(Vehicle::query())
+        ->pluck('uuid')
+        ->all();
+
+    expect($internal('vendor-1'))->toBe(['vehicle-1'])
+        ->and($internal('vendor_test'))->toBe(['vehicle-1']);
 });
 
 test('track appends current order context and reports geofence failures to sentry', function () {


### PR DESCRIPTION
## Problem

`GET /v1/vehicles?vendor=...` can never return results.

Two constraints were ANDed onto the same request parameter:

- `queryVehicles()` added `whereHas('vendor', fn ($q) => $q->where('public_id', $request->input('vendor')))`
- `VehicleFilter::vendor()` added `whereHas('vendor', fn ($q) => $q->where('uuid', $vendorId))`

`searchBuilder()` applies the filter before the controller's query callback runs, so both land on the same builder. A vendor's `uuid` and `public_id` are never the same value in production, so the parameter matches nothing.

## Fix

Drop the redundant `whereHas` from `queryVehicles()`, and widen `VehicleFilter::vendor` to resolve the identifier the same way `PartFilter::vendor` already does:

- public id or internal id on any request
- uuid additionally on internal routes

The internal management console sends the vendor uuid (the internal `Vendor` resource exposes `uuid` as its `id`), so the uuid branch is kept behind `Http::isInternalRequest` to avoid regressing it. The lookup is also company-scoped, consistent with `PartFilter`.

## Tests

The pipeline test in `VehicleControllerTrackingTest` was named "filters by vendor" but passed no `vendor` parameter at all, so it never exercised the conflict — it asserted a count of 1 against a single unconstrained row. It now runs against two vendors and two vehicles and covers:

- no vendor constraint returns both vehicles
- public id and internal id each resolve to the right vehicle
- a uuid is rejected on the public route, and an unknown identifier matches nothing
- an internal route still resolves the uuid (asserted at the filter level, because the internal pipeline routes through `fastPaginate()`, which the SQLite harness does not provide)

`ControllerFilterContractsTest` drove the old `whereHas` shape with a fake builder; the resolved branch now needs a database, so those two call sites move to the blank-vendor early return — the same way `PartFilter::vendor` is asserted in that file. Every line of the new filter body is covered across the two files (slice-verified).

## Verification

- Full server suite run per-file. The only failures are three pre-existing ones that reproduce identically on a clean baseline: `ContactControllerEndpointsTest`, `OrderControllerUpstreamNotFoundTest` (fails by design until core-api 1.6.55 ships), and `PlaceGeocodingResultsTest`.
- `php-cs-fixer` clean on all four files.
- PHPStan findings on the two changed source files are byte-identical before and after the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)