### PR TITLE
fix(drivers): close verify-code authentication bypass

### DIFF
--- a/server/src/Http/Controllers/Api/v1/DriverController.php
+++ b/server/src/Http/Controllers/Api/v1/DriverController.php
@@ -611,7 +611,7 @@ class DriverController extends Controller
 
         // find and verify code
         $verificationCode = VerificationCode::where(['subject_uuid' => $user->uuid, 'code' => $code, 'for' => $for])->exists();
-        if (!$verificationCode && $code !== config('fleetops.navigator.bypass_verification_code')) {
+        if (!$verificationCode && !static::verificationBypassMatches($code)) {
             return response()->apiError('Invalid verification code!');
         }
 
@@ -1033,6 +1033,35 @@ class DriverController extends Controller
         }
 
         return $company;
+    }
+
+    /**
+     * Whether the supplied code matches the configured testing bypass code.
+     *
+     * Three conditions, all required, mirroring the console equivalent in
+     * Fleetbase\Http\Controllers\Internal\v1\AuthController::authenticateWithVerificationCode:
+     *
+     *  - a bypass code must actually be configured. The previous
+     *    `$code !== config(...)` comparison meant that on a default install --
+     *    where the config resolves to null -- omitting `code` entirely made the
+     *    check `null !== null`, i.e. false, so the guard never fired and any
+     *    caller with a valid org API credential could mint a driver token for
+     *    any driver in the install without a code at all;
+     *  - the app must not be in production, so a code left set in a deployed
+     *    .env cannot be used against a live fleet;
+     *  - the comparison is constant-time.
+     *
+     * Shared with Internal\v1\DriverController so both verify-code paths cannot
+     * drift apart.
+     */
+    public static function verificationBypassMatches(?string $code): bool
+    {
+        $bypassCode = config('fleetops.navigator.bypass_verification_code');
+
+        return $bypassCode !== null
+            && $bypassCode !== ''
+            && !app()->environment('production')
+            && hash_equals((string) $bypassCode, (string) $code);
     }
 
     /**

--- a/server/src/Http/Controllers/Internal/v1/DriverController.php
+++ b/server/src/Http/Controllers/Internal/v1/DriverController.php
@@ -665,7 +665,7 @@ class DriverController extends FleetOpsController
 
         // Find and verify code
         $verificationCode = static::verificationCodeExists($user, $code, $for);
-        if (!$verificationCode && $code !== config('fleetops.navigator.bypass_verification_code')) {
+        if (!$verificationCode && !ApiDriverController::verificationBypassMatches($code)) {
             return response()->error('Invalid verification code!');
         }
 

--- a/server/tests/Feature/Http/Api/DriverControllerAuthFlowsTest.php
+++ b/server/tests/Feature/Http/Api/DriverControllerAuthFlowsTest.php
@@ -84,8 +84,59 @@ class FleetOpsDriverAuthMailerFake
     }
 }
 
+/**
+ * Swap in a container that answers environment().
+ *
+ * verificationBypassMatches() asks app()->environment('production'), which the bare
+ * Illuminate\Container\Container used by this harness does not implement. Mirrors
+ * fleetopsCustomerHelperContainer() in CustomerControllerHelperSeamsTest.
+ */
+function fleetopsDriverAuthContainer(): void
+{
+    $current = Illuminate\Container\Container::getInstance();
+    if (method_exists($current, 'hasDebugModeEnabled')) {
+        return;
+    }
+
+    $replacement = new class extends Illuminate\Container\Container {
+        public function environment(...$environments)
+        {
+            if (empty($environments)) {
+                return 'testing';
+            }
+
+            $checks = is_array($environments[0]) ? $environments[0] : $environments;
+
+            return in_array('testing', $checks, true);
+        }
+
+        public function hasDebugModeEnabled()
+        {
+            return true;
+        }
+    };
+
+    foreach (['bindings', 'instances', 'aliases', 'abstractAliases', 'resolved', 'extenders', 'tags', 'contextual', 'scopedInstances', 'reboundCallbacks', 'globalBeforeResolvingCallbacks', 'globalResolvingCallbacks', 'globalAfterResolvingCallbacks', 'beforeResolvingCallbacks', 'resolvingCallbacks', 'afterResolvingCallbacks'] as $property) {
+        if (!property_exists(Illuminate\Container\Container::class, $property)) {
+            continue;
+        }
+        $reflection = new ReflectionProperty(Illuminate\Container\Container::class, $property);
+        $reflection->setAccessible(true);
+        if ($reflection->isInitialized($current)) {
+            $reflection->setValue($replacement, $reflection->getValue($current));
+        }
+    }
+
+    Illuminate\Container\Container::setInstance($replacement);
+    Illuminate\Support\Facades\Facade::setFacadeApplication($replacement);
+}
+
 function fleetopsDriverAuthBoot(): SQLiteConnection
 {
+    // Must run before the app()->instance() calls below, so those bindings land on
+    // the replacement container rather than the one it supersedes.
+    fleetopsDriverAuthContainer();
+
     $connection = new SQLiteConnection(new PDO('sqlite::memory:'));
     $resolver   = new ConnectionResolver(['default' => $connection, 'mysql' => $connection]);
     $resolver->setDefaultConnection('mysql');

--- a/server/tests/Feature/Http/Internal/DriverControllerContractsTest.php
+++ b/server/tests/Feature/Http/Internal/DriverControllerContractsTest.php
@@ -307,6 +307,11 @@ class FleetOpsInternalDriverAuthControllerProbe extends DriverController
 
     public static function resetProbe(): void
     {
+        // verifyCode() defers to DriverController::verificationBypassMatches(), which
+        // asks app()->environment('production'). The bare container this harness binds
+        // has no such method, so swap it before any verify-code test runs.
+        fleetopsInternalDriverAuthContainer();
+
         static::$loginUser          = null;
         static::$verificationUser   = null;
         static::$loginDriver        = null;
@@ -529,6 +534,53 @@ function fleetopsInternalDriverExportSelections(DriverExport $export): array
     $property->setAccessible(true);
 
     return $property->getValue($export);
+}
+
+/**
+ * Swap in a container that answers environment().
+ *
+ * Mirrors fleetopsCustomerHelperContainer() in CustomerControllerHelperSeamsTest and
+ * fleetopsDriverAuthContainer() in Api/DriverControllerAuthFlowsTest. Idempotent, so
+ * resetProbe() can call it per test.
+ */
+function fleetopsInternalDriverAuthContainer(): void
+{
+    $current = Illuminate\Container\Container::getInstance();
+    if (method_exists($current, 'hasDebugModeEnabled')) {
+        return;
+    }
+
+    $replacement = new class extends Illuminate\Container\Container {
+        public function environment(...$environments)
+        {
+            if (empty($environments)) {
+                return 'testing';
+            }
+
+            $checks = is_array($environments[0]) ? $environments[0] : $environments;
+
+            return in_array('testing', $checks, true);
+        }
+
+        public function hasDebugModeEnabled()
+        {
+            return true;
+        }
+    };
+
+    foreach (['bindings', 'instances', 'aliases', 'abstractAliases', 'resolved', 'extenders', 'tags', 'contextual', 'scopedInstances', 'reboundCallbacks', 'globalBeforeResolvingCallbacks', 'globalResolvingCallbacks', 'globalAfterResolvingCallbacks', 'beforeResolvingCallbacks', 'resolvingCallbacks', 'afterResolvingCallbacks'] as $property) {
+        if (!property_exists(Illuminate\Container\Container::class, $property)) {
+            continue;
+        }
+        $reflection = new ReflectionProperty(Illuminate\Container\Container::class, $property);
+        $reflection->setAccessible(true);
+        if ($reflection->isInitialized($current)) {
+            $reflection->setValue($replacement, $reflection->getValue($current));
+        }
+    }
+
+    Illuminate\Container\Container::setInstance($replacement);
+    Illuminate\Support\Facades\Facade::setFacadeApplication($replacement);
 }
 
 function fleetopsInternalDriverUseHelperDatabase(): SQLiteConnection


### PR DESCRIPTION
## The bug

`POST /v1/drivers/verify-code` mints a driver token **with no verification code at all**, in the default configuration.

```php
$verificationCode = VerificationCode::where([...])->exists();
if (!$verificationCode && $code !== config('fleetops.navigator.bypass_verification_code')) {
    return response()->apiError('Invalid verification code!');
}
```

- `$code = $request->input('code')` is unvalidated, so omitting it from the body makes it `null`.
- `config('fleetops.navigator.bypass_verification_code')` is `env('SMS_AUTH_BYPASS_CODE', env('NAVIGATOR_BYPASS_VERIFICATION_CODE'))`, which is `null` when neither is set — the default for every install.
- `null !== null` is `false`, so the whole condition is `false` and **the guard never fires**.

The route sits behind `fleetbase.api`, so any caller holding a valid org API credential can reach it, and the user lookup (`User::whereHas('driver')->where(phone)->orWhere(email)`) is **not company-scoped** — so the reachable set is every driver in the install, not just the caller's own.

Identical twin at `Internal/v1/DriverController.php`.

## Verified against a live stack

With `SMS_AUTH_BYPASS_CODE` unset, a request carrying only an identity:

```
POST /v1/drivers/verify-code   {"identity": "<driver phone>"}
-> HTTP 200, with a Sanctum token
```

## The fix

Replaces the comparison with a shared guard requiring all three conditions the console equivalent already uses (`AuthController::authenticateWithVerificationCode`):

- a bypass code must actually be **configured** (closes the null-equals-null hole),
- the app must **not be in production** (a code left set in a deployed `.env` cannot be used against a live fleet),
- the comparison is **constant-time**.

Defined once on `Api\v1\DriverController` and called from `Internal\v1` so the two verify-code paths cannot drift. Uses `!== null && !== ''` rather than `!empty()`, so a configured bypass code of `"0"` still works.

## Behaviour change

Truth table over every relevant combination — the only changes are the two bypassable cases becoming rejections:

| case | before | after |
| --- | --- | --- |
| default install, no code submitted | **BYPASS** | reject |
| default install, in production, no code | **BYPASS** | reject |
| configured + matching, production | **BYPASS** | reject |
| configured + matching, non-production | bypass | bypass |
| configured + wrong code | reject | reject |
| default install, some code submitted | reject | reject |

Legitimate non-production use is unchanged. Existing tests set the config explicitly and are unaffected.

## Note

Found while investigating unrelated Postman contract failures. The vulnerability is proven live; the fix itself was proven by the truth table above rather than live, so a re-test before merge is worthwhile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)