### PR TITLE
fix(api): return 422 instead of 500 on duplicate part SKU and fuel transaction id

### DIFF
--- a/server/migrations/2026_08_08_000001_make_sku_and_provider_transaction_unique_indexes_soft_delete_aware.php
+++ b/server/migrations/2026_08_08_000001_make_sku_and_provider_transaction_unique_indexes_soft_delete_aware.php
@@ -1,0 +1,152 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Both `parts` and `fuel_provider_transactions` soft-delete, but their unique
+ * indexes were not soft-delete aware.  A deleted row kept occupying the key, so
+ * re-creating a Part with a previously used SKU (or re-ingesting a fuel provider
+ * transaction that had been deleted) raised a UniqueConstraintViolationException.
+ * On the public v1 API that surfaced as an HTTP 500, and because there is no
+ * restore/force-delete route the key was unusable from then on.
+ *
+ * The fix follows the pattern already used for alrashed contract numbers in
+ * 2026_05_25_000001_make_contract_number_unique_for_active_contracts: a STORED
+ * generated column that is NULL for soft-deleted rows.  MySQL permits any number
+ * of NULLs in a unique index, so tombstones stop colliding while live rows stay
+ * constrained.
+ *
+ * `fuel_provider_transactions` additionally gains `company_uuid` in the key.  The
+ * old index was global, so one company's provider transaction id blocked — or,
+ * via FuelProviderService::ingestTransaction()'s updateOrCreate, silently
+ * overwrote — another company's.  Provider transaction ids are only unique within
+ * the account they were issued for, so the key belongs per tenant.
+ *
+ * Both new indexes are strictly more permissive than the ones they replace, so no
+ * existing row can violate them and no backfill is required.
+ */
+return new class extends Migration {
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        // ---- parts: (company_uuid, sku) -> (company_uuid, active_sku) ----
+        if (!Schema::hasColumn('parts', 'active_sku')) {
+            Schema::table('parts', function (Blueprint $table) {
+                $table->string('active_sku')->nullable()->storedAs('IF(`deleted_at` IS NULL, `sku`, NULL)');
+            });
+        }
+
+        // The replacement index MUST be created before the old one is dropped:
+        // parts_company_uuid_sku_unique is currently the only index covering
+        // company_uuid, and parts_company_uuid_foreign depends on it. Adding an
+        // index that also leads with company_uuid lets it take over as the
+        // covering index, otherwise the drop below fails with errno 150.
+        if (!$this->indexExists('parts', 'parts_company_uuid_active_sku_unique')) {
+            Schema::table('parts', function (Blueprint $table) {
+                $table->unique(['company_uuid', 'active_sku'], 'parts_company_uuid_active_sku_unique');
+            });
+        }
+
+        if ($this->indexExists('parts', 'parts_company_uuid_sku_unique')) {
+            Schema::table('parts', function (Blueprint $table) {
+                $table->dropUnique('parts_company_uuid_sku_unique');
+            });
+        }
+
+        // ---- fuel_provider_transactions: (provider, provider_transaction_id)
+        //      -> (company_uuid, provider, active_provider_transaction_id) ----
+        if (!Schema::hasColumn('fuel_provider_transactions', 'active_provider_transaction_id')) {
+            Schema::table('fuel_provider_transactions', function (Blueprint $table) {
+                $table->string('active_provider_transaction_id', 191)->nullable()->storedAs('IF(`deleted_at` IS NULL, `provider_transaction_id`, NULL)');
+            });
+        }
+
+        if (!$this->indexExists('fuel_provider_transactions', 'fuel_provider_txn_company_provider_unique')) {
+            Schema::table('fuel_provider_transactions', function (Blueprint $table) {
+                $table->unique(['company_uuid', 'provider', 'active_provider_transaction_id'], 'fuel_provider_txn_company_provider_unique');
+            });
+        }
+
+        if ($this->indexExists('fuel_provider_transactions', 'fuel_provider_txn_provider_unique')) {
+            Schema::table('fuel_provider_transactions', function (Blueprint $table) {
+                $table->dropUnique('fuel_provider_txn_provider_unique');
+            });
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * Restoring the old global index can fail if rows now exist that only the new
+     * key permits (two tenants sharing a provider transaction id, or a live row
+     * whose SKU matches a soft-deleted one). That is inherent to reversing a
+     * relaxed constraint, so the old indexes are restored on a best-effort basis
+     * and the generated columns are dropped either way.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        if (!$this->indexExists('parts', 'parts_company_uuid_sku_unique')) {
+            try {
+                Schema::table('parts', function (Blueprint $table) {
+                    $table->unique(['company_uuid', 'sku'], 'parts_company_uuid_sku_unique');
+                });
+            } catch (Throwable $e) {
+                // Duplicate SKUs the new index allowed now block the old one.
+            }
+        }
+
+        if ($this->indexExists('parts', 'parts_company_uuid_active_sku_unique')) {
+            Schema::table('parts', function (Blueprint $table) {
+                $table->dropUnique('parts_company_uuid_active_sku_unique');
+            });
+        }
+
+        if (Schema::hasColumn('parts', 'active_sku')) {
+            Schema::table('parts', function (Blueprint $table) {
+                $table->dropColumn('active_sku');
+            });
+        }
+
+        if (!$this->indexExists('fuel_provider_transactions', 'fuel_provider_txn_provider_unique')) {
+            try {
+                Schema::table('fuel_provider_transactions', function (Blueprint $table) {
+                    $table->unique(['provider', 'provider_transaction_id'], 'fuel_provider_txn_provider_unique');
+                });
+            } catch (Throwable $e) {
+                // Cross-tenant duplicates the new index allows now block the old one.
+            }
+        }
+
+        if ($this->indexExists('fuel_provider_transactions', 'fuel_provider_txn_company_provider_unique')) {
+            Schema::table('fuel_provider_transactions', function (Blueprint $table) {
+                $table->dropUnique('fuel_provider_txn_company_provider_unique');
+            });
+        }
+
+        if (Schema::hasColumn('fuel_provider_transactions', 'active_provider_transaction_id')) {
+            Schema::table('fuel_provider_transactions', function (Blueprint $table) {
+                $table->dropColumn('active_provider_transaction_id');
+            });
+        }
+    }
+
+    private function indexExists(string $table, string $index): bool
+    {
+        $database = DB::connection()->getDatabaseName();
+
+        return DB::table('information_schema.statistics')
+            ->where('table_schema', $database)
+            ->where('table_name', $table)
+            ->where('index_name', $index)
+            ->exists();
+    }
+};

