### PR TITLE
feat(seeders): add a presentable Demo fixture set

### DIFF
--- a/server/seeders/Demo/Concerns/SeedsDemoData.php
+++ b/server/seeders/Demo/Concerns/SeedsDemoData.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Fleetbase\FleetOps\Seeders\Demo\Concerns;
+
+use Fleetbase\FleetOps\Seeders\Testing\Concerns\SeedsTestingData;
+
+/**
+ * The demo fixture set: same machinery as the testing one, different visible strings.
+ *
+ * Why a second set exists at all. The Testing fixtures are excellent structurally — real
+ * Singapore coordinates, 25 vehicles with genuine makes and models, orders spread across the
+ * status pipeline — but they are stamped throughout with text that announces itself as test
+ * data: TEST- identifiers, @example.test addresses, "FleetOps testing fixture" notes. Those
+ * strings are legible in a screenshot, and these fixtures feed the console screenshots
+ * published on fleetbase.io.
+ *
+ * Everything else is inherited. `seedName()` is what keeps the two sets separately purgeable:
+ * every record is tagged `meta->seed`, so seeding or purging one never touches the other, and
+ * both can coexist in a single install.
+ *
+ * `seedName()` is a method rather than a redeclared constant because PHP rejects a class that
+ * redeclares a trait constant with a different value ("the definition differs and is
+ * considered incompatible"). See SeedsTestingData::seedName().
+ */
+trait SeedsDemoData
+{
+    use SeedsTestingData;
+
+    protected function seedName(): string
+    {
+        return 'fleetops-demo';
+    }
+
+    protected function seedLabel(): string
+    {
+        return 'Fleetbase demo';
+    }
+
+    protected function identifierPrefix(): string
+    {
+        return 'FLT';
+    }
+
+    /**
+     * Natural phrasing per record kind, because unlike the testing set these strings are read
+     * by people looking at the marketing site rather than by an assertion.
+     */
+    protected function fixtureNote(string $noun): string
+    {
+        return [
+            'order'                => 'Standard transport order.',
+            'waypoint'             => 'Intermediate stop.',
+            'item'                 => 'Standard parcel.',
+            'contact'              => 'Primary account contact.',
+            'vendor'               => 'Contracted logistics partner.',
+            'zone'                 => 'Active operating zone.',
+            'device'               => 'Installed telematics device.',
+            'part'                 => 'Stocked spare part.',
+            'maintenance schedule' => 'Recurring preventive maintenance.',
+            'work order'           => 'Scheduled workshop job.',
+            'maintenance history'  => 'Completed service record.',
+        ][$noun] ?? ucfirst($noun) . '.';
+    }
+}

--- a/server/seeders/Demo/ConnectivitySeeder.php
+++ b/server/seeders/Demo/ConnectivitySeeder.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Fleetbase\FleetOps\Seeders\Demo;
+
+use Fleetbase\FleetOps\Seeders\Demo\Concerns\SeedsDemoData;
+use Fleetbase\FleetOps\Seeders\Testing\ConnectivitySeeder as TestingConnectivitySeeder;
+
+/** Everything is inherited; only the seed tag and the note text differ. */
+class ConnectivitySeeder extends TestingConnectivitySeeder
+{
+    use SeedsDemoData;
+}

