### PR TITLE
ci: fix the Postman contract and track the latest release automatically

### DIFF
--- a/.github/workflows/postman.yml
+++ b/.github/workflows/postman.yml
@@ -4,9 +4,15 @@ name: API Contract (Postman)
 # collection against the live API. Delegates to the reusable workflow in
 # fleetbase/fleetbase. Requires org secrets POSTMAN_API_KEY + _GITHUB_AUTH_TOKEN
 # (inherited); no-ops until POSTMAN_API_KEY is set.
-# Pinned to the v0.7.53 release tag: that is the commit fleetbase/fleetbase-api:v0.7.53
-# was built from, so the booted stack and the published image match. Bump both refs
-# together at each release.
+#
+# Deliberately unpinned. The reusable workflow defaults to booting fleetbase/fleetbase@main
+# against fleetbase/fleetbase-api:latest, so every release is picked up automatically and
+# there is no ref here to remember to bump. Each run records the image digest it actually
+# resolved in its job summary, so a result stays traceable. To reproduce an older run:
+#
+#   with:
+#     fleetbase-ref: v0.7.53
+#     api-image: fleetbase/fleetbase-api:v0.7.53
 
 on:
   push:
@@ -20,9 +26,8 @@ permissions:
 
 jobs:
   contract:
-    uses: fleetbase/fleetbase/.github/workflows/api-contract.yml@v0.7.53
+    uses: fleetbase/fleetbase/.github/workflows/api-contract.yml@main
     with:
       collections: "Fleetbase API"
       build-from-source: false
-      fleetbase-ref: v0.7.53
     secrets: inherit

--- a/.github/workflows/postman.yml
+++ b/.github/workflows/postman.yml
@@ -4,7 +4,9 @@ name: API Contract (Postman)
 # collection against the live API. Delegates to the reusable workflow in
 # fleetbase/fleetbase. Requires org secrets POSTMAN_API_KEY + _GITHUB_AUTH_TOKEN
 # (inherited); no-ops until POSTMAN_API_KEY is set.
-# TODO: change @dev-v0.7.53 to @main once that branch is merged.
+# Pinned to the v0.7.53 release tag: that is the commit fleetbase/fleetbase-api:v0.7.53
+# was built from, so the booted stack and the published image match. Bump both refs
+# together at each release.
 
 on:
   push:
@@ -18,8 +20,9 @@ permissions:
 
 jobs:
   contract:
-    uses: fleetbase/fleetbase/.github/workflows/api-contract.yml@dev-v0.7.53
+    uses: fleetbase/fleetbase/.github/workflows/api-contract.yml@v0.7.53
     with:
       collections: "Fleetbase API"
       build-from-source: false
+      fleetbase-ref: v0.7.53
     secrets: inherit


### PR DESCRIPTION
Fixes the Postman contract CI now that the v0.7.53 images have published — and, after [fleetbase/fleetbase#578](https://github.com/fleetbase/fleetbase/pull/578) merged, without pinning a version at all.

```yaml
jobs:
  contract:
    uses: fleetbase/fleetbase/.github/workflows/api-contract.yml@main
    with:
      collections: "Fleetbase API"
      build-from-source: false
    secrets: inherit
```

The reusable workflow now defaults `fleetbase-ref` to `main` and tests against `fleetbase/fleetbase-api:latest`, so each release is picked up automatically and there is no ref in this repo to remember to bump. The tradeoff of a floating tag is reproducibility, which the upstream run covers by recording the resolved image digest and build date in its job summary.

To reproduce an older result, pass both explicitly:

```yaml
    with:
      fleetbase-ref: v0.7.53
      api-image: fleetbase/fleetbase-api:v0.7.53
```

That same upstream PR also made the run visible — collection output is no longer collapsed inside `::group::`, the job summary carries a per-collection table of requests/assertions/failures, and full logs upload as a `postman-results` artifact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)