--- a/server/src/Http/Requests/CreateFuelTransactionRequest.php
+++ b/server/src/Http/Requests/CreateFuelTransactionRequest.php
@@ -2,6 +2,7 @@
 
 namespace Fleetbase\FleetOps\Http\Requests;
 
+use Fleetbase\FleetOps\Models\FuelProviderTransaction;
 use Fleetbase\Http\Requests\FleetbaseRequest;
 use Illuminate\Validation\Rule;
 
@@ -16,7 +17,7 @@ class CreateFuelTransactionRequest extends FleetbaseRequest
     {
         return [
             'provider'                => [Rule::requiredIf($this->isMethod('POST')), 'string'],
-            'provider_transaction_id' => [Rule::requiredIf($this->isMethod('POST')), 'string'],
+            'provider_transaction_id' => [Rule::requiredIf($this->isMethod('POST')), 'string', $this->uniqueProviderTransactionIdRule()],
             'connection'              => ['nullable', 'string'],
             'fuel_report'             => ['nullable', 'string'],
             'vehicle'                 => ['nullable', 'string'],
@@ -46,5 +47,67 @@ class CreateFuelTransactionRequest extends FleetbaseRequest
             'raw_payload'             => ['nullable', 'array'],
             'meta'                    => ['nullable', 'array'],
         ];
+    }
+
+    public function messages(): array
+    {
+        return [
+            'provider_transaction_id.unique' => 'A fuel transaction with this provider transaction id already exists for this provider.',
+        ];
+    }
+
+    /**
+     * Mirrors the fuel_provider_txn_company_provider_unique index.
+     *
+     * Provider transaction ids are natural idempotency keys, so a re-sent batch
+     * used to raise an unhandled UniqueConstraintViolationException — an HTTP 500
+     * rather than a duplicate signal the client could act on.
+     *
+     * @return \Illuminate\Validation\Rules\Unique
+     */
+    protected function uniqueProviderTransactionIdRule()
+    {
+        $provider = $this->resolveProvider();
+
+        $rule = Rule::unique('fuel_provider_transactions', 'provider_transaction_id')
+            ->where(function ($query) use ($provider) {
+                $query->where('company_uuid', session('company'));
+                $query->where('provider', $provider);
+
+                return $query->whereNull('deleted_at');
+            });
+
+        // On PUT the record re-sends its own provider_transaction_id. The v1 route
+        // parameter is a public_id (fuel_provider_transaction_xxxxx), not a uuid.
+        $id = $this->route('id');
+        if (!$this->isMethod('POST') && filled($id)) {
+            $rule->ignore($id, 'public_id');
+        }
+
+        return $rule;
+    }
+
+    /**
+     * The uniqueness scope is per provider, but `provider` is only required on
+     * POST — a PUT may change the transaction id while leaving the provider out of
+     * the body. Fall back to the stored value so the scope is never null, which
+     * would otherwise compare against the wrong set of rows.
+     */
+    protected function resolveProvider(): ?string
+    {
+        if ($this->filled('provider')) {
+            return $this->input('provider');
+        }
+
+        $id = $this->route('id');
+        if (blank($id)) {
+            return null;
+        }
+
+        return FuelProviderTransaction::where('company_uuid', session('company'))
+            ->where(function ($query) use ($id) {
+                $query->where('public_id', $id)->orWhere('uuid', $id);
+            })
+            ->value('provider');
     }
 }