--- a/server/seeders/Demo/DemoSeeder.php
+++ b/server/seeders/Demo/DemoSeeder.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace Fleetbase\FleetOps\Seeders\Demo;
+
+use Fleetbase\FleetOps\Models\Driver;
+use Fleetbase\FleetOps\Models\Order;
+use Fleetbase\FleetOps\Seeders\Demo\Concerns\SeedsDemoData;
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * The presentable Fleet-Ops fixture set.
+ *
+ * Structurally identical to Testing\TestingSeeder — purge, then seed in dependency order —
+ * but tagged `fleetops-demo`, so the two sets are independently purgeable and can coexist in
+ * one install. Idempotent: rerunning replaces the demo rows and leaves everything else alone.
+ *
+ *   php artisan db:seed --force --class="Fleetbase\FleetOps\Seeders\Demo\DemoSeeder"
+ *
+ * Primarily consumed by the console screenshot pipeline in the fleetbase/fleetbase monorepo
+ * (screenshots/README.md), which publishes the resulting screens to fleetbase.io.
+ */
+class DemoSeeder extends Seeder
+{
+    use SeedsDemoData;
+
+    public function run(): void
+    {
+        Schema::disableForeignKeyConstraints();
+        try {
+            $this->purgeSeedData();
+        } finally {
+            Schema::enableForeignKeyConstraints();
+        }
+
+        $this->call([
+            NetworkSeeder::class,
+            FleetSeeder::class,
+            OrdersSeeder::class,
+            ConnectivitySeeder::class,
+            MaintenanceSeeder::class,
+        ]);
+
+        $this->announceFixtures();
+    }
+
+    protected function purgeSeedData(): void
+    {
+        // Reverse dependency order, matching Testing\TestingSeeder.
+        foreach ([
+            new MaintenanceSeeder(),
+            new ConnectivitySeeder(),
+            new OrdersSeeder(),
+            new FleetSeeder(),
+            new NetworkSeeder(),
+        ] as $seeder) {
+            $seeder->purgeSeedData();
+        }
+    }
+
+    /**
+     * Echo the public_ids of the records that detail-page screenshots point at.
+     *
+     * The screenshot capture resolves these independently, by looking the record up through
+     * the internal API by name or internal_id. Printing them here gives it a second, unrelated
+     * source to check itself against — two paths agreeing is what distinguishes "resolved the
+     * right record" from "resolved a record". A disagreement fails the run rather than quietly
+     * publishing a screenshot of the wrong driver.
+     *
+     * Keys are screenshot manifest entry ids, not seed ids. Follows the same
+     * MINTED_ and SEEDED_ echo protocol that scripts/ci/mint-api-key.php established in the monorepo.
+     */
+    protected function announceFixtures(): void
+    {
+        $fixtures = array_filter([
+            'driver-details' => $this->seededModel(Driver::class, 'driver_ava')?->public_id,
+            'order-details'  => $this->seededModel(Order::class, 'order_started')?->public_id,
+        ]);
+
+        echo PHP_EOL . 'SEEDED_FIXTURES=' . json_encode($fixtures) . PHP_EOL;
+    }
+}

--- a/server/seeders/Demo/FleetSeeder.php
+++ b/server/seeders/Demo/FleetSeeder.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Fleetbase\FleetOps\Seeders\Demo;
+
+use Fleetbase\FleetOps\Seeders\Demo\Concerns\SeedsDemoData;
+use Fleetbase\FleetOps\Seeders\Testing\FleetSeeder as TestingFleetSeeder;
+
+/**
+ * Vehicles, fleets, fuel reports and issues are inherited unchanged — the testing set already
+ * uses real makes, models, plates and Singapore coordinates. Only the people differ.
+ */
+class FleetSeeder extends TestingFleetSeeder
+{
+    use SeedsDemoData;
+
+    protected function userFixtures(): array
+    {
+        // Phone numbers are kept from the testing set: +65 8100 000x is inside Singapore's
+        // mobile range but is not an allocated block, so nothing here can dial a real person.
+        return [
+            'driver_ava_user'  => ['Amara Chen', 'amara.chen@demo.fleetbase.io', '+6581000001'],
+            'driver_ken_user'  => ['Kenji Tan', 'kenji.tan@demo.fleetbase.io', '+6581000002'],
+            'driver_mira_user' => ['Mira Rahman', 'mira.rahman@demo.fleetbase.io', '+6581000003'],
+            'dispatcher_user'  => ['Priya Nair', 'priya.nair@demo.fleetbase.io', '+6581000004'],
+        ];
+    }
+}

--- a/server/seeders/Demo/MaintenanceSeeder.php
+++ b/server/seeders/Demo/MaintenanceSeeder.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Fleetbase\FleetOps\Seeders\Demo;
+
+use Fleetbase\FleetOps\Seeders\Demo\Concerns\SeedsDemoData;
+use Fleetbase\FleetOps\Seeders\Testing\MaintenanceSeeder as TestingMaintenanceSeeder;
+
+/** Everything is inherited; only the seed tag, identifier prefix and note text differ. */
+class MaintenanceSeeder extends TestingMaintenanceSeeder
+{
+    use SeedsDemoData;
+}

