### PR TITLE
fix(api): answer 404 instead of 500 for an unknown onboard organization

### DIFF
--- a/server/src/Http/Controllers/Api/v1/NavigatorController.php
+++ b/server/src/Http/Controllers/Api/v1/NavigatorController.php
@@ -10,25 +10,21 @@ use Illuminate\Http\JsonResponse;
 class NavigatorController extends Controller
 {
     /**
-     * Retrieve the driver onboard settings.
+     * Retrieve the driver onboard settings for an organization.
      *
-     * This method retrieves the driver onboard settings for the current company session. If no company session
-     * is found in the request, an error response is returned. The method retrieves the company ID from the session,
-     * then fetches the saved driver onboard settings. If settings for the current company are found, they are returned,
-     * otherwise, default settings are provided.
-     *
-     * @return JsonResponse
-     */
-
-    /**
-     * Retrieve driver onboard settings.
+     * The organization is resolved from its public id. An unknown public id is a client
+     * error, not a server error, so it answers 404 rather than dereferencing a null company.
      *
      * @return JsonResponse
      */
     public function getDriverOnboardSettings($companyId)
     {
-        $company                = $this->findCompanyByPublicId($companyId);
-        $driverOnboardSettings  = $this->driverOnboardSetting($company->uuid);
+        $company = $this->findCompanyByPublicId($companyId);
+        if (!$company) {
+            return $this->errorResponse('Organization not found.', 404);
+        }
+
+        $driverOnboardSettings = $this->driverOnboardSetting($company->uuid);
         if (!$driverOnboardSettings) {
             $driverOnboardSettings = [];
         }
@@ -49,5 +45,10 @@ class NavigatorController extends Controller
     protected function jsonResponse(array $payload): JsonResponse
     {
         return response()->json($payload);
+    }
+
+    protected function errorResponse(string $message, int $statusCode): JsonResponse
+    {
+        return response()->error($message, $statusCode);
     }
 }

--- a/server/tests/SmallControllerContractsTest.php
+++ b/server/tests/SmallControllerContractsTest.php
@@ -227,17 +227,28 @@ class FleetOpsGettingStartedControllerProbe extends GettingStartedController
 
 class FleetOpsPublicNavigatorControllerProbe extends PublicNavigatorController
 {
-    public mixed $settings = ['require_photo' => true];
-    public array $lookups  = [];
+    public mixed $settings   = ['require_photo' => true];
+    public array $lookups    = [];
+    public bool $companyMiss = false;
 
     protected function findCompanyByPublicId(string $companyId): ?Company
     {
+        $this->lookups[] = $companyId;
+
+        // Mirrors the real lookup returning null for an unknown public id.
+        if ($this->companyMiss) {
+            return null;
+        }
+
         $company = new Company();
         $company->setRawAttributes(['uuid' => 'company-uuid', 'public_id' => $companyId], true);
 
-        $this->lookups[] = $companyId;
-
         return $company;
+    }
+
+    protected function errorResponse(string $message, int $statusCode): JsonResponse
+    {
+        return new JsonResponse(['errors' => [$message]], $statusCode);
     }
 
     protected function driverOnboardSetting(string $companyUuid): mixed
@@ -410,6 +421,19 @@ test('public navigator controller returns configured or default driver onboardin
             'company_public',
             'company-uuid',
         ]);
+});
+
+test('public navigator controller answers 404 for an organization public id that does not resolve', function () {
+    $controller               = new FleetOpsPublicNavigatorControllerProbe();
+    $controller->companyMiss  = true;
+
+    $response = $controller->getDriverOnboardSettings('company_does_not_exist');
+
+    // Regression: the unresolved company used to be dereferenced anyway, which threw a
+    // TypeError out of the controller and rendered an HTML stack trace with a 500.
+    expect($response->getStatusCode())->toBe(404)
+        ->and($response->getData(true))->toBe(['errors' => ['Organization not found.']])
+        ->and($controller->lookups)->toBe(['company_does_not_exist']);
 });
 
 test('public contact controller normalizes create input and preserves update fields', function () {

--- a/server/tests/Unit/Jobs/GeofenceDwellAndBulkNotifyTest.php
+++ b/server/tests/Unit/Jobs/GeofenceDwellAndBulkNotifyTest.php
@@ -180,4 +180,11 @@ test('navigator driver onboard settings endpoint resolves company settings', fun
     $connection->table('companies')->insert(['uuid' => 'company-2', 'public_id' => 'company_two', 'name' => 'Beta']);
     $empty = (new NavigatorController())->getDriverOnboardSettings('company_two');
     expect($empty->getData(true)['driverOnboardSettings'])->toBe([]);
+
+    // An unresolved public id is a client error. This drives the real
+    // errorResponse() seam, which the probe in SmallControllerContractsTest
+    // replaces — only the status is asserted, because the harness `response()`
+    // shim envelopes errors differently from the core-api macro it stands in for.
+    $missing = (new NavigatorController())->getDriverOnboardSettings('company_missing');
+    expect($missing->getStatusCode())->toBe(404);
 });


### PR DESCRIPTION
## Problem

`GET /v1/onboard/driver-onboard-settings/{companyId}` returned **HTTP 500 with a ~1.2 MB HTML stack trace**.

`getDriverOnboardSettings()` passed `findCompanyByPublicId()` straight into `driverOnboardSetting()` without checking it. The lookup is declared `?Company` — the null return is deliberate — but the call site never guarded it, so `null->uuid` yielded `null`, which hit the `string` type declaration and threw:

```
TypeError: Fleetbase\FleetOps\Http\Controllers\Api\v1\NavigatorController::driverOnboardSetting():
Argument #1 ($companyUuid) must be of type string, null given
```

Reproduced against a live stack:

| Path variable | Before | After |
|---|---|---|
| valid `company_hfUOJNWBuO` | 200 JSON | 200 JSON (unchanged) |
| bogus `company_DOESNOTEXIST` | 500, `text/html`, 1,190,813 b | 404 JSON |
| literal `{{organization_id}}` | 500, `text/html`, 1,193,751 b | 404 JSON |

The failure was **independent of the unresolved Postman variable** — any public id that does not resolve produced it.

## Change

Guard the null and return 404 via a new `errorResponse()` seam, matching the protected-seam style the rest of this controller already uses (`jsonResponse`, `findCompanyByPublicId`, `driverOnboardSetting`).

## Test coverage

`FleetOpsPublicNavigatorControllerProbe` overrode `findCompanyByPublicId()` to *always* return a hydrated `Company`, so the null branch was unreachable — which is why this shipped. The probe can now be made to miss, and a regression test pins the 404 and its error envelope.

## Related

The HTML-instead-of-JSON rendering is a separate, broader defect in the API exception handler — any unlisted exception on any `/v1/*` route leaks the same way (confirmed on `PUT /v1/orders`). Fixed separately in fleetbase/core-api.

## Verification status

⚠️ **Not verified locally** — the dev stack was down when this was committed, so the three cases above are unrun against the fix. The reproduction numbers are real (captured pre-fix). CI is the first real run.

To verify once a stack is up:

```bash
K=<api_key>; for P in 'company_hfUOJNWBuO' 'company_DOESNOTEXIST'; do curl -s -H "Authorization: Bearer $K" -w ' <- %{http_code} %{content_type}\n' "http://localhost:8000/v1/onboard/driver-onboard-settings/$P"; done
```

The unit test also has not been run locally — it needs a real 542 MB `server_vendor` copy in the worktree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)