--- a/server/src/Http/Requests/CreatePartRequest.php
+++ b/server/src/Http/Requests/CreatePartRequest.php
@@ -15,7 +15,7 @@ class CreatePartRequest extends FleetbaseRequest
     public function rules(): array
     {
         return [
-            'sku'              => ['nullable', 'string'],
+            'sku'              => ['nullable', 'string', $this->uniqueSkuRule()],
             'name'             => [Rule::requiredIf($this->isMethod('POST')), 'string'],
             'manufacturer'     => ['nullable', 'string'],
             'model'            => ['nullable', 'string'],
@@ -36,5 +36,43 @@ class CreatePartRequest extends FleetbaseRequest
             'specs'            => ['nullable', 'array'],
             'meta'             => ['nullable', 'array'],
         ];
+    }
+
+    public function messages(): array
+    {
+        return [
+            'sku.unique' => 'A part with this SKU already exists.',
+        ];
+    }
+
+    /**
+     * Mirrors the parts_company_uuid_active_sku_unique index.
+     *
+     * Without this rule a duplicate SKU reached the driver and came back as an
+     * unhandled UniqueConstraintViolationException — an HTTP 500 with no field
+     * attribution, since public v1 controllers have no QueryException catch.
+     *
+     * `nullable` runs first, so this never fires on a null SKU; that matches the
+     * nullable column and MySQL's tolerance of repeated NULLs in a unique index.
+     *
+     * @return \Illuminate\Validation\Rules\Unique
+     */
+    protected function uniqueSkuRule()
+    {
+        $rule = Rule::unique('parts', 'sku')
+            ->where(function ($query) {
+                $query->where('company_uuid', session('company'));
+
+                return $query->whereNull('deleted_at');
+            });
+
+        // On PUT the record re-sends its own SKU, so it must not collide with
+        // itself. The v1 route parameter is a public_id (part_xxxxx), not a uuid.
+        $id = $this->route('id');
+        if (!$this->isMethod('POST') && filled($id)) {
+            $rule->ignore($id, 'public_id');
+        }
+
+        return $rule;
     }
 }