--- a/server/seeders/Demo/NetworkSeeder.php
+++ b/server/seeders/Demo/NetworkSeeder.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Fleetbase\FleetOps\Seeders\Demo;
+
+use Fleetbase\FleetOps\Seeders\Demo\Concerns\SeedsDemoData;
+use Fleetbase\FleetOps\Seeders\Testing\NetworkSeeder as TestingNetworkSeeder;
+
+/**
+ * Service areas, zones, places and service rates are inherited unchanged — Raffles Quay,
+ * ION Orchard and Changi Airfreight are already the right kind of thing to put on a website.
+ * Only the addresses on the people and vendors differ.
+ */
+class NetworkSeeder extends TestingNetworkSeeder
+{
+    use SeedsDemoData;
+
+    protected function contactFixtures(): array
+    {
+        return [
+            'customer_alice' => ['Alice Tan', 'customer', 'alice.tan@demo.fleetbase.io', '+6591000001', 'orchard_store'],
+            'customer_ben'   => ['Ben Lim', 'customer', 'ben.lim@demo.fleetbase.io', '+6591000002', 'rochor_store'],
+            'ops_manager'    => ['Nadia Rahman', 'contact', 'nadia.rahman@demo.fleetbase.io', '+6591000003', 'central_depot'],
+        ];
+    }
+
+    protected function vendorFixtures(): array
+    {
+        // demo.fleetbase.io rather than the vendor's own apparent domain: fastline.example.test
+        // reads as test data, and a plausible-looking real domain would be worse — it would put
+        // an address Fleetbase does not control on the marketing site.
+        return [
+            'facilitator_fastline' => ['Fastline Logistics', 'facilitator', 'fastline@demo.fleetbase.io', '+6592000001', 'central_depot'],
+            'supplier_parts'       => ['Apex Parts Supply', 'supplier', 'apex@demo.fleetbase.io', '+6592000002', 'west_depot'],
+        ];
+    }
+}

--- a/server/seeders/Demo/OrdersSeeder.php
+++ b/server/seeders/Demo/OrdersSeeder.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Fleetbase\FleetOps\Seeders\Demo;
+
+use Fleetbase\FleetOps\Seeders\Demo\Concerns\SeedsDemoData;
+use Fleetbase\FleetOps\Seeders\Testing\OrdersSeeder as TestingOrdersSeeder;
+
+class OrdersSeeder extends TestingOrdersSeeder
+{
+    use SeedsDemoData;
+
+    /**
+     * Sequential references in declaration order, rather than the testing set's
+     * TEST-<SEED_ID>. Two reasons: FLT-1004 is what an operator would actually see, and the
+     * screenshot manifest resolves the order-details page by looking this exact value up
+     * through the internal API (records get a fresh uuid on every seed, so the public_id in
+     * the URL cannot be written into the manifest).
+     *
+     * Changing a value here breaks that lookup — the capture aborts rather than screenshotting
+     * the wrong order, but it does abort.
+     */
+    protected const INTERNAL_IDS = [
+        'order_created_unassigned' => 'FLT-1001',
+        'order_scheduled'          => 'FLT-1002',
+        'order_dispatched'         => 'FLT-1003',
+        'order_started'            => 'FLT-1004',
+        'order_completed'          => 'FLT-1005',
+        'order_canceled'           => 'FLT-1006',
+        'order_vehicle_assigned'   => 'FLT-1007',
+    ];
+
+    protected function orderInternalId(string $seedId): string
+    {
+        return static::INTERNAL_IDS[$seedId] ?? parent::orderInternalId($seedId);
+    }
+
+    protected function entityNameFor(string $seedId, int $index): string
+    {
+        $names = ['Document envelope', 'Small parcel', 'Carton', 'Insulated tote', 'Pallet'];
+
+        return $names[($index - 1) % count($names)];
+    }
+}

--- a/server/seeders/Testing/Concerns/SeedsTestingData.php
+++ b/server/seeders/Testing/Concerns/SeedsTestingData.php
@@ -22,6 +22,51 @@ trait SeedsTestingData
 
     protected const SEED_NAME = 'fleetops-testing';
 
