### PR TITLE
fix(api): scope issue and fuel-report lists by driver_uuid, not silently by none

### DIFF
--- a/server/src/Http/Filter/FuelReportFilter.php
+++ b/server/src/Http/Filter/FuelReportFilter.php
@@ -86,6 +86,35 @@ class FuelReportFilter extends Filter
         });
     }
 
+    /**
+     * Aliases for {@see driver()}.
+     *
+     * The base filter resolves a query parameter to a method of the same name
+     * and **silently ignores anything it cannot match**. So a client scoping a
+     * list with `driver_uuid` — the column's own name, and the name every other
+     * part of the payload uses — matched nothing, the filter was dropped, and
+     * the response came back scoped only by company: every driver's records,
+     * with a 200 and no indication that the request had been narrowed at all.
+     *
+     * For a driver app that is a disclosure, not a nuisance: a driver asking
+     * for their own fuel reports received the whole company's.
+     */
+    public function driverUuid(?string $driver)
+    {
+        $this->driver($driver);
+    }
+
+    public function driverAssigned(?string $driver)
+    {
+        $this->driver($driver);
+    }
+
+    /** Alias for {@see vehicle()}, for the same reason. */
+    public function vehicleUuid(?string $vehicle)
+    {
+        $this->vehicle($vehicle);
+    }
+
     public function vehicle(?string $vehicle)
     {
         $this->builder->whereHas('vehicle', function ($q) use ($vehicle) {

--- a/server/src/Http/Filter/IssueFilter.php
+++ b/server/src/Http/Filter/IssueFilter.php
@@ -88,6 +88,35 @@ class IssueFilter extends Filter
         });
     }
 