--- a/server/src/Support/FuelProviders/FuelProviderService.php
+++ b/server/src/Support/FuelProviders/FuelProviderService.php
@@ -173,8 +173,17 @@ class FuelProviderService
         return DB::transaction(function () use ($connection, $payload) {
             $provider              = $payload['provider'] ?? $connection->provider;
             $providerTransactionId = $payload['provider_transaction_id'];
+            // The match must include company_uuid. Provider transaction ids are only
+            // unique within the account they were issued for, so keying on
+            // (provider, provider_transaction_id) alone let one company's sync find
+            // and overwrite another company's transaction — reassigning its
+            // company_uuid. Mirrors fuel_provider_txn_company_provider_unique.
             $transaction           = FuelProviderTransaction::updateOrCreate(
-                ['provider' => $provider, 'provider_transaction_id' => $providerTransactionId],
+                [
+                    'company_uuid'            => $connection->company_uuid,
+                    'provider'                => $provider,
+                    'provider_transaction_id' => $providerTransactionId,
+                ],
                 array_merge($payload, [
                     'company_uuid'                  => $connection->company_uuid,
                     'fuel_provider_connection_uuid' => $connection->uuid,

--- a/server/tests/FuelProviderTransactionControllerContractsTest.php
+++ b/server/tests/FuelProviderTransactionControllerContractsTest.php
@@ -178,4 +178,21 @@ test('fuel provider transaction real lookup scopes identifier and company', func
 
     expect($reflection->invoke($controller, 'fpt-real-1')->public_id)->toBe('fuel_provider_transaction_real1')
         ->and($reflection->invoke($controller, 'fuel_provider_transaction_real1')->uuid)->toBe('fpt-real-1');
+
+    // resolveProvider() falls back to the stored provider when a PUT omits it, so the
+    // uniqueness scope is never null — a null scope would compare the transaction id
+    // against the wrong set of rows. Needs a real connection, which is why this lives
+    // here rather than in RequestContractsTest.
+    $resolveProvider = new ReflectionMethod(Fleetbase\FleetOps\Http\Requests\CreateFuelTransactionRequest::class, 'resolveProvider');
+    $resolveProvider->setAccessible(true);
+
+    $withRouteId = Fleetbase\FleetOps\Http\Requests\CreateFuelTransactionRequest::create('/fleetops-test', 'PUT')
+        ->setRouteResolver(fn () => new class {
+            public function parameter($key, $default = null)
+            {
+                return $key === 'id' ? 'fuel_provider_transaction_real1' : $default;
+            }
+        });
+
+    expect($resolveProvider->invoke($withRouteId))->toBe('petroapp');
 });

--- a/server/tests/RequestContractsTest.php
+++ b/server/tests/RequestContractsTest.php
@@ -76,6 +76,18 @@ namespace Illuminate\Validation {
                 return $this;
             }
 
+            /**
+             * Recorded so tests can assert the ignore-self clause on update
+             * requests, including which column it matches on — the v1 routes
+             * pass a public_id, not a uuid.
+             */
+            public function ignore($id, $idColumn = null): self
+            {
+                $this->constraints[] = ['ignore', $id, $idColumn];
+
+                return $this;
+            }
+
             public function __toString(): string
             {
                 return $this->rule;
@@ -245,11 +257,16 @@ namespace {
     });
 
     test('fuel transaction request requires provider identifiers on create', function () {
+        // The harness `session()` stand-in is a process-wide static, so seed it
+        // here rather than relying on an earlier test in the file having done so.
+        session(['company' => 'company-uuid']);
+        bindFleetOpsRequestSession(['api_credential' => 'credential-uuid', 'company' => 'company-uuid']);
+
         $createRules = requestRules(CreateFuelTransactionRequest::class);
         $patchRules  = requestRules(CreateFuelTransactionRequest::class, 'PATCH');
 
         expect(ruleStrings($createRules['provider']))->toContain('required', 'string')
-            ->and(ruleStrings($createRules['provider_transaction_id']))->toContain('required', 'string')
+            ->and(ruleStrings($createRules['provider_transaction_id']))->toContain('required', 'string', 'unique:fuel_provider_transactions,provider_transaction_id')
             ->and(ruleStrings($patchRules['provider']))->not->toContain('required')
             ->and(ruleStrings($patchRules['provider_transaction_id']))->not->toContain('required')
             ->and($createRules['station_latitude'])->toBe(['nullable', 'numeric'])
@@ -257,6 +274,19 @@ namespace {
             ->and($createRules['normalized_payload'])->toBe(['nullable', 'array'])
             ->and($createRules['raw_payload'])->toBe(['nullable', 'array'])
             ->and($createRules['meta'])->toBe(['nullable', 'array']);
+
+        // Mirrors fuel_provider_txn_company_provider_unique. The provider is part
+        // of the scope, and company_uuid is what stops one tenant's provider
+        // transaction id from colliding with another's — the old index was global.
+        $rulesWithProvider = CreateFuelTransactionRequest::create('/fleetops-test', 'POST', ['provider' => 'petroapp'])->rules();
+        $uniqueRule        = collect($rulesWithProvider['provider_transaction_id'])->first(fn ($rule) => $rule instanceof Illuminate\Validation\Rule);
+
+        expect($uniqueRule)->not->toBeNull()
+            ->and($uniqueRule->constraints)->toBe([
+                ['where', 'company_uuid', 'company-uuid'],
+                ['where', 'provider', 'petroapp'],
+                ['whereNull', 'deleted_at'],
+            ]);
     });
 
     test('vehicle and fuel report requests expose core validation contracts', function () {
@@ -649,13 +679,14 @@ namespace {
 
         expect($request->authorize())->toBeFalse();
 
-        bindFleetOpsRequestSession(['api_credential' => 'credential-uuid']);
+        session(['company' => 'company-uuid']);
+        bindFleetOpsRequestSession(['api_credential' => 'credential-uuid', 'company' => 'company-uuid']);
 
         $createRules = $request->rules();
         $patchRules  = CreatePartRequest::create('/fleetops-test', 'PATCH')->rules();
 
         expect($request->authorize())->toBeTrue()
-            ->and($createRules['sku'])->toBe(['nullable', 'string'])
+            ->and(ruleStrings($createRules['sku']))->toContain('nullable', 'string', 'unique:parts,sku')
             ->and(ruleStrings($createRules['name']))->toContain('required', 'string')
             ->and(ruleStrings($patchRules['name']))->not->toContain('required')
             ->and($createRules['manufacturer'])->toBe(['nullable', 'string'])
@@ -670,6 +701,33 @@ namespace {
             ->and($createRules['photo'])->toBe(['nullable', 'string'])
             ->and($createRules['specs'])->toBe(['nullable', 'array'])
             ->and($createRules['meta'])->toBe(['nullable', 'array']);
+
+        // The SKU uniqueness rule mirrors parts_company_uuid_active_sku_unique:
+        // scoped to the session company and ignoring soft-deleted parts, so a SKU
+        // freed by a deleted part — or held by another company — stays available.
+        // Without it a duplicate reached the driver and returned a 500.
+        $skuRule = collect($createRules['sku'])->first(fn ($rule) => $rule instanceof Illuminate\Validation\Rule);
+
+        expect($skuRule)->not->toBeNull()
+            ->and($skuRule->constraints)->toBe([
+                ['where', 'company_uuid', 'company-uuid'],
+                ['whereNull', 'deleted_at'],
+            ]);
+
+        // On update the record re-sends its own SKU, so it must not collide with
+        // itself. The v1 route parameter is a public_id, not a uuid.
+        $updateRules = CreatePartRequest::create('/fleetops-test', 'PUT')
+            ->setRouteResolver(fn () => new class {
+                public function parameter($key, $default = null)
+                {
+                    return $key === 'id' ? 'part_abc123' : $default;
+                }
+            })
+            ->rules();
+
+        $updateSkuRule = collect($updateRules['sku'])->first(fn ($rule) => $rule instanceof Illuminate\Validation\Rule);
+
+        expect($updateSkuRule->constraints)->toContain(['ignore', 'part_abc123', 'public_id']);
 
         bindFleetOpsRequestSession(['is_sanctum_token' => true]);
 

--- a/server/tests/RequestContractsTest.php
+++ b/server/tests/RequestContractsTest.php
@@ -734,6 +734,34 @@ namespace {
         expect($request->authorize())->toBeTrue();
     });
 
+    test('duplicate-key requests name the offending field and ignore themselves on update', function () {
+        session(['company' => 'company-uuid']);
+        bindFleetOpsRequestSession(['api_credential' => 'credential-uuid', 'company' => 'company-uuid']);
+
+        // Without these the violation surfaces as the framework's generic "has already
+        // been taken", which does not say which record collided or on what.
+        expect(CreatePartRequest::create('/fleetops-test', 'POST')->messages())
+            ->toBe(['sku.unique' => 'A part with this SKU already exists.'])
+            ->and(CreateFuelTransactionRequest::create('/fleetops-test', 'POST')->messages())
+            ->toBe(['provider_transaction_id.unique' => 'A fuel transaction with this provider transaction id already exists for this provider.']);
+
+        // `provider` is supplied here, so resolveProvider() short-circuits on the input
+        // and this exercises only the ignore-self clause. The stored-provider fallback
+        // needs a database and is covered in FuelProviderTransactionControllerContractsTest.
+        $updateRules = CreateFuelTransactionRequest::create('/fleetops-test', 'PUT', ['provider' => 'petroapp'])
+            ->setRouteResolver(fn () => new class {
+                public function parameter($key, $default = null)
+                {
+                    return $key === 'id' ? 'fuel_provider_transaction_abc123' : $default;
+                }
+            })
+            ->rules();
+
+        $updateRule = collect($updateRules['provider_transaction_id'])->first(fn ($rule) => $rule instanceof Illuminate\Validation\Rule);
+
+        expect($updateRule->constraints)->toContain(['ignore', 'fuel_provider_transaction_abc123', 'public_id']);
+    });
+
     test('entity equipment payload and simulation requests expose conditional contracts', function () {
         bindFleetOpsRequestSession();
 


### PR DESCRIPTION
## Problem

`POST /v1/parts` and `POST /v1/fuel-transactions` return **HTTP 500 on a well-formed body**. Each one also takes a folder of dependent Postman requests down with it (3 for Parts, 7 for Fuel Transactions).

They are the same defect twice. A `UNIQUE` index exists, the FormRequest has no matching `unique:` rule, and the resulting `UniqueConstraintViolationException` escapes uncaught:

```
Illuminate\Database\UniqueConstraintViolationException: SQLSTATE[23000]: 1062
Duplicate entry '665b178b-…-FLT-OIL-001' for key 'parts.parts_company_uuid_sku_unique'
  at PartController.php:123 (Part::create) ← PartController.php:28

Illuminate\Database\UniqueConstraintViolationException: SQLSTATE[23000]: 1062
Duplicate entry 'petroapp-TX-10001' for key 'fuel_provider_transactions.fuel_provider_txn_provider_unique'
  at FuelTransactionController.php:144 ← FuelTransactionController.php:36
```

There is no central safety net — `core-api/src/Exceptions/Handler.php:144` gates on a hardcoded class-basename allowlist that omits `QueryException`. Public v1 controllers extend the bare `Controller` with no try/catch, while internal `/int/v1` controllers get `HasApiControllerBehavior`, which *does* catch it and degrades to a 400. That is why this is v1-only.

## Two aggravating factors found while reproducing

**1. Soft-delete tombstones made the key permanently unusable.** Neither index was soft-delete aware, so a deleted row kept occupying it:

```
DELETE /v1/parts/part_chfwxe7vyz  → 200
POST   /v1/parts  (same sku)      → 500   ← tombstone still holds the key
```

There is no restore or force-delete route (`/restore` → 400), so a consumer who deletes a part could never reuse that SKU again. The Fuel Transactions collision was *already* a tombstone (`deleted_at = 2026-08-08 08:07:54`) left by a prior collection run.

This is why a validation rule alone is not enough — a rule scoped `whereNull('deleted_at')` would pass validation and still fail at the driver. The rule and the index had to move together.

**2. `fuel_provider_transactions` was not tenant-scoped.** The index was `(provider, provider_transaction_id)` with no `company_uuid`, and `FuelProviderService::ingestTransaction()` keyed its `updateOrCreate` on the same pair. Neither model registers `CompanyScope`, and `CompanyScope` is inert under CLI — exactly where the provider sync runs. So Org B's sync could find Org A's row and **overwrite it, reassigning `company_uuid`**. Same family as GHSA-3wj9-hh56-7fw7.

## Changes

- **`2026_08_08_000001_…soft_delete_aware.php`** — replaces both unique indexes with soft-delete-aware ones via a STORED generated column that is `NULL` for deleted rows, following the existing pattern in `alrashed-transport/…/2026_05_25_000001`. `parts` → `(company_uuid, active_sku)`; `fuel_provider_transactions` → `(company_uuid, provider, active_provider_transaction_id)`.
- **`FuelProviderService.php`** — `company_uuid` added to the `updateOrCreate` match array, closing the cross-tenant overwrite.
- **`CreatePartRequest` / `CreateFuelTransactionRequest`** — tenant-scoped `Rule::unique` mirroring each index, using the idiom already in `CreateCustomerRequest`. Includes `->ignore(…, 'public_id')` on update (the v1 route param is a public_id, not a uuid) and a `resolveProvider()` fallback so a `PUT` that omits `provider` still scopes correctly.
- **`RequestContractsTest`** — `ignore()` added to the hand-written `Rule` stand-in, plus assertions on the new scoping.

### Two notes for the reviewer

- The parts replacement index is created **before** the old one is dropped. `parts_company_uuid_sku_unique` was the only index covering `company_uuid` and `parts_company_uuid_foreign` depends on it, so dropping first fails with errno 150.
- No `: Unique` return type hints on the rule helpers: `illuminate/validation` is not in the vendor tree, so `Rule::unique()` returns the harness stand-in and the hint is a TypeError under test. Documented with a docblock instead.

## Migration safety

Both new indexes are **strictly more permissive** than the ones they replace — tombstones drop out, and the fuel key gains a tenant column. No existing row can violate them, so **no backfill is required**. Every step is guarded by `Schema::hasColumn` / `indexExists`, so the migration is re-runnable (verified: it recovered cleanly from an interrupted first attempt).

## Verification

Against a live MySQL 8.0.41 stack:

- Migration applies and is re-runnable. Confirmed directly in `information_schema`: both new indexes present with the correct column order, both generated columns carrying `if((deleted_at is null), …)`, both old indexes gone.
- Test files, all green: `RequestContractsTest`, `ApiPartControllerContractsTest`, `PartTest`, `FuelProviderTransactionControllerContractsTest`, `FuelTransactionControllerContractsTest`, `FuelProviderImplementationTest`, `FuelProviderRegistryTest`, `FuelProviderServiceMatchingTest`, `PublicApiControllerInputContractsTest`.
- `php-cs-fixer` clean on all five files.

**Not yet verified:** the end-to-end HTTP checks (duplicate → 422, delete-then-recreate → 201, PUT ignore-self, per-provider scoping). The app container would not boot on the verification host — FrankenPHP's `build-info` subprocess times out under heavy load, unrelated to this change. Cross-tenant isolation likewise has no runtime evidence yet; the index definition and the `updateOrCreate` change are the argument.

## Severity

Both endpoints are plain public v1 routes reachable with any org API key. Fuel Transactions is the more serious: `provider_transaction_id` is an idempotency key by nature, so an integration retrying a batch hits this constantly, plus the cross-tenant leak and overwrite. Neither 500 wrote to `laravel.log`, so in production these surface only via Sentry.

## Follow-ups (not in this PR)

- A `UniqueConstraintViolationException` branch in `core-api/src/Exceptions/Handler.php` would retire this bug class across all 30 bare v1 controllers. Note the dispatch is by `classBasename` and `UniqueConstraintViolationException extends QueryException`, so it needs both names or an `instanceof` switch; and `response()->error()` defaults to 400, not 422.
- Latent same-shape instances, currently shielded by the internal controllers' catch: `vehicles.engine_number` (global, no tenant scope), `assets (company_uuid, code)`, `users.username` in core-api, and pallet's `products` / `product_variants (company_uuid, sku)`.

Collection-side companion PR in `fleetbase/postman` updates the two request bodies that self-poison on a second CI run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)