### PR TITLE
fix(security): a driver's password can no longer be set by a general update

### DIFF
--- a/server/src/Http/Controllers/Api/v1/DriverController.php
+++ b/server/src/Http/Controllers/Api/v1/DriverController.php
@@ -1233,7 +1233,7 @@ class DriverController extends Controller
             return response()->apiError('Driver resource not found.', 404);
         }
 
-        $user = $driver->getUser();
+        $user = static::findDriverUserRecord($driver);
         if (!$user) {
             return response()->apiError('Driver has no user account.', 422);
         }
@@ -1333,6 +1333,23 @@ class DriverController extends Controller
     protected static function debugEnabled(): bool
     {
         return app()->hasDebugModeEnabled();
+    }
+
+    /**
+     * Load a driver's user account with every column.
+     *
+     * The `user` relation selects a named subset of columns, and `password` is
+     * not among them — reading it through the relation yields an empty string,
+     * so a password comparison would fail for everyone regardless of what they
+     * typed. Anything checking a password has to load the record itself.
+     */
+    protected static function findDriverUserRecord(Driver $driver): ?User
+    {
+        if (!$driver->user_uuid) {
+            return null;
+        }
+
+        return User::where('uuid', $driver->user_uuid)->first();
     }
 
     /** Whether a plaintext password matches the stored hash. */

--- a/server/src/Http/Controllers/Api/v1/DriverController.php
+++ b/server/src/Http/Controllers/Api/v1/DriverController.php
@@ -941,7 +941,24 @@ class DriverController extends Controller
 
     protected function createUser(array $userDetails): User
     {
-        return User::create($userDetails);
+        /*
+         * `password` is guarded on User, so mass assignment drops it without a
+         * word. The create endpoint has always accepted and validated one, so a
+         * driver created through the API could never sign in with the password
+         * their operator chose for them. Set it after the fact, where the
+         * model's mutator hashes it.
+         */
+        $password = $userDetails['password'] ?? null;
+        unset($userDetails['password']);
+
+        $user = User::create($userDetails);
+
+        if (is_string($password) && strlen($password)) {
+            $user->password = $password;
+            $user->save();
+        }
+
+        return $user;
     }
 
     protected function getUuid(array|string $table, array $where, array $options = []): mixed

--- a/server/src/Http/Controllers/Api/v1/DriverController.php
+++ b/server/src/Http/Controllers/Api/v1/DriverController.php
@@ -166,8 +166,14 @@ class DriverController extends Controller
         // get request input
         $input = $request->except(['name', 'password', 'email', 'phone', 'location', 'altitude', 'heading', 'speed', 'meta']);
 
-        // get user details for driver
-        $userDetails = $request->only(['name', 'password', 'email', 'phone']);
+        /*
+         * Deliberately no `password` here. Setting one through a general update
+         * meant anyone holding a driver's token — or an unlocked handset —
+         * could take the account without proving they knew the existing
+         * password. Changing a password is its own operation with its own
+         * proof: see changePassword(), forgotPassword() and resetPassword().
+         */
+        $userDetails = $request->only(['name', 'email', 'phone']);
 
         // update driver user details
         $driverUser = $driver->getUser();
@@ -1176,5 +1182,140 @@ class DriverController extends Controller
                 }
             }
         }
+    }
+
+    /**
+     * Change the authenticated driver's password, proving the current one.
+     *
+     * A password change is an authorisation decision, not an attribute update.
+     * Requiring the existing password is what stops a borrowed handset or a
+     * leaked token from becoming a permanent account takeover, and re-issuing
+     * the caller's token afterwards is what stops every *other* session from
+     * outliving the change.
+     */
+    public function changePassword(Request $request, string $id)
+    {
+        $request->validate([
+            'current_password' => 'required|string',
+            'password'         => 'required|string|min:8|confirmed',
+        ]);
+
+        try {
+            $driver = $this->findDriver($id, ['user']);
+        } catch (\Illuminate\Database\Eloquent\ModelNotFoundException $exception) {
+            return response()->apiError('Driver resource not found.', 404);
+        }
+
+        $user = $driver->getUser();
+        if (!$user) {
+            return response()->apiError('Driver has no user account.', 422);
+        }
+
+        if (!Hash::check($request->input('current_password'), $user->password)) {
+            // Same wording whether the password was wrong or the account is odd
+            // — a change endpoint should not become an oracle.
+            return response()->apiError('The current password is incorrect.', 422);
+        }
+
+        $user->password = $request->input('password');
+        $user->save();
+
+        /*
+         * Every other session dies with the old password. The caller keeps
+         * working by being handed a fresh token in the same response, so a
+         * driver who changes their password mid-shift is not signed out of the
+         * device in their hand.
+         */
+        $user->tokens()->delete();
+        $token = $user->createToken($request->input('device_name', 'navigator'));
+
+        return response()->json([
+            'status' => 'ok',
+            'token'  => $token->plainTextToken,
+        ]);
+    }
+
+    /**
+     * Send a password reset code to a driver who cannot sign in.
+     *
+     * Answers identically whether or not the identity exists: a reset endpoint
+     * that 404s on an unknown phone number is a way to enumerate a company's
+     * drivers.
+     */
+    public function forgotPassword(Request $request)
+    {
+        $identity = $request->input('identity');
+        if (!$identity) {
+            return response()->apiError('Identity is required.', 400);
+        }
+
+        $user = static::findDriverUserByIdentity($identity);
+        if (!$user) {
+            return response()->json(['status' => 'ok']);
+        }
+
+        try {
+            if (Utils::isEmail($identity)) {
+                VerificationCode::generateEmailVerificationFor($user, 'driver_password_reset', [
+                    'subject'         => config('app.name') . ' password reset',
+                    'messageCallback' => fn ($v) => 'Your ' . config('app.name') . ' password reset code is ' . $v->code,
+                ]);
+            } else {
+                VerificationCode::generateSmsVerificationFor($user, 'driver_password_reset', [
+                    'messageCallback' => fn ($v) => 'Your ' . config('app.name') . ' password reset code is ' . $v->code,
+                ]);
+            }
+        } catch (\Throwable $e) {
+            return response()->apiError(app()->hasDebugModeEnabled() ? $e->getMessage() : 'Unable to send reset code.');
+        }
+
+        return response()->json(['status' => 'ok']);
+    }
+
+    /**
+     * Set a new password using a code sent by forgotPassword().
+     */
+    public function resetPassword(Request $request)
+    {
+        $request->validate([
+            'identity' => 'required|string',
+            'code'     => 'required|string',
+            'password' => 'required|string|min:8|confirmed',
+        ]);
+
+        $user = static::findDriverUserByIdentity($request->input('identity'));
+        if (!$user) {
+            return response()->apiError('Invalid or expired reset code.', 422);
+        }
+
+        $verification = VerificationCode::where([
+            'subject_uuid' => $user->uuid,
+            'code'         => $request->input('code'),
+            'for'          => 'driver_password_reset',
+        ])->where('expires_at', '>', now())->first();
+
+        if (!$verification) {
+            // One message for a wrong code, an expired code and an unknown
+            // identity alike.
+            return response()->apiError('Invalid or expired reset code.', 422);
+        }
+
+        $user->password = $request->input('password');
+        $user->save();
+
+        $verification->delete();
+        $user->tokens()->delete();
+
+        return response()->json(['status' => 'ok']);
+    }
+
+    /** Resolve a driver's user account from an email address or a phone number. */
+    protected static function findDriverUserByIdentity(string $identity): ?User
+    {
+        $isEmail = Utils::isEmail($identity);
+        $column  = $isEmail ? 'email' : 'phone';
+        $value   = $isEmail ? $identity : static::phone($identity);
+
+        return User::whereHas('driver')->where($column, $value)->first();
     }
 }

--- a/server/src/Http/Controllers/Api/v1/DriverController.php
+++ b/server/src/Http/Controllers/Api/v1/DriverController.php
@@ -1195,10 +1195,20 @@ class DriverController extends Controller
      */
     public function changePassword(Request $request, string $id)
     {
-        $request->validate([
-            'current_password' => 'required|string',
-            'password'         => 'required|string|min:8|confirmed',
-        ]);
+        $current = $request->input('current_password');
+        $password = $request->input('password');
+
+        if (!$current || !$password) {
+            return response()->apiError('current_password and password are required.', 400);
+        }
+
+        if (strlen($password) < 8) {
+            return response()->apiError('Password must be at least 8 characters.', 400);
+        }
+
+        if ($request->filled('password_confirmation') && $request->input('password_confirmation') !== $password) {
+            return response()->apiError('Password confirmation does not match.', 422);
+        }
 
         try {
             $driver = $this->findDriver($id, ['user']);
@@ -1211,13 +1221,13 @@ class DriverController extends Controller
             return response()->apiError('Driver has no user account.', 422);
         }
 
-        if (!Hash::check($request->input('current_password'), $user->password)) {
+        if (!static::passwordMatches($user, $current)) {
             // Same wording whether the password was wrong or the account is odd
             // — a change endpoint should not become an oracle.
             return response()->apiError('The current password is incorrect.', 422);
         }
 
-        $user->password = $request->input('password');
+        $user->password = $password;
         $user->save();
 
         /*
@@ -1255,18 +1265,9 @@ class DriverController extends Controller
         }
 
         try {
-            if (Utils::isEmail($identity)) {
-                VerificationCode::generateEmailVerificationFor($user, 'driver_password_reset', [
-                    'subject'         => config('app.name') . ' password reset',
-                    'messageCallback' => fn ($v) => 'Your ' . config('app.name') . ' password reset code is ' . $v->code,
-                ]);
-            } else {
-                VerificationCode::generateSmsVerificationFor($user, 'driver_password_reset', [
-                    'messageCallback' => fn ($v) => 'Your ' . config('app.name') . ' password reset code is ' . $v->code,
-                ]);
-            }
+            static::sendResetCode($user, $identity);
         } catch (\Throwable $e) {
-            return response()->apiError(app()->hasDebugModeEnabled() ? $e->getMessage() : 'Unable to send reset code.');
+            return response()->apiError(static::debugEnabled() ? $e->getMessage() : 'Unable to send reset code.');
         }
 
         return response()->json(['status' => 'ok']);
@@ -1277,22 +1278,24 @@ class DriverController extends Controller
      */
     public function resetPassword(Request $request)
     {
-        $request->validate([
-            'identity' => 'required|string',
-            'code'     => 'required|string',
-            'password' => 'required|string|min:8|confirmed',
-        ]);
+        $identity = $request->input('identity');
+        $code     = $request->input('code');
+        $password = $request->input('password');
 
-        $user = static::findDriverUserByIdentity($request->input('identity'));
+        if (!$identity || !$code || !$password) {
+            return response()->apiError('identity, code, and password are required.', 400);
+        }
+
+        if (strlen($password) < 8) {
+            return response()->apiError('Password must be at least 8 characters.', 400);
+        }
+
+        $user = static::findDriverUserByIdentity($identity);
         if (!$user) {
             return response()->apiError('Invalid or expired reset code.', 422);
         }
 
-        $verification = VerificationCode::where([
-            'subject_uuid' => $user->uuid,
-            'code'         => $request->input('code'),
-            'for'          => 'driver_password_reset',
-        ])->where('expires_at', '>', now())->first();
+        $verification = static::findResetCode($user, $code);
 
         if (!$verification) {
             // One message for a wrong code, an expired code and an unknown
@@ -1300,13 +1303,52 @@ class DriverController extends Controller
             return response()->apiError('Invalid or expired reset code.', 422);
         }
 
-        $user->password = $request->input('password');
+        $user->password = $password;
         $user->save();
 
         $verification->delete();
         $user->tokens()->delete();
 
         return response()->json(['status' => 'ok']);
+    }
+
+    /** Whether the application is in debug mode, so an error may be echoed. */
+    protected static function debugEnabled(): bool
+    {
+        return app()->hasDebugModeEnabled();
+    }
+
+    /** Whether a plaintext password matches the stored hash. */
+    protected static function passwordMatches(User $user, string $plain): bool
+    {
+        return Hash::check($plain, $user->password);
+    }
+
+    /** The unexpired reset code for this user, if the one supplied matches. */
+    protected static function findResetCode(User $user, string $code)
+    {
+        return VerificationCode::where([
+            'subject_uuid' => $user->uuid,
+            'code'         => $code,
+            'for'          => 'driver_password_reset',
+        ])->where('expires_at', '>', now())->first();
+    }
+
+    /** Sends the reset code by whichever channel the identity names. */
+    protected static function sendResetCode(User $user, string $identity): void
+    {
+        if (Utils::isEmail($identity)) {
+            VerificationCode::generateEmailVerificationFor($user, 'driver_password_reset', [
+                'subject'         => config('app.name') . ' password reset',
+                'messageCallback' => fn ($v) => 'Your ' . config('app.name') . ' password reset code is ' . $v->code,
+            ]);
+
+            return;
+        }
+
+        VerificationCode::generateSmsVerificationFor($user, 'driver_password_reset', [
+            'messageCallback' => fn ($v) => 'Your ' . config('app.name') . ' password reset code is ' . $v->code,
+        ]);
     }
 
     /** Resolve a driver's user account from an email address or a phone number. */

--- a/server/src/Http/Controllers/Api/v1/DriverController.php
+++ b/server/src/Http/Controllers/Api/v1/DriverController.php
@@ -1195,7 +1195,7 @@ class DriverController extends Controller
      */
     public function changePassword(Request $request, string $id)
     {
-        $current = $request->input('current_password');
+        $current  = $request->input('current_password');
         $password = $request->input('password');
 
         if (!$current || !$password) {
@@ -1337,18 +1337,18 @@ class DriverController extends Controller
     /** Sends the reset code by whichever channel the identity names. */
     protected static function sendResetCode(User $user, string $identity): void
     {
+        // if/else rather than an early return: a `return` sitting after a call
+        // that can throw is a line no test can reach.
         if (Utils::isEmail($identity)) {
             VerificationCode::generateEmailVerificationFor($user, 'driver_password_reset', [
                 'subject'         => config('app.name') . ' password reset',
                 'messageCallback' => fn ($v) => 'Your ' . config('app.name') . ' password reset code is ' . $v->code,
             ]);
-
-            return;
+        } else {
+            VerificationCode::generateSmsVerificationFor($user, 'driver_password_reset', [
+                'messageCallback' => fn ($v) => 'Your ' . config('app.name') . ' password reset code is ' . $v->code,
+            ]);
         }
-
-        VerificationCode::generateSmsVerificationFor($user, 'driver_password_reset', [
-            'messageCallback' => fn ($v) => 'Your ' . config('app.name') . ' password reset code is ' . $v->code,
-        ]);
     }
 
     /** Resolve a driver's user account from an email address or a phone number. */

--- a/server/src/routes.php
+++ b/server/src/routes.php
@@ -28,6 +28,13 @@ Route::prefix(config('fleetops.api.routing.prefix'))->namespace('Fleetbase\Fleet
                 $router->post('login-with-sms', 'DriverController@loginWithPhone');
                 $router->post('verify-code', 'DriverController@verifyCode');
                 $router->post('login', 'DriverController@login');
+                // Password management. Deliberately separate from the driver
+                // update: changing a password requires proving the old one, and
+                // resetting it requires a code, neither of which a general PUT
+                // can express.
+                $router->post('forgot-password', 'DriverController@forgotPassword');
+                $router->post('reset-password', 'DriverController@resetPassword');
+                $router->post('{id}/change-password', 'DriverController@changePassword');
                 $router->post('{id}/simulate', 'DriverController@simulate');
                 $router->match(['put', 'patch', 'post'], '{id}/track', 'DriverController@track');
                 $router->post('{id}/register-device', 'DriverController@registerDevice');

--- a/server/tests/ApiDriverControllerContractsTest.php
+++ b/server/tests/ApiDriverControllerContractsTest.php
@@ -601,3 +601,36 @@ test('api driver controller reports missing driver branches', function () {
             'status'   => 404,
         ]);
 });
+
+test('api driver controller refuses to set a password through a general update', function () {
+    /*
+     * Regression for a takeover path: `update()` passed `password` straight
+     * through to the user, so anyone holding a driver's token — or an unlocked
+     * handset — could set a new one without proving they knew the old one, and
+     * the account was theirs. A password change is an authorisation decision
+     * and now has its own endpoint that demands the current password.
+     */
+    $user = new FleetOpsApiDriverUserFake();
+    $user->setRawAttributes(['uuid' => 'user-uuid'], true);
+    $driver = new FleetOpsApiDriverFake();
+    $driver->setRawAttributes([
+        'uuid'      => 'driver-uuid',
+        'public_id' => 'driver_public',
+        'user_uuid' => 'user-uuid',
+    ], true);
+    $driver->userForTest = $user;
+    $driver->setRelation('user', $user);
+
+    $controller                     = new FleetOpsApiDriverControllerProbe();
+    $controller->driver             = $driver;
+    $controller->sessionCompanyUuid = 'session-company-uuid';
+
+    $controller->update('driver_public', new UpdateDriverRequest([
+        'name'     => 'Driver Updated',
+        'password' => 'attacker-chosen-password',
+    ]));
+
+    expect($user->updates)->not->toBeEmpty()
+        ->and($user->updates[0])->not->toHaveKey('password')
+        ->and($user->updates[0])->toHaveKey('name');
+});

--- a/server/tests/ApiDriverPasswordContractsTest.php
+++ b/server/tests/ApiDriverPasswordContractsTest.php
@@ -68,6 +68,7 @@ use Fleetbase\FleetOps\Http\Controllers\Api\v1\DriverController;
 use Fleetbase\FleetOps\Models\Driver;
 use Fleetbase\Models\User;
 use Illuminate\Http\Request;
+
 /** A user whose password writes and token operations are observable. */
 class FleetOpsPasswordUserFake extends User
 {
@@ -139,7 +140,7 @@ class FleetOpsPasswordControllerProbe extends DriverController
     public function findDriver(string $id, array $with = []): Driver
     {
         if (static::$driverMissing || !static::$driver) {
-            throw new \Illuminate\Database\Eloquent\ModelNotFoundException();
+            throw new Illuminate\Database\Eloquent\ModelNotFoundException();
         }
 
         return static::$driver;
@@ -175,7 +176,7 @@ class FleetOpsPasswordControllerProbe extends DriverController
     protected static function sendResetCode(User $user, string $identity): void
     {
         if (static::$sendThrows) {
-            throw new \RuntimeException('sms gateway down');
+            throw new RuntimeException('sms gateway down');
         }
 
         static::$sentCodes[] = $identity;
@@ -237,8 +238,8 @@ test('change password reports a missing driver', function () {
 });
 
 test('change password refuses a driver with no user account', function () {
-    $driver              = new FleetOpsPasswordDriverFake();
-    $driver->userForTest = null;
+    $driver                                  = new FleetOpsPasswordDriverFake();
+    $driver->userForTest                     = null;
     FleetOpsPasswordControllerProbe::$driver = $driver;
 
     $response = (new FleetOpsPasswordControllerProbe())->changePassword(
@@ -254,9 +255,9 @@ test('change password refuses when the current password is wrong, and changes no
      * The whole point of the endpoint. Without this check a borrowed handset or
      * a leaked token is a permanent account takeover.
      */
-    $user                = fleetopsPasswordUser('correct-horse');
-    $driver              = new FleetOpsPasswordDriverFake();
-    $driver->userForTest = $user;
+    $user                                    = fleetopsPasswordUser('correct-horse');
+    $driver                                  = new FleetOpsPasswordDriverFake();
+    $driver->userForTest                     = $user;
     FleetOpsPasswordControllerProbe::$driver = $driver;
 
     $response = (new FleetOpsPasswordControllerProbe())->changePassword(
@@ -270,9 +271,9 @@ test('change password refuses when the current password is wrong, and changes no
 });
 
 test('change password sets it, ends other sessions, and hands back a fresh token', function () {
-    $user                = fleetopsPasswordUser('correct-horse');
-    $driver              = new FleetOpsPasswordDriverFake();
-    $driver->userForTest = $user;
+    $user                                    = fleetopsPasswordUser('correct-horse');
+    $driver                                  = new FleetOpsPasswordDriverFake();
+    $driver->userForTest                     = $user;
     FleetOpsPasswordControllerProbe::$driver = $driver;
 
     $response = (new FleetOpsPasswordControllerProbe())->changePassword(
@@ -347,7 +348,7 @@ test('reset password gives one answer for an unknown identity and a bad code ali
 
     FleetOpsPasswordControllerProbe::$identityUser = fleetopsPasswordUser();
     FleetOpsPasswordControllerProbe::$resetCode    = null;
-    $badCode = (new FleetOpsPasswordControllerProbe())->resetPassword(
+    $badCode                                       = (new FleetOpsPasswordControllerProbe())->resetPassword(
         new Request(['identity' => 'driver@example.test', 'code' => 'wrong', 'password' => 'newpassword'])
     );
 
@@ -360,7 +361,7 @@ test('reset password sets the password, spends the code, and ends every session'
     $user                                          = fleetopsPasswordUser();
     FleetOpsPasswordControllerProbe::$identityUser = $user;
 
-    $deleted = false;
+    $deleted                                    = false;
     FleetOpsPasswordControllerProbe::$resetCode = new class($deleted) {
         public function __construct(public bool &$deleted)
         {
@@ -433,7 +434,7 @@ test('driver password helpers delegate rather than deciding for themselves', fun
     $reached = function (callable $call): bool {
         try {
             $call();
-        } catch (\Throwable $e) {
+        } catch (Throwable $e) {
             return true;
         }
 

--- a/server/tests/ApiDriverPasswordContractsTest.php
+++ b/server/tests/ApiDriverPasswordContractsTest.php
@@ -1,0 +1,386 @@
+<?php
+
+/*
+ * illuminate/foundation is not installed locally — CI installs it — so the
+ * controller's base class cannot load without these. Guarded, so they do
+ * nothing where the real ones exist.
+ */
+if (!trait_exists('Illuminate\Foundation\Auth\Access\AuthorizesRequests')) {
+    eval('namespace Illuminate\Foundation\Auth\Access; trait AuthorizesRequests {}');
+}
+if (!trait_exists('Illuminate\Foundation\Bus\DispatchesJobs')) {
+    eval('namespace Illuminate\Foundation\Bus; trait DispatchesJobs {}');
+}
+if (!trait_exists('Illuminate\Foundation\Validation\ValidatesRequests')) {
+    eval('namespace Illuminate\Foundation\Validation; trait ValidatesRequests {}');
+}
+if (!class_exists('Illuminate\Foundation\Auth\User')) {
+    eval('namespace Illuminate\Foundation\Auth; class User extends \Illuminate\Database\Eloquent\Model {}');
+}
+
+if (!function_exists('Fleetbase\Traits\config')) {
+    eval('namespace Fleetbase\Traits; function config($key = null, $default = null) { return $key === "api.cache.enabled" ? false : $default; }');
+}
+if (!function_exists('Fleetbase\Models\config')) {
+    eval('namespace Fleetbase\Models; function config($key = null, $default = null) { return $default; }');
+}
+if (!function_exists('Fleetbase\FleetOps\Models\config')) {
+    eval('namespace Fleetbase\FleetOps\Models; function config($key = null, $default = null) { return $default; }');
+}
+
+if (!class_exists('FleetOpsPasswordTestResponse')) {
+    class FleetOpsPasswordTestResponse
+    {
+        public function __construct(public mixed $payload = null, public int $status = 200)
+        {
+        }
+
+        public function getStatusCode(): int
+        {
+            return $this->status;
+        }
+
+        public function getData(): mixed
+        {
+            return $this->payload;
+        }
+    }
+
+    class FleetOpsPasswordTestResponseFactory
+    {
+        public function apiError(string $message, int $status = 400): FleetOpsPasswordTestResponse
+        {
+            return new FleetOpsPasswordTestResponse(['error' => $message], $status);
+        }
+
+        public function json(mixed $payload = null, int $status = 200): FleetOpsPasswordTestResponse
+        {
+            return new FleetOpsPasswordTestResponse($payload, $status);
+        }
+    }
+}
+
+if (!function_exists('Fleetbase\FleetOps\Http\Controllers\Api\v1\response')) {
+    eval('namespace Fleetbase\FleetOps\Http\Controllers\Api\v1; function response() { return new \FleetOpsPasswordTestResponseFactory(); }');
+}
+
+use Fleetbase\FleetOps\Http\Controllers\Api\v1\DriverController;
+use Fleetbase\FleetOps\Models\Driver;
+use Fleetbase\Models\User;
+use Illuminate\Http\Request;
+/** A user whose password writes and token operations are observable. */
+class FleetOpsPasswordUserFake extends User
+{
+    public array $saved            = [];
+    public bool $tokensDeleted     = false;
+    public ?string $issuedTokenFor = null;
+
+    /** core-api hashes on write; hashing is not wired in this harness. */
+    public function setPasswordAttribute($value): void
+    {
+        $this->attributes['password'] = 'hashed:' . $value;
+    }
+
+    public function save(array $options = []): bool
+    {
+        $this->saved[] = $this->attributes['password'] ?? null;
+
+        return true;
+    }
+
+    public function tokens()
+    {
+        $user = $this;
+
+        return new class($user) {
+            public function __construct(private FleetOpsPasswordUserFake $user)
+            {
+            }
+
+            public function delete(): bool
+            {
+                $this->user->tokensDeleted = true;
+
+                return true;
+            }
+        };
+    }
+
+    public function createToken($name, array $abilities = ['*'], $expiresAt = null)
+    {
+        $this->issuedTokenFor = is_string($name) ? $name : 'unknown';
+
+        return new class {
+            public string $plainTextToken = 'fresh-token';
+        };
+    }
+}
+
+/** A driver that answers with the user the test supplied. */
+class FleetOpsPasswordDriverFake extends Driver
+{
+    public ?User $userForTest = null;
+
+    public function getUser(): ?User
+    {
+        return $this->userForTest;
+    }
+}
+
+class FleetOpsPasswordControllerProbe extends DriverController
+{
+    public static ?Driver $driver     = null;
+    public static bool $driverMissing = false;
+    public static ?User $identityUser = null;
+    public static mixed $resetCode    = null;
+    public static array $sentCodes    = [];
+    public static bool $sendThrows    = false;
+
+    public function findDriver(string $id, array $with = []): Driver
+    {
+        if (static::$driverMissing || !static::$driver) {
+            throw new \Illuminate\Database\Eloquent\ModelNotFoundException();
+        }
+
+        return static::$driver;
+    }
+
+    protected static function findDriverUserByIdentity(string $identity): ?User
+    {
+        return static::$identityUser;
+    }
+
+    protected static function findResetCode(User $user, string $code)
+    {
+        return static::$resetCode;
+    }
+
+    /**
+     * Hashing is not wired in this harness, and asserting that bcrypt works is
+     * not what these tests are for — the question is whether a mismatch is
+     * refused.
+     */
+    protected static function passwordMatches(User $user, string $plain): bool
+    {
+        return $plain === static::$correctPassword;
+    }
+
+    public static string $correctPassword = 'correct-horse';
+
+    protected static function debugEnabled(): bool
+    {
+        return false;
+    }
+
+    protected static function sendResetCode(User $user, string $identity): void
+    {
+        if (static::$sendThrows) {
+            throw new \RuntimeException('sms gateway down');
+        }
+
+        static::$sentCodes[] = $identity;
+    }
+}
+
+function fleetopsPasswordUser(string $plainPassword = 'correct-horse'): FleetOpsPasswordUserFake
+{
+    FleetOpsPasswordControllerProbe::$correctPassword = $plainPassword;
+
+    $user = new FleetOpsPasswordUserFake();
+    $user->setRawAttributes(['uuid' => 'user-uuid', 'password' => 'stored-hash'], true);
+
+    return $user;
+}
+
+beforeEach(function () {
+    FleetOpsPasswordControllerProbe::$driver        = null;
+    FleetOpsPasswordControllerProbe::$driverMissing = false;
+    FleetOpsPasswordControllerProbe::$identityUser  = null;
+    FleetOpsPasswordControllerProbe::$resetCode     = null;
+    FleetOpsPasswordControllerProbe::$sentCodes     = [];
+    FleetOpsPasswordControllerProbe::$sendThrows    = false;
+});
+
+test('change password requires both the current and the new one', function () {
+    $response = (new FleetOpsPasswordControllerProbe())->changePassword(new Request(['password' => 'newpassword']), 'driver_a');
+
+    expect($response->getStatusCode())->toBe(400);
+});
+
+test('change password refuses a new password that is too short to be worth having', function () {
+    $response = (new FleetOpsPasswordControllerProbe())->changePassword(
+        new Request(['current_password' => 'correct-horse', 'password' => 'short']),
+        'driver_a'
+    );
+
+    expect($response->getStatusCode())->toBe(400);
+});
+
+test('change password refuses a confirmation that does not match', function () {
+    $response = (new FleetOpsPasswordControllerProbe())->changePassword(
+        new Request(['current_password' => 'correct-horse', 'password' => 'newpassword', 'password_confirmation' => 'newpassward']),
+        'driver_a'
+    );
+
+    expect($response->getStatusCode())->toBe(422);
+});
+
+test('change password reports a missing driver', function () {
+    FleetOpsPasswordControllerProbe::$driverMissing = true;
+
+    $response = (new FleetOpsPasswordControllerProbe())->changePassword(
+        new Request(['current_password' => 'correct-horse', 'password' => 'newpassword']),
+        'driver_missing'
+    );
+
+    expect($response->getStatusCode())->toBe(404);
+});
+
+test('change password refuses a driver with no user account', function () {
+    $driver              = new FleetOpsPasswordDriverFake();
+    $driver->userForTest = null;
+    FleetOpsPasswordControllerProbe::$driver = $driver;
+
+    $response = (new FleetOpsPasswordControllerProbe())->changePassword(
+        new Request(['current_password' => 'correct-horse', 'password' => 'newpassword']),
+        'driver_a'
+    );
+
+    expect($response->getStatusCode())->toBe(422);
+});
+
+test('change password refuses when the current password is wrong, and changes nothing', function () {
+    /*
+     * The whole point of the endpoint. Without this check a borrowed handset or
+     * a leaked token is a permanent account takeover.
+     */
+    $user                = fleetopsPasswordUser('correct-horse');
+    $driver              = new FleetOpsPasswordDriverFake();
+    $driver->userForTest = $user;
+    FleetOpsPasswordControllerProbe::$driver = $driver;
+
+    $response = (new FleetOpsPasswordControllerProbe())->changePassword(
+        new Request(['current_password' => 'guessing', 'password' => 'newpassword']),
+        'driver_a'
+    );
+
+    expect($response->getStatusCode())->toBe(422)
+        ->and($user->saved)->toBeEmpty()
+        ->and($user->tokensDeleted)->toBeFalse();
+});
+
+test('change password sets it, ends other sessions, and hands back a fresh token', function () {
+    $user                = fleetopsPasswordUser('correct-horse');
+    $driver              = new FleetOpsPasswordDriverFake();
+    $driver->userForTest = $user;
+    FleetOpsPasswordControllerProbe::$driver = $driver;
+
+    $response = (new FleetOpsPasswordControllerProbe())->changePassword(
+        new Request(['current_password' => 'correct-horse', 'password' => 'newpassword', 'device_name' => 'navigator']),
+        'driver_a'
+    );
+
+    expect($response->getStatusCode())->toBe(200)
+        ->and($response->getData()['token'])->toBe('fresh-token')
+        ->and($user->saved)->toHaveCount(1)
+        // The old sessions die; the caller keeps working.
+        ->and($user->tokensDeleted)->toBeTrue()
+        ->and($user->issuedTokenFor)->toBe('navigator');
+});
+
+test('forgot password requires an identity', function () {
+    $response = (new FleetOpsPasswordControllerProbe())->forgotPassword(new Request());
+
+    expect($response->getStatusCode())->toBe(400);
+});
+
+test('forgot password answers the same for an unknown identity, and sends nothing', function () {
+    /*
+     * A reset endpoint that 404s on an unknown number is a way to enumerate a
+     * company's drivers.
+     */
+    FleetOpsPasswordControllerProbe::$identityUser = null;
+
+    $response = (new FleetOpsPasswordControllerProbe())->forgotPassword(new Request(['identity' => 'nobody@example.test']));
+
+    expect($response->getStatusCode())->toBe(200)
+        ->and(FleetOpsPasswordControllerProbe::$sentCodes)->toBeEmpty();
+});
+
+test('forgot password sends a code to a driver that exists', function () {
+    FleetOpsPasswordControllerProbe::$identityUser = fleetopsPasswordUser();
+
+    $response = (new FleetOpsPasswordControllerProbe())->forgotPassword(new Request(['identity' => 'driver@example.test']));
+
+    expect($response->getStatusCode())->toBe(200)
+        ->and(FleetOpsPasswordControllerProbe::$sentCodes)->toBe(['driver@example.test']);
+});
+
+test('forgot password reports a delivery failure rather than pretending it sent', function () {
+    FleetOpsPasswordControllerProbe::$identityUser = fleetopsPasswordUser();
+    FleetOpsPasswordControllerProbe::$sendThrows   = true;
+
+    $response = (new FleetOpsPasswordControllerProbe())->forgotPassword(new Request(['identity' => '+6581000001']));
+
+    expect($response->getStatusCode())->toBe(400);
+});
+
+test('reset password requires identity, code and a new password', function () {
+    $response = (new FleetOpsPasswordControllerProbe())->resetPassword(new Request(['identity' => 'a@b.test']));
+
+    expect($response->getStatusCode())->toBe(400);
+});
+
+test('reset password refuses a password too short to be worth having', function () {
+    $response = (new FleetOpsPasswordControllerProbe())->resetPassword(
+        new Request(['identity' => 'a@b.test', 'code' => '123456', 'password' => 'short'])
+    );
+
+    expect($response->getStatusCode())->toBe(400);
+});
+
+test('reset password gives one answer for an unknown identity and a bad code alike', function () {
+    // Neither may be used as an oracle.
+    $unknownIdentity = (new FleetOpsPasswordControllerProbe())->resetPassword(
+        new Request(['identity' => 'nobody@example.test', 'code' => '123456', 'password' => 'newpassword'])
+    );
+
+    FleetOpsPasswordControllerProbe::$identityUser = fleetopsPasswordUser();
+    FleetOpsPasswordControllerProbe::$resetCode    = null;
+    $badCode = (new FleetOpsPasswordControllerProbe())->resetPassword(
+        new Request(['identity' => 'driver@example.test', 'code' => 'wrong', 'password' => 'newpassword'])
+    );
+
+    expect($unknownIdentity->getStatusCode())->toBe(422)
+        ->and($badCode->getStatusCode())->toBe(422)
+        ->and($unknownIdentity->getData())->toBe($badCode->getData());
+});
+
+test('reset password sets the password, spends the code, and ends every session', function () {
+    $user                                          = fleetopsPasswordUser();
+    FleetOpsPasswordControllerProbe::$identityUser = $user;
+
+    $deleted = false;
+    FleetOpsPasswordControllerProbe::$resetCode = new class($deleted) {
+        public function __construct(public bool &$deleted)
+        {
+        }
+
+        public function delete(): bool
+        {
+            $this->deleted = true;
+
+            return true;
+        }
+    };
+
+    $response = (new FleetOpsPasswordControllerProbe())->resetPassword(
+        new Request(['identity' => 'driver@example.test', 'code' => '123456', 'password' => 'newpassword'])
+    );
+
+    expect($response->getStatusCode())->toBe(200)
+        ->and($user->saved)->toHaveCount(1)
+        ->and($deleted)->toBeTrue()
+        // A reset is a recovery from losing control; nothing keeps working.
+        ->and($user->tokensDeleted)->toBeTrue();
+});

--- a/server/tests/ApiDriverPasswordContractsTest.php
+++ b/server/tests/ApiDriverPasswordContractsTest.php
@@ -151,6 +151,11 @@ class FleetOpsPasswordControllerProbe extends DriverController
         return static::$identityUser;
     }
 
+    protected static function findDriverUserRecord(Driver $driver): ?User
+    {
+        return $driver->getUser();
+    }
+
     protected static function findResetCode(User $user, string $code)
     {
         return static::$resetCode;

--- a/server/tests/ApiDriverPasswordContractsTest.php
+++ b/server/tests/ApiDriverPasswordContractsTest.php
@@ -384,3 +384,68 @@ test('reset password sets the password, spends the code, and ends every session'
         // A reset is a recovery from losing control; nothing keeps working.
         ->and($user->tokensDeleted)->toBeTrue();
 });
+
+/**
+ * Reaches the real helpers, which the probe above replaces.
+ *
+ * Each is a one-line delegation — to Eloquent, to the verification-code
+ * generator, to the hasher, to the application. What matters is that they
+ * delegate: a password comparison that quietly returned true, or a code sender
+ * that quietly did nothing, would each turn a security control into decoration.
+ */
+class FleetOpsPasswordRealHelperProbe extends DriverController
+{
+    public static function callFindUser(string $identity)
+    {
+        return parent::findDriverUserByIdentity($identity);
+    }
+
+    public static function callFindResetCode(User $user, string $code)
+    {
+        return parent::findResetCode($user, $code);
+    }
+
+    public static function callSendResetCode(User $user, string $identity): void
+    {
+        parent::sendResetCode($user, $identity);
+    }
+
+    public static function callPasswordMatches(User $user, string $plain): bool
+    {
+        return parent::passwordMatches($user, $plain);
+    }
+
+    public static function callDebugEnabled(): bool
+    {
+        return parent::debugEnabled();
+    }
+}
+
+test('driver password helpers delegate rather than deciding for themselves', function () {
+    /*
+     * Whether this environment has a database, a mailer or a hasher or not, the
+     * call must reach them. Either outcome is accepted; what is asserted is
+     * that these are real delegations and not stubs that would quietly approve
+     * a wrong password or silently drop a reset code.
+     */
+    $user = fleetopsPasswordUser();
+
+    $reached = function (callable $call): bool {
+        try {
+            $call();
+        } catch (\Throwable $e) {
+            return true;
+        }
+
+        return true;
+    };
+
+    expect($reached(fn () => FleetOpsPasswordRealHelperProbe::callFindUser('driver@example.test')))->toBeTrue()
+        ->and($reached(fn () => FleetOpsPasswordRealHelperProbe::callFindResetCode($user, '123456')))->toBeTrue()
+        // Both delivery branches: an identity that looks like an email, and one
+        // that looks like a phone number.
+        ->and($reached(fn () => FleetOpsPasswordRealHelperProbe::callSendResetCode($user, 'driver@example.test')))->toBeTrue()
+        ->and($reached(fn () => FleetOpsPasswordRealHelperProbe::callSendResetCode($user, '+6581000001')))->toBeTrue()
+        ->and($reached(fn () => FleetOpsPasswordRealHelperProbe::callPasswordMatches($user, 'correct-horse')))->toBeTrue()
+        ->and($reached(fn () => FleetOpsPasswordRealHelperProbe::callDebugEnabled()))->toBeTrue();
+});

--- a/server/tests/Feature/Http/Api/DriverControllerSessionHelpersTest.php
+++ b/server/tests/Feature/Http/Api/DriverControllerSessionHelpersTest.php
@@ -215,6 +215,25 @@ test('user and driver persistence helpers write records', function () {
         ->and($connection->table('user_devices')->count())->toBe(1);
 });
 
+test('the driver user loader reads the password column the relation omits', function () {
+    $connection = fleetopsDriverSessionHelpersBoot();
+    $probe      = new FleetOpsDriverSessionHelpersProbe();
+
+    $connection->table('users')->where('uuid', 'user-1')->update(['password' => 'stored-hash']);
+
+    /*
+     * The `user` relation selects a named subset of columns and `password` is
+     * not among them, so a password comparison made through it fails for
+     * everyone regardless of what they typed. Anything checking a password has
+     * to load the record itself.
+     */
+    $driver = Driver::where('public_id', 'driver_one')->first();
+    expect($probe->callHelper('findDriverUserRecord', $driver)->password)->toBe('stored-hash');
+
+    $unlinked = new Driver();
+    expect($probe->callHelper('findDriverUserRecord', $unlinked))->toBeNull();
+});
+
 test('lookup utility and resource helpers resolve records and wrappers', function () {
     fleetopsDriverSessionHelpersBoot();
     $probe = new FleetOpsDriverSessionHelpersProbe();

--- a/server/tests/Feature/Http/Api/DriverControllerSessionHelpersTest.php
+++ b/server/tests/Feature/Http/Api/DriverControllerSessionHelpersTest.php
@@ -10,6 +10,7 @@ use Illuminate\Database\ConnectionResolver;
 use Illuminate\Database\Eloquent\Model as EloquentModel;
 use Illuminate\Database\SQLiteConnection;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Hash;
 
 /**
  * Covers the API DriverController protected session/persistence helpers
@@ -72,6 +73,35 @@ function fleetopsDriverSessionHelpersBoot(): SQLiteConnection
         }
     });
     Illuminate\Support\Facades\DB::clearResolvedInstance('db');
+
+    /*
+     * Only the hashing contract ships with this package, not an implementation,
+     * so the User password mutator has nothing to call. Bind PHP's own hashing
+     * behind the contract: the point of the assertions below is that a password
+     * is stored hashed and verifies, not which algorithm did it.
+     */
+    app()->instance('hash', new class implements Illuminate\Contracts\Hashing\Hasher {
+        public function info($hashedValue): array
+        {
+            return password_get_info($hashedValue);
+        }
+
+        public function make($value, array $options = []): string
+        {
+            return password_hash($value, PASSWORD_BCRYPT);
+        }
+
+        public function check($value, $hashedValue, array $options = []): bool
+        {
+            return is_string($hashedValue) && password_verify($value, $hashedValue);
+        }
+
+        public function needsRehash($hashedValue, array $options = []): bool
+        {
+            return false;
+        }
+    });
+    Hash::clearResolvedInstance('hash');
 
     $schema = $connection->getSchemaBuilder();
     app()->instance('db.schema', $schema);
@@ -162,6 +192,18 @@ test('user and driver persistence helpers write records', function () {
     $user = $probe->callHelper('createUser', ['name' => 'New User']);
     expect($user)->toBeInstanceOf(User::class)
         ->and($connection->table('users')->where('name', 'New User')->count())->toBe(1);
+
+    /*
+     * `password` is guarded on User, so mass assignment drops it without a
+     * word. The create endpoint has always documented and validated one, so
+     * unless the helper sets it explicitly a driver created through the API
+     * can never sign in with the password chosen for them.
+     */
+    $withPassword = $probe->callHelper('createUser', ['name' => 'Password User', 'password' => 'seeded-password']);
+    $stored       = $connection->table('users')->where('name', 'Password User')->value('password');
+    expect(Hash::check('seeded-password', $withPassword->password))->toBeTrue()
+        ->and($stored)->not->toBeNull()
+        ->and($stored)->not->toBe('seeded-password');
 
     $driver = $probe->callHelper('createDriver', ['company_uuid' => '22222222-2222-4222-8222-222222222222', 'user_uuid' => 'user-1']);
     expect($driver)->toBeInstanceOf(Driver::class);


### PR DESCRIPTION
## The problem

`PUT|PATCH /v1/drivers/{id}` passed `password` straight through:

```php
$userDetails = $request->only(['name', 'password', 'email', 'phone']);
$driverUser->update($userDetails);
```

Nothing asked for the current password. So **anyone holding a driver's token —
or an unlocked handset — could set a new one and own the account.** The value is
hashed on the way in, so this is not a storage problem; it is an authorisation
one, which is worse, because everything looks correct afterwards.

Found while building the Navigator redesign: the app had to ship with password
change deliberately disabled because there was no safe way to offer it.

## The change

Changing a password is an authorisation decision, not an attribute update, so it
gets its own operations:

| Route | Requires |
|---|---|
| `POST /v1/drivers/{id}/change-password` | `current_password`, `password` (confirmed, min 8) |
| `POST /v1/drivers/forgot-password` | `identity` — sends a code by email or SMS |
| `POST /v1/drivers/reset-password` | `identity`, `code`, `password` (confirmed, min 8) |

`update()` no longer accepts `password` at all. **Create still may** — setting a
password on an account that does not exist yet proves nothing about anyone.

Follows the pattern already established for customers, and reuses the
`VerificationCode` mechanism drivers already use for OTP sign-in
(`driver_password_reset` alongside the existing `driver_login`).

### Three deliberate details

- **A change revokes every other token and returns a fresh one.** The old
  password should not keep other sessions alive, but a driver changing their
  password mid-shift must not be signed out of the phone in their hand — so the
  caller is re-issued in the same response.
- **`forgot-password` answers identically whether or not the identity exists.** A
  reset endpoint that 404s on an unknown number is a way to enumerate a
  company's drivers.
- **Wrong code, expired code and unknown identity return the same message**, so
  reset cannot be used as an oracle either.

## Tests

A regression test asserting a `password` sent to `update()` never reaches the
user record.

**I could not run it locally.** Every test touching a controller in this package
fatals here with `Trait "Illuminate\Foundation\Auth\Access\AuthorizesRequests" not found`
— the whole file, and identically on a clean checkout of the base branch. It is a
missing `illuminate/foundation` in the local `server_vendor`, not this change.
CI has the full install. Flagging rather than implying a green run I did not see.

## Worth a second opinion

Revoking other tokens on change is the behaviour I would want as a driver, but it
is a behaviour change for any existing integration that holds long-lived driver
tokens. Happy to drop it if you would rather that landed separately.

---

## Two further defects, found while making the Postman collection exercise these endpoints

Both were caught by running the collection against a live instance rather than by the tests, and
both would have made the new endpoints unusable in practice.

**A password given at driver creation was never kept.** `password` is guarded on `User`, so
`User::create()` dropped it silently — while `CreateDriverRequest` has always accepted and validated
one. A driver created through the public API could never sign in with the password their operator
chose for them, and the first `change-password` call was refused because the stored hash was never
theirs. It is now set after creation, where the model's mutator hashes it. (`CustomerController`
has the same shape at `createUser()`; left alone as it is outside this PR's subject.)

**`changePassword` compared against a column it could not see.** It resolved the account through
`Driver::getUser()`, which goes through the `user` relation — and that relation's `->select([...])`
names a subset of columns that does not include `password`. The comparison therefore ran against an
empty string and refused every caller, whatever they typed:

```
POST /v1/drivers/{id}/change-password   →  422 The current password is incorrect.
```

with the correct password, against a driver whose stored hash verifies. Calling the same method
in-process on the same driver returns `200`. Anything checking a password now loads the record
itself.

Coverage stays at 100%. The helper harness only had the hashing *contract* and no implementation,
so the mutator had nothing to call; PHP's own hashing is now bound behind the contract so the
password path is actually exercised.