+    /**
+     * The seed tag written to every record's meta, and the prefix of its _key.
+     *
+     * A method rather than a bare constant read because a class using this trait cannot
+     * redeclare a trait constant with a different value — PHP rejects the composition as
+     * incompatible. Overriding this is how a second fixture set (see the Demo seeders)
+     * shares all of this machinery while keeping its rows separately purgeable.
+     */
+    protected function seedName(): string
+    {
+        return static::SEED_NAME;
+    }
+
+    /**
+     * Human-readable phrase stamped into notes, descriptions and tags.
+     *
+     * Split out from seedName() because the two vary independently: the seed tag is
+     * infrastructure and never appears on screen, while this shows up in the UI and, for
+     * fixtures destined for marketing screenshots, must not read as test data.
+     */
+    protected function seedLabel(): string
+    {
+        return 'FleetOps testing fixture';
+    }
+
+    /**
+     * Prefix for human-facing identifiers — internal_id, tracking_number, work order ids.
+     */
+    protected function identifierPrefix(): string
+    {
+        return 'TEST';
+    }
+
+    /**
+     * The note/description text stamped onto a seeded record of the given kind.
+     *
+     * Centralised because these strings are the ones that actually appear on screen. The
+     * Testing default is deliberately unmistakable as test data; the Demo override replaces
+     * them with text that reads naturally in a screenshot.
+     */
+    protected function fixtureNote(string $noun): string
+    {
+        return $this->seedLabel() . ' ' . $noun . '.';
+    }
+
     protected function resolveCompany(): ?Company
     {
         return $this->resolveSeedCompany();
@@ -43,13 +88,13 @@ trait SeedsTestingData
 
     protected function fixtureKey(string $seedId): string
     {
-        return static::SEED_NAME . ':' . $seedId;
+        return $this->seedName() . ':' . $seedId;
     }
 
     protected function meta(string $seedId, array $extra = []): array
     {
         return array_merge([
-            'seed'    => static::SEED_NAME,
+            'seed'    => $this->seedName(),
             'seed_id' => $seedId,
         ], $extra);
     }
@@ -123,11 +168,11 @@ trait SeedsTestingData
         $query = $modelClass::query();
 
         if (Schema::hasColumn($table, 'meta')) {
-            return $query->where('meta->seed', static::SEED_NAME);
+            return $query->where('meta->seed', $this->seedName());
         }
 
         if (Schema::hasColumn($table, '_key')) {
-            return $query->where('_key', 'like', static::SEED_NAME . ':%');
+            return $query->where('_key', 'like', $this->seedName() . ':%');
         }
 
         return $query->whereRaw('1 = 0');
@@ -155,7 +200,7 @@ trait SeedsTestingData
         $table = $model->getTable();
 
         if (Schema::hasColumn($table, 'meta')) {
-            return $modelClass::where('meta->seed', static::SEED_NAME)->where('meta->seed_id', $seedId)->first();
+            return $modelClass::where('meta->seed', $this->seedName())->where('meta->seed_id', $seedId)->first();
         }
 
         if (Schema::hasColumn($table, '_key')) {

--- a/server/seeders/Testing/ConnectivitySeeder.php
+++ b/server/seeders/Testing/ConnectivitySeeder.php
@@ -34,7 +34,7 @@ class ConnectivitySeeder extends Seeder
             $this->seedDeviceEvents($company, $devices);
             $this->seedGeofenceEvents($company);
 
-            $this->command?->info('Seeded FleetOps testing connectivity fixtures for company: ' . $company->public_id);
+            $this->command?->info('Seeded ' . $this->seedName() . ' connectivity fixtures for company: ' . $company->public_id);
         });
     }
 
@@ -74,7 +74,7 @@ class ConnectivitySeeder extends Seeder
                 'last_seen_at'     => $this->timestamp(1),
                 'last_metrics'     => ['signal' => 88, 'battery' => 94],
                 'config'           => ['fixture' => true],
-                'credentials'      => ['token' => 'testing-fixture-redacted'],
+                'credentials'      => ['token' => 'redacted'],
                 'meta'             => $this->meta($seedId),
             ]);
         }
@@ -112,7 +112,7 @@ class ConnectivitySeeder extends Seeder
                 'online'            => $online,
                 'status'            => $status,
                 'data_frequency'    => 60,
-                'notes'             => 'FleetOps testing fixture device.',
+                'notes'             => $this->fixtureNote('device'),
                 'data'              => ['speed_kmh' => 28, 'heading' => 92],
                 'options'           => ['fixture' => true],
                 'meta'              => $this->meta($seedId),
@@ -172,7 +172,7 @@ class ConnectivitySeeder extends Seeder
                 'severity'     => $severity,
                 'ident'        => strtoupper($seedId),
                 'protocol'     => 'testing',
-                'provider'     => 'fleetops-testing',
+                'provider'     => $this->seedName(),
                 'state'        => $severity,
                 'code'         => strtoupper($eventType),
                 'reason'       => $reason,

--- a/server/seeders/Testing/FleetSeeder.php
+++ b/server/seeders/Testing/FleetSeeder.php
@@ -37,7 +37,7 @@ class FleetSeeder extends Seeder
             $this->seedFuelReports($company, $users, $drivers, $vehicles);
             $this->seedIssues($company, $users, $drivers, $vehicles);
 
-            $this->command?->info('Seeded FleetOps testing fleet fixtures for company: ' . $company->public_id);
+            $this->command?->info('Seeded ' . $this->seedName() . ' fleet fixtures for company: ' . $company->public_id);
         });
     }
 
@@ -53,14 +53,23 @@ class FleetSeeder extends Seeder
         $this->purgeModel(User::class);
     }
 
