### PR TITLE
fix(customers): default a Place location so signup with a place works

### DIFF
--- a/server/src/Http/Controllers/Api/v1/CustomerController.php
+++ b/server/src/Http/Controllers/Api/v1/CustomerController.php
@@ -19,6 +19,7 @@ use Fleetbase\FleetOps\Models\ServiceQuote;
 use Fleetbase\FleetOps\Support\CustomerAuth;
 use Fleetbase\FleetOps\Support\Utils;
 use Fleetbase\Http\Controllers\Controller;
+use Fleetbase\LaravelMysqlSpatial\Types\Point as SpatialPoint;
 use Fleetbase\Models\File;
 use Fleetbase\Models\User;
 use Fleetbase\Models\UserDevice;
@@ -312,6 +313,14 @@ class CustomerController extends Controller
                 'company_uuid' => $companyUuid,
                 'owner_uuid'   => $contact->uuid,
                 'owner_type'   => get_class($contact),
+                // `places.location` is a NOT NULL POINT column with no database default,
+                // and $allowed above is address-only — a caller cannot supply coordinates
+                // here. Without this the insert fails with SQLSTATE[HY000] 1364 ("Field
+                // 'location' doesn't have a default value"), turning a documented signup
+                // payload into a 500. Point(0, 0) is the same placeholder the geocoding
+                // helpers fall back to when an address cannot be resolved — see
+                // Place::getGoogleAddressArray and Place::findExistingSharedPlace.
+                'location'     => new SpatialPoint(0, 0),
             ],
             $attributes,
         ));


### PR DESCRIPTION
## The bug

`POST /v1/customers` accepts an optional `place` object, and the payload documented in the Postman collection sends one. Creating it **always** failed:

```
SQLSTATE[HY000]: General error: 1364
Field 'location' doesn't have a default value
```

`places.location` is a `POINT NOT NULL` column with no database default, and the attribute allow-list in `resolveCustomerPlace` is address-only — a caller **cannot** supply coordinates through this surface — so `Place::create()` was always called without one.

Every documented signup that included a place returned a 500.

## The fix

Default it to `Point(0, 0)` — the same placeholder the geocoding helpers already fall back to when an address cannot be resolved (`Place::getGoogleAddressArray`, `Place::findExistingSharedPlace`).

The default sits in the base array of the `array_merge`, and `location` is not in the allow-list, so a caller can never override it.

## Verified against a live stack

- Before: the documented `Create a Customer` payload → 500 with the error above.
- After: 200, with the address resolved (`HOME - 123 MAIN STREET, KINGSTON, 00000, JAMAICA`).
- Control: `Place::create()` **without** a location still fails with `1364`, confirming the default is what fixes it — and the same request with no `place` key already returned 200 both before and after.

## Context

Found while making the `Customers` folder of the Postman collection pass (fleetbase/fleetbase#581) — this was the last blocker before all 16 requests returned 2xx.

🤖 Generated with [Claude Code](https://claude.com/claude-code)