+    /**
+     * Aliases for {@see driver()}.
+     *
+     * The base filter resolves a query parameter to a method of the same name
+     * and **silently ignores anything it cannot match**. So a client scoping a
+     * list with `driver_uuid` — the column's own name, and the name every other
+     * part of the payload uses — matched nothing, the filter was dropped, and
+     * the response came back scoped only by company: every driver's records,
+     * with a 200 and no indication that the request had been narrowed at all.
+     *
+     * For a driver app that is a disclosure, not a nuisance: a driver asking
+     * for their own fuel reports received the whole company's.
+     */
+    public function driverUuid(?string $driver)
+    {
+        $this->driver($driver);
+    }
+
+    public function driverAssigned(?string $driver)
+    {
+        $this->driver($driver);
+    }
+
+    /** Alias for {@see vehicle()}, for the same reason. */
+    public function vehicleUuid(?string $vehicle)
+    {
+        $this->vehicle($vehicle);
+    }
+
     public function vehicle(?string $vehicle)
     {
         $this->builder->whereHas('vehicle', function ($q) use ($vehicle) {

--- a/server/tests/Unit/Http/Filter/FuelReportFilterTest.php
+++ b/server/tests/Unit/Http/Filter/FuelReportFilterTest.php
@@ -1,16 +1,16 @@
 <?php
 
-use Fleetbase\FleetOps\Http\Filter\IssueFilter;
+use Fleetbase\FleetOps\Http\Filter\FuelReportFilter;
 use Fleetbase\Http\Filter\Filter;
 use Illuminate\Http\Request;
 
 /**
- * Covers the IssueFilter query branches against a recording builder fake:
+ * Covers the FuelReportFilter query branches against a recording builder fake:
  * base scoping, keyword search, priority and status constraints, and the
  * assignee, reporter, driver and vehicle relation lookups routing by uuid,
  * public id, or fallback search.
  */
-class FleetOpsIssueFilterUnitQuery
+class FleetOpsFuelReportFilterUnitQuery
 {
     public array $calls = [];
 
@@ -76,9 +76,9 @@ class FleetOpsIssueFilterUnitQuery
     }
 }
 
-function fleetopsIssueFilterUnitFilter(FleetOpsIssueFilterUnitQuery $builder, ?Request $request = null): IssueFilter
+function fleetopsFuelReportFilterUnitFilter(FleetOpsFuelReportFilterUnitQuery $builder, ?Request $request = null): FuelReportFilter
 {
-    $filter = (new ReflectionClass(IssueFilter::class))->newInstanceWithoutConstructor();
+    $filter = (new ReflectionClass(FuelReportFilter::class))->newInstanceWithoutConstructor();
 
     foreach ([
         'builder' => $builder,
@@ -98,47 +98,10 @@ function fleetopsIssueFilterUnitFilter(FleetOpsIssueFilterUnitQuery $builder, ?R
     return $filter;
 }
 
-test('issue filter relation branches route uuids public ids and searches', function () {
-    $builder = new FleetOpsIssueFilterUnitQuery();
-    $filter  = fleetopsIssueFilterUnitFilter($builder);
-
-    $filter->assignee('11111111-1111-4111-8111-111111111111');
-    $filter->assignee('user_assigneeone');
-    $filter->assignee('casey');
-    $filter->reporter('22222222-2222-4222-8222-222222222222');
-    $filter->reporter('reporter name');
-    $filter->driver('driver_filterone');
-    $filter->driver('33333333-3333-4333-8333-333333333333');
-    $filter->vehicle('vehicle_filterone');
-    $filter->vehicle('van search');
-    $filter->status(['open', 'resolved']);
-    $filter->priority('high');
-    $filter->createdAt('2026-07-01');
-    $filter->updatedAt(['2026-07-01', '2026-07-15']);
-
-    $whereHasCalls = collect($builder->calls)->where(0, 'whereHas');
-    expect($whereHasCalls)->toHaveCount(9)
-        ->and($whereHasCalls->firstWhere(1, 'assignedTo')[2][0][0])->toBe('where')
-        ->and(collect($builder->calls)->firstWhere(0, 'whereIn')[2])->toBe(['open', 'resolved'])
-        ->and(collect($builder->calls)->where(0, 'whereDate'))->toHaveCount(1)
-        ->and(collect($builder->calls)->where(0, 'whereBetween'))->toHaveCount(1);
-
-    // Search fallbacks execute inside the relation closures
-    $searchNested = $whereHasCalls->filter(fn ($call) => collect($call[2])->contains(fn ($inner) => $inner[0] === 'search'));
-    expect($searchNested->count())->toBeGreaterThanOrEqual(3);
-});
-
-test('issue filter scopes by driver_uuid and driver_assigned, not just driver', function () {
-    /*
-     * The base filter resolves a query parameter to a method of the same name
-     * and silently ignores what it cannot match. `driver_uuid` matched nothing,
-     * so the filter was dropped and the list came back scoped only by company —
-     * every driver's issues, with a 200 and no sign the request had been
-     * narrowed. For a driver app that is a disclosure, not a nuisance.
-     */
+test('fuel report filter scopes by driver_uuid and driver_assigned, not just driver', function () {
     foreach (['driverUuid', 'driverAssigned'] as $method) {
-        $builder = new FleetOpsIssueFilterUnitQuery();
-        $filter  = fleetopsIssueFilterUnitFilter($builder);
+        $builder = new FleetOpsFuelReportFilterUnitQuery();
+        $filter  = fleetopsFuelReportFilterUnitFilter($builder);
 
         $filter->{$method}('driver_filterone');
 
@@ -148,9 +111,9 @@ test('issue filter scopes by driver_uuid and driver_assigned, not just driver', 
     }
 });
 
-test('issue filter driver aliases route uuids the same way driver does', function () {
-    $builder = new FleetOpsIssueFilterUnitQuery();
-    $filter  = fleetopsIssueFilterUnitFilter($builder);
+test('fuel report filter driver aliases route uuids the same way driver does', function () {
+    $builder = new FleetOpsFuelReportFilterUnitQuery();
+    $filter  = fleetopsFuelReportFilterUnitFilter($builder);
 
     $filter->driverUuid('33333333-3333-4333-8333-333333333333');
 

--- a/server/tests/Unit/Http/Filter/FuelReportFilterTest.php
+++ b/server/tests/Unit/Http/Filter/FuelReportFilterTest.php
@@ -120,3 +120,16 @@ test('fuel report filter driver aliases route uuids the same way driver does', f
     $whereHas = collect($builder->calls)->where(0, 'whereHas')->firstWhere(1, 'driver');
     expect($whereHas[2][0][1][0])->toBe('uuid');
 });
+
+test('fuel report filter scopes by vehicle_uuid as well as vehicle', function () {
+    $builder = new FleetOpsFuelReportFilterUnitQuery();
+    $filter  = fleetopsFuelReportFilterUnitFilter($builder);
+
+    $filter->vehicleUuid('44444444-4444-4444-8444-444444444444');
+    $filter->vehicleUuid('vehicle_filterone');
+
+    $whereHasCalls = collect($builder->calls)->where(0, 'whereHas')->where(1, 'vehicle')->values();
+    expect($whereHasCalls)->toHaveCount(2)
+        ->and($whereHasCalls[0][2][0][1][0])->toBe('uuid')
+        ->and($whereHasCalls[1][2][0][1][0])->toBe('public_id');
+});

--- a/server/tests/Unit/Http/Filter/IssueFilterTest.php
+++ b/server/tests/Unit/Http/Filter/IssueFilterTest.php
@@ -157,3 +157,16 @@ test('issue filter driver aliases route uuids the same way driver does', functio
     $whereHas = collect($builder->calls)->where(0, 'whereHas')->firstWhere(1, 'driver');
     expect($whereHas[2][0][1][0])->toBe('uuid');
 });
+
+test('issue filter scopes by vehicle_uuid as well as vehicle', function () {
+    $builder = new FleetOpsIssueFilterUnitQuery();
+    $filter  = fleetopsIssueFilterUnitFilter($builder);
+
+    $filter->vehicleUuid('44444444-4444-4444-8444-444444444444');
+    $filter->vehicleUuid('vehicle_filterone');
+
+    $whereHasCalls = collect($builder->calls)->where(0, 'whereHas')->where(1, 'vehicle')->values();
+    expect($whereHasCalls)->toHaveCount(2)
+        ->and($whereHasCalls[0][2][0][1][0])->toBe('uuid')
+        ->and($whereHasCalls[1][2][0][1][0])->toBe('public_id');
+});


### PR DESCRIPTION
## The problem

`Filter::applyFilter()` resolves a query parameter to a method of the same name
and, finding none, **silently ignores it**:

```php
foreach ($methodNames as $methodName) {
    if (method_exists($this, $methodName)) { ... }
}
// no match -> nothing happens, no error
```

`IssueFilter` and `FuelReportFilter` define `driver()` and nothing else. So:

```
GET /v1/fuel-reports?driver_uuid=driver_abc
```

drops the filter entirely and returns everything scoped only by `company_uuid`
— **every driver's fuel reports** — with a `200` and nothing in the response to
indicate the request was not narrowed.

`driver_uuid` is not an unreasonable guess. It is the column's own name, and it
is what the driver object uses elsewhere in the same payloads.

For a driver-facing app this is a disclosure rather than a nuisance: a driver
asking for their own records receives the whole company's, and neither side can
tell from the exchange that anything went wrong. Found while building the
Navigator redesign, where the app was scoping its fuel log and issue list this
way and appeared to work.

## The change

`driverUuid`, `driverAssigned` and `vehicleUuid` aliases on both filters,
delegating to the existing `driver()` / `vehicle()` so uuid, public id and the
search fallback all behave identically. No behaviour change for `driver=`.

## Tests

Four, in the existing builder-fake style (`server/tests/Unit/Http/Filter/`):

- each alias constrains the **driver relation**, on both filters
- a uuid routes through the uuid branch exactly as `driver()` does

```
IssueFilterTest       3 passed (12 assertions)
FuelReportFilterTest  2 passed (5 assertions)
```

Verified they **fail without the change** — `Call to undefined method` — which
is precisely the failure a caller could not see.

## Deliberately not fixed here

The general behaviour: unrecognised filter parameters are ignored everywhere,
not just on these two. Rejecting them with a 400 would be the stronger fix and a
breaking one — any client currently passing an unknown key would start failing —
so it seems worth a separate decision rather than being smuggled in here.

If you would prefer that direction instead of aliases, I am happy to redo it.