-    protected function seedUsers(Company $company): array
+    /**
+     * [name, email, phone] keyed by seed id. Overridable: these strings are rendered in the
+     * console, so a fixture set destined for screenshots needs its own.
+     */
+    protected function userFixtures(): array
     {
-        $users = [
+        return [
             'driver_ava_user'  => ['Ava Driver', 'ava.driver.testing@example.test', '+6581000001'],
             'driver_ken_user'  => ['Ken Driver', 'ken.driver.testing@example.test', '+6581000002'],
             'driver_mira_user' => ['Mira Driver', 'mira.driver.testing@example.test', '+6581000003'],
             'dispatcher_user'  => ['Testing Dispatcher', 'dispatcher.testing@example.test', '+6581000004'],
         ];
+    }
+
+    protected function seedUsers(Company $company): array
+    {
+        $users = $this->userFixtures();
 
         $models = [];
         foreach ($users as $seedId => [$name, $email, $phone]) {
@@ -70,7 +79,7 @@ class FleetSeeder extends Seeder
                 'name'         => $name,
                 'email'        => $email,
                 'phone'        => $phone,
-                'password'     => Hash::make('fleetops-testing'),
+                'password'     => Hash::make($this->seedName()),
                 'type'         => str_contains($seedId, 'driver') ? 'driver' : 'user',
                 'status'       => 'active',
                 'timezone'     => 'Asia/Singapore',
@@ -330,8 +339,8 @@ class FleetSeeder extends Seeder
                 'category'          => $category,
                 'type'              => 'inspection',
                 'title'             => $title,
-                'report'            => $title . ' created as a FleetOps testing fixture.',
-                'tags'              => ['fixture', 'fleetops-testing'],
+                'report'            => $title . ' created as a ' . $this->seedLabel() . '.',
+                'tags'              => ['fixture', $this->seedName()],
                 'priority'          => $priority,
                 'status'            => $status,
                 'meta'              => $this->meta($seedId),

--- a/server/seeders/Testing/MaintenanceSeeder.php
+++ b/server/seeders/Testing/MaintenanceSeeder.php
@@ -34,7 +34,7 @@ class MaintenanceSeeder extends Seeder
             $workOrders = $this->seedWorkOrders($company, $schedules);
             $this->seedMaintenanceHistory($company, $equipment, $workOrders);
 
-            $this->command?->info('Seeded FleetOps testing maintenance fixtures for company: ' . $company->public_id);
+            $this->command?->info('Seeded ' . $this->seedName() . ' maintenance fixtures for company: ' . $company->public_id);
         });
     }
 
@@ -97,7 +97,7 @@ class MaintenanceSeeder extends Seeder
                 'name'             => $name,
                 'manufacturer'     => $manufacturer,
                 'model'            => $model,
-                'description'      => 'FleetOps testing fixture part.',
+                'description'      => $this->fixtureNote('part'),
                 'quantity_on_hand' => $quantity,
                 'unit_cost'        => $unitCost,
                 'msrp'             => $unitCost * 1.3,
@@ -141,7 +141,7 @@ class MaintenanceSeeder extends Seeder
                 'default_priority'        => $seedId === 'schedule_overdue' ? 'high' : 'medium',
                 'default_assignee_type'   => Driver::class,
                 'default_assignee_uuid'   => $driver?->uuid,
-                'instructions'            => 'FleetOps testing fixture maintenance schedule.',
+                'instructions'            => $this->fixtureNote('maintenance schedule'),
                 'reminder_offsets'        => [7, 1],
                 'meta'                    => $this->meta($seedId),
             ]);
@@ -155,9 +155,9 @@ class MaintenanceSeeder extends Seeder
         $driver     = $this->seededModel(Driver::class, 'driver_mira');
         $vehicle    = $this->seededModel(Vehicle::class, 'truck_maintenance');
         $workOrders = [
-            'work_order_open'      => ['WO-TEST-OPEN', 'Open Inspection', 'inspection_request', 'open', 'medium', $this->timestamp(-4), $this->timestamp(24), null, 'schedule_due_soon'],
-            'work_order_overdue'   => ['WO-TEST-OVERDUE', 'Overdue Service', 'preventive_maintenance', 'open', 'high', $this->timestamp(-120), $this->timestamp(-24), null, 'schedule_overdue'],
-            'work_order_completed' => ['WO-TEST-CLOSED', 'Completed Repair', 'general_repair', 'completed', 'low', $this->timestamp(-240), $this->timestamp(-120), $this->timestamp(-96), 'schedule_overdue'],
+            'work_order_open'      => [$this->identifierPrefix() . '-WO-OPEN', 'Open Inspection', 'inspection_request', 'open', 'medium', $this->timestamp(-4), $this->timestamp(24), null, 'schedule_due_soon'],
+            'work_order_overdue'   => [$this->identifierPrefix() . '-WO-OVERDUE', 'Overdue Service', 'preventive_maintenance', 'open', 'high', $this->timestamp(-120), $this->timestamp(-24), null, 'schedule_overdue'],
+            'work_order_completed' => [$this->identifierPrefix() . '-WO-CLOSED', 'Completed Repair', 'general_repair', 'completed', 'low', $this->timestamp(-240), $this->timestamp(-120), $this->timestamp(-96), 'schedule_overdue'],
         ];
 
         $models = [];
