### PR TITLE
ci(postman): test this branch's API code, and unpin the contract workflow

### DIFF
--- a/.github/workflows/postman.yml
+++ b/.github/workflows/postman.yml
@@ -30,4 +30,8 @@ jobs:
     with:
       collections: "Fleetbase API"
       build-from-source: false
+      # Without this the run tests the version of fleetbase/fleetops-api baked into the
+      # published image, not the branch under review. The workflow checks this
+      # repository out at the commit under test and swaps it into the container.
+      overlay-package: fleetbase/fleetops-api
     secrets: inherit


### PR DESCRIPTION
Two one-line problems, both of which meant this repository's contract check was not testing this repository.

## 1. It was running an old copy of the workflow

The call was pinned to `fleetbase/fleetbase@dev-v0.7.53`, a ref that predates every fix to the contract workflow — including the one where [the collections were never actually executing](https://github.com/fleetbase/fleetbase/pull/579) (the step ran for 25ms, produced no output, and passed).

Now `@main`. The reusable workflow defaults `fleetbase-ref` to `main` and tests against `fleetbase/fleetbase-api:latest`, so releases are picked up automatically and there is no ref here to remember to bump. Each run records the resolved image digest in its job summary, so results stay traceable.

## 2. It was testing the published package, not this branch

This is the substantive one. With `build-from-source: false` the stack boots the published API image, and `fleetbase/fleetops-api` is a composer dependency **baked into that image**. So a PR here booted the released version and ran the collections against it. Its own API changes were never exercised — the check was green on code that was not under review, which is worse than no check because it reads as coverage.

`overlay-package` ([fleetbase/fleetbase#582](https://github.com/fleetbase/fleetbase/pull/582)) makes the reusable workflow check this repository out at the commit under test and swap it into the running container. It then dumps the autoloader — necessary, because the image is built with `--optimize-autoloader` and the frozen classmap would otherwise hide any class added or moved on the branch — clears caches, runs migrations, and re-checks health so a broken overlay fails loudly.

```yaml
jobs:
  contract:
    uses: fleetbase/fleetbase/.github/workflows/api-contract.yml@main
    with:
      collections: "Fleetbase API"
      build-from-source: false
      overlay-package: fleetbase/fleetops-api
    secrets: inherit
```

`overlay-path` is not needed here: this repository's root is the package root (`composer.json` declares `fleetbase/fleetops-api`).

## What to expect on the first run

This is the first time these collections will execute against this package's actual branch code, so treat failures as real signal rather than regression. Collection-side fixes landed separately in [fleetbase/postman#11](https://github.com/fleetbase/postman/pull/11), which took the Fleetbase API collection from 85/180 to 129/180 requests returning 2xx.

The overlay has not been exercised end to end anywhere yet — it was verified structurally (vendor layout, package root, the 579-entry frozen classmap, composer availability in the container). This run is its first real test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)