### PR TITLE
fix(api): register device without an id + default device last_position

### DIFF
--- a/server/src/Http/Controllers/Api/v1/DriverController.php
+++ b/server/src/Http/Controllers/Api/v1/DriverController.php
@@ -436,10 +436,13 @@ class DriverController extends Controller
      *
      * @return \Illuminate\Http\Response
      */
-    public function registerDevice(string $id, Request $request)
+    public function registerDevice(?string $id = null, ?Request $request = null)
     {
         try {
-            $driver = $this->findDriver($id);
+            // With an id (…/{id}/register-device) look the driver up directly; without
+            // one (…/register-device and the internal delegation) resolve the driver
+            // from the authenticated user.
+            $driver = $id ? $this->findDriver($id) : $this->currentDriver($request);
         } catch (\Illuminate\Database\Eloquent\ModelNotFoundException $exception) {
             return $this->jsonResponse(
                 [
@@ -947,6 +950,17 @@ class DriverController extends Controller
     protected function findDriver(string $id, array $with = []): Driver
     {
         return Driver::findRecordOrFail($id, $with);
+    }
+
+    /**
+     * Resolve the driver for the authenticated request (used when no explicit
+     * driver id is supplied, e.g. a driver-authenticated session).
+     *
+     * @throws \Illuminate\Database\Eloquent\ModelNotFoundException
+     */
+    protected function currentDriver(?Request $request): Driver
+    {
+        return Driver::where('user_uuid', optional(optional($request)->user())->uuid)->firstOrFail();
     }
 
     protected function queryDrivers(Request $request)

--- a/server/src/Http/Controllers/Internal/v1/DriverController.php
+++ b/server/src/Http/Controllers/Internal/v1/DriverController.php
@@ -605,7 +605,8 @@ class DriverController extends FleetOpsController
      */
     public function registerDevice(Request $request)
     {
-        return app(ApiDriverController::class)->registerDevice($request);
+        // The public controller resolves the driver from the request when no id is given.
+        return app(ApiDriverController::class)->registerDevice(null, $request);
     }
 
     /**

--- a/server/src/Models/Device.php
+++ b/server/src/Models/Device.php
@@ -176,6 +176,24 @@ class Device extends Model
     ];
 
     /**
+     * Bootstrap the model.
+     *
+     * Devices require a non-null spatial `last_position` (the column is NOT NULL
+     * to support its spatial index), so default it to POINT(0,0) on create when
+     * the caller hasn't provided a position.
+     */
+    protected static function boot()
+    {
+        parent::boot();
+
+        static::creating(function (self $device) {
+            if (empty($device->last_position)) {
+                $device->last_position = new SpatialPoint(0, 0);
+            }
+        });
+    }
+
+    /**
      * Properties which activity needs to be logged.
      *
      * @var array

--- a/server/tests/ApiDriverControllerContractsTest.php
+++ b/server/tests/ApiDriverControllerContractsTest.php
@@ -113,6 +113,17 @@ class FleetOpsApiDriverControllerProbe extends DriverController
         return $this->driver;
     }
 
+    protected function currentDriver(?Request $request): Driver
+    {
+        $this->findCalls[] = ['current', $request];
+
+        if ($this->driverNotFound) {
+            throw new ModelNotFoundException();
+        }
+
+        return $this->driver ??= new FleetOpsApiDriverFake();
+    }
+
     protected function queryDrivers(Request $request)
     {
         return $this->queryResults ?? [['uuid' => 'driver-uuid']];
@@ -517,6 +528,28 @@ test('api driver controller registers devices and validates required inputs', fu
         ]);
 });
 
+test('api driver controller registers a device for the authenticated driver without an id', function () {
+    $driver = new FleetOpsApiDriverFake();
+    $driver->setRawAttributes([
+        'uuid'      => 'driver-uuid',
+        'public_id' => 'driver_public',
+        'user_uuid' => 'user-uuid',
+    ], true);
+
+    $controller         = new FleetOpsApiDriverControllerProbe();
+    $controller->driver = $driver;
+
+    $response = $controller->registerDevice(null, new FleetOpsApiDriverRegisterDeviceRequest([
+        'token'    => 'push-token',
+        'platform' => 'ios',
+    ]));
+
+    expect($response)->toBe([
+        'json'   => ['device' => 'device_public'],
+        'status' => 200,
+    ]);
+});
+
 test('api driver controller reports missing driver branches', function () {
     $controller                 = new FleetOpsApiDriverControllerProbe();
     $controller->driverNotFound = true;
@@ -530,6 +563,7 @@ test('api driver controller reports missing driver branches', function () {
         ->and($controller->delete('missing-driver', new Request()))->toBe($json404)
         ->and($controller->toggleOnline('missing-driver', new Request()))->toBe($json404)
         ->and($controller->registerDevice('missing-driver', new FleetOpsApiDriverRegisterDeviceRequest()))->toBe($json404)
+        ->and($controller->registerDevice(null, new FleetOpsApiDriverRegisterDeviceRequest()))->toBe($json404)
         ->and($controller->track('missing-driver', new Request(['latitude' => 1, 'longitude' => 2])))->toBe([
             'apiError' => 'Driver resource not found.',
             'status'   => 404,


### PR DESCRIPTION
## Summary

Fixes two public-API `500`s surfaced by the Postman API contract run against a live stack (both verified against a running instance).

### 1. `POST /v1/drivers/register-device` — `ArgumentCountError` (500)
`Api\v1\DriverController::registerDevice(string $id, Request $request)` required an `$id`, but two call sites never provide one:
- the `drivers/register-device` route (no `{id}` segment), and
- the internal delegation `Internal\v1\DriverController::registerDevice()` → `app(ApiDriverController::class)->registerDevice($request)`.

Both passed a single argument → `ArgumentCountError`. Fix:
- `registerDevice(?string $id = null, ?Request $request = null)` — with an id it looks the driver up directly; without one it resolves the driver from the authenticated user via a new `currentDriver()` seam.
- The internal delegation now calls `registerDevice(null, $request)`.

The `{id}/register-device` route and all existing positional test calls (`registerDevice('id', $request)`) are unchanged.

### 2. `POST /v1/devices` — `Field 'last_position' doesn't have a default value` (500)
`devices.last_position` is `NOT NULL` (to support its spatial index) with no default, so every insert failed. `Device::boot()` now defaults it to `POINT(0,0)` on create when the caller hasn't supplied a position.

## Tests
- `ApiDriverControllerContractsTest`: added a `currentDriver()` override to the probe and covered the no-id register-device **happy path** (→ 200) and **missing-driver** branch (→ 404).

## ⚠️ Validation note
I could **not run pest locally** to confirm the 100%-coverage gate (local PHP is 8.2 and the suite/deps target 8.4 — the run is drowned in deprecation notices with no usable test output). Both fixes are **runtime-verified** against a live stack, and the probe-level branches are covered, but please let CI confirm coverage — in particular the **real** `currentDriver()` resolver and `Device::boot()` may need DB-backed Feature-test coverage that I couldn't author blind. Happy to iterate against the CI result.

Verified live: `/v1/drivers/register-device` → 404 (was 500), `/v1/devices` → 200 (was 500). (A third fix from the same investigation — the geofence-inventory `d.name`→`u.name` join — is already on `dev-v0.6.59`.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