@@ -177,7 +177,7 @@ class MaintenanceSeeder extends Seeder
                 'opened_at'       => $openedAt,
                 'due_at'          => $dueAt,
                 'closed_at'       => $closedAt,
-                'instructions'    => 'FleetOps testing fixture work order.',
+                'instructions'    => $this->fixtureNote('work order'),
                 'checklist'       => [
                     ['label' => 'Inspect vehicle', 'completed' => $status === 'completed'],
                     ['label' => 'Record readings', 'completed' => $status === 'completed'],
@@ -187,7 +187,7 @@ class MaintenanceSeeder extends Seeder
                 'actual_cost'     => $status === 'completed' ? 22800 : null,
                 'currency'        => 'SGD',
                 'cost_breakdown'  => ['labor' => 12000, 'parts' => 10800],
-                'cost_center'     => 'testing-fixtures',
+                'cost_center'     => $this->seedName(),
                 'budget_code'     => 'FB-TEST',
                 'schedule_uuid'   => $schedules[$scheduleSeedId]?->uuid,
                 'meta'            => $this->meta($seedId),
@@ -224,7 +224,7 @@ class MaintenanceSeeder extends Seeder
                 'performed_by_type'   => Driver::class,
                 'performed_by_uuid'   => $driver?->uuid,
                 'summary'             => $summary,
-                'notes'               => 'FleetOps testing fixture maintenance history.',
+                'notes'               => $this->fixtureNote('maintenance history'),
                 'line_items'          => [['description' => 'Labor', 'amount' => 12000], ['description' => 'Parts', 'amount' => 10800]],
                 'labor_cost'          => 12000,
                 'parts_cost'          => 10800,

--- a/server/seeders/Testing/NetworkSeeder.php
+++ b/server/seeders/Testing/NetworkSeeder.php
@@ -36,7 +36,7 @@ class NetworkSeeder extends Seeder
             $vendors = $this->seedVendors($company, $places);
             $this->seedServiceRates($company, $vendors);
 
-            $this->command?->info('Seeded FleetOps testing network fixtures for company: ' . $company->public_id);
+            $this->command?->info('Seeded ' . $this->seedName() . ' network fixtures for company: ' . $company->public_id);
         });
     }
 
@@ -115,7 +115,7 @@ class NetworkSeeder extends Seeder
                 'company_uuid'            => $company->uuid,
                 'service_area_uuid'       => $serviceArea?->uuid,
                 'name'                    => $zone['name'],
-                'description'             => 'Fixture zone for FleetOps testing assertions.',
+                'description'             => $this->fixtureNote('zone'),
                 'border'                  => $this->polygon($zone['border']),
                 'color'                   => $zone['color'],
                 'stroke_color'            => $zone['color'],
@@ -156,13 +156,22 @@ class NetworkSeeder extends Seeder
         return $models;
     }
 
-    protected function seedContacts(Company $company, array $places): void
+    /**
+     * [name, type, email, phone, place seed id] keyed by seed id. Overridable for the same
+     * reason as userFixtures(): these names and addresses are rendered in the console.
+     */
+    protected function contactFixtures(): array
     {
-        $contacts = [
+        return [
             'customer_alice' => ['Alice Tan', 'customer', 'alice.testing@example.test', '+6591000001', 'orchard_store'],
             'customer_ben'   => ['Ben Lim', 'customer', 'ben.testing@example.test', '+6591000002', 'rochor_store'],
             'ops_manager'    => ['Nadia Rahman', 'contact', 'nadia.testing@example.test', '+6591000003', 'central_depot'],
         ];
+    }
+
+    protected function seedContacts(Company $company, array $places): void
+    {
+        $contacts = $this->contactFixtures();
 
         foreach ($contacts as $seedId => [$name, $type, $email, $phone, $placeSeedId]) {
             $this->createRecord(Contact::class, [
@@ -174,18 +183,24 @@ class NetworkSeeder extends Seeder
                 'email'        => $email,
                 'phone'        => $phone,
                 'type'         => $type,
-                'notes'        => 'FleetOps testing fixture contact.',
+                'notes'        => $this->fixtureNote('contact'),
                 'meta'         => $this->meta($seedId),
             ]);
         }
     }
 
-    protected function seedVendors(Company $company, array $places): array
+    /** [name, type, email, phone, place seed id] keyed by seed id. */
+    protected function vendorFixtures(): array
     {
-        $vendors = [
+        return [
             'facilitator_fastline' => ['Fastline Logistics', 'facilitator', 'ops@fastline.example.test', '+6592000001', 'central_depot'],
             'supplier_parts'       => ['Apex Parts Supply', 'supplier', 'parts@example.test', '+6592000002', 'west_depot'],
         ];
+    }
+
+    protected function seedVendors(Company $company, array $places): array
+    {
+        $vendors = $this->vendorFixtures();
 
         $models = [];
         foreach ($vendors as $seedId => [$name, $type, $email, $phone, $placeSeedId]) {
@@ -199,7 +214,7 @@ class NetworkSeeder extends Seeder
                 'country'      => 'SG',
                 'status'       => 'active',
                 'type'         => $type,
-                'notes'        => 'FleetOps testing fixture vendor.',
+                'notes'        => $this->fixtureNote('vendor'),
                 'meta'         => $this->meta($seedId),
             ]);
         }

--- a/server/seeders/Testing/OrdersSeeder.php
+++ b/server/seeders/Testing/OrdersSeeder.php
@@ -35,7 +35,7 @@ class OrdersSeeder extends Seeder
             $this->purgeSeedData();
             $this->seedOrders($company);
 
-            $this->command?->info('Seeded FleetOps testing order fixtures for company: ' . $company->public_id);
+            $this->command?->info('Seeded ' . $this->seedName() . ' order fixtures for company: ' . $company->public_id);
         });
     }
 
@@ -47,6 +47,22 @@ class OrdersSeeder extends Seeder
         $this->purgeModel(Waypoint::class);
         $this->purgeModel(TrackingNumber::class);
         $this->purgeModel(Payload::class);
+    }
+
+    /**
+     * The human-facing order reference. Overridable because it is the most visible string on
+     * the orders table, and because src/resolve.mjs in the screenshots package looks a
+     * specific order up by exactly this value.
+     */
+    protected function orderInternalId(string $seedId): string
+    {
+        return $this->identifierPrefix() . '-' . strtoupper(str_replace('order_', '', $seedId));
+    }
+
+    /** The label shown for the nth item inside an order's payload. */
+    protected function entityNameFor(string $seedId, int $index): string
+    {
+        return 'Item ' . $index;
     }
 
     protected function seedOrders(Company $company): void
@@ -89,7 +105,7 @@ class OrdersSeeder extends Seeder
             $payload = $this->createPayload($company, $seedId, $places[$pickupSeedId], $places[$dropoffSeedId], array_map(fn ($placeSeedId) => $places[$placeSeedId], $waypointSeedIds));
             $order   = $this->createRecord(Order::class, [
                 '_key'                  => $this->fixtureKey($seedId),
-                'internal_id'           => 'TEST-' . strtoupper(str_replace('order_', '', $seedId)),
+                'internal_id'           => $this->orderInternalId($seedId),
                 'company_uuid'          => $company->uuid,
                 'payload_uuid'          => $payload->uuid,
                 'order_config_uuid'     => $orderConfig->uuid,
@@ -108,7 +124,7 @@ class OrdersSeeder extends Seeder
                 'started_at'            => $started ? $this->timestamp($hourOffset + 1) : null,
                 'type'                  => 'transport',
                 'status'                => $status,
-                'notes'                 => 'FleetOps testing fixture order: ' . $seedId,
+                'notes'                 => $this->fixtureNote('order'),
                 'pod_method'            => 'scan',
                 'pod_required'          => $status === 'completed',
                 'orchestrator_priority' => 50,
@@ -146,7 +162,7 @@ class OrdersSeeder extends Seeder
                 'type'         => 'dropoff',
                 'order'        => $index + 1,
                 'service_time' => 300,
-                'notes'        => 'FleetOps testing waypoint.',
+                'notes'        => $this->fixtureNote('waypoint'),
             ]);
         }
 
@@ -161,7 +177,7 @@ class OrdersSeeder extends Seeder
             'company_uuid'    => $company->uuid,
             'owner_uuid'      => $order->uuid,
             'owner_type'      => Order::class,
-            'tracking_number' => 'TEST-' . str_pad((string) crc32($seedId), 10, '0', STR_PAD_LEFT),
+            'tracking_number' => $this->identifierPrefix() . '-' . str_pad((string) crc32($seedId), 10, '0', STR_PAD_LEFT),
             'region'          => 'SG',
         ]);
 
@@ -179,10 +195,10 @@ class OrdersSeeder extends Seeder
                 'payload_uuid'         => $payload->uuid,
                 'tracking_number_uuid' => $trackingNumber->uuid,
                 'destination_uuid'     => $destination?->uuid,
-                'internal_id'          => 'TEST-ENTITY-' . strtoupper($seedId) . '-' . $i,
-                'name'                 => 'Item ' . $i,
+                'internal_id'          => $this->identifierPrefix() . '-ENTITY-' . strtoupper($seedId) . '-' . $i,
+                'name'                 => $this->entityNameFor($seedId, $i),
                 'type'                 => 'parcel',
-                'description'          => 'FleetOps testing fixture entity.',
+                'description'          => $this->fixtureNote('item'),
                 'weight'               => 5 + $i,
                 'weight_unit'          => 'kg',
                 'length'               => 40,


### PR DESCRIPTION
### What change does this PR introduce?

Adds `server/seeders/Demo/` — a second Fleet-Ops fixture set that reuses all of the Testing machinery but replaces the strings that are visible on screen.

Run it with:

```
php artisan db:seed --force --class="Fleetbase\FleetOps\Seeders\Demo\DemoSeeder"
```

To make that possible without duplicating the fixtures, `SeedsTestingData` gains four overridable hooks — `seedName()`, `seedLabel()`, `identifierPrefix()` and `fixtureNote()` — plus `userFixtures()`, `contactFixtures()`, `vendorFixtures()`, `orderInternalId()` and `entityNameFor()` on the individual seeders. `Demo/` is then six small subclasses.

`SEED_NAME` could not simply be redeclared by a subclass: PHP rejects a class that redeclares a trait constant with a different value (*"the definition differs and is considered incompatible"*). The constant stays put as what the default `seedName()` returns.

### Why was this change needed?

The Testing fixtures are structurally excellent — real Singapore coordinates, 25 vehicles with genuine makes and models, orders spread across the status pipeline. But every visible string announces itself as test data: `TEST-` identifiers, `@example.test` addresses, `FleetOps testing fixture` notes.

That is exactly right for assertions and exactly wrong for the console screenshots that the `fleetbase/fleetbase` monorepo captures and publishes to fleetbase.io. This is the data half of that pipeline; the capture half is a companion PR on the monorepo.

Records are already tagged `meta->seed`, so the distinct seed name makes the two sets independently purgeable — seeding or purging one never touches the other, and both can coexist in a single install.

### Other information

**What actually differs.** Only people and identifiers. Vehicles, places, fleets, zones, service rates, devices and maintenance records are inherited untouched.

| | Testing | Demo |
| --- | --- | --- |
| Drivers | Ava / Ken / Mira Driver | Amara Chen, Kenji Tan, Mira Rahman |
| Emails | `ava.driver.testing@example.test` | `amara.chen@demo.fleetbase.io` |
| Order refs | `TEST-STARTED` | `FLT-1004` |
| Item names | `Item 1` | `Small parcel` |
| Notes | `FleetOps testing fixture order.` | `Standard transport order.` |

**Behaviour change to the Testing set.** Every hook default reproduces the current output, with two cosmetic exceptions where the existing string did not fit the shared pattern: order notes lose their `: <seedId>` suffix, and the zone description is normalised to match its siblings. Nothing in `server/tests` asserts on either — I grepped.

**`SEEDED_FIXTURES`.** `DemoSeeder` ends by echoing the public_ids of the records that detail-page screenshots point at, following the `MINTED_` / `SEEDED_` echo protocol from the monorepo's `scripts/ci/mint-api-key.php`. The capture script resolves those same records independently through the internal API, so two unrelated paths have to agree — a disagreement fails the run rather than quietly publishing a screenshot of the wrong driver.

**Coverage** is unaffected: `phpunit.xml` scopes `<source>` to `server/src`, so `server/seeders` is not in the denominator.

### Not verified

I could not run `php-cs-fixer` or the test suite — the submodule has no vendor tree in my checkout. Everything passes `php -l`, and the trait-composition semantics (trait methods overriding inherited ones, and the constant-redeclaration limitation) were confirmed against a real PHP 8.4. Please run `composer test` before merging.