### PR TITLE
Fix editing unsaved geocoded places in order form

### DIFF
--- a/addon/components/order/form/route.js
+++ b/addon/components/order/form/route.js
@@ -5,6 +5,7 @@ import { action, get } from '@ember/object';
 import { task } from 'ember-concurrency';
 import { colorForId, routeColorForStatus, routeStyleForStatus } from '../../../utils/route-colors';
 import { buildRoutePointMarkerPresentation, buildRoutePointsFromPayload, describeRoutePoint } from '../../../utils/route-visualization';
+import preparePlaceForSave from '../../../utils/prepare-place-for-save';
 
 const ORDER_ROUTE_PREVIEW_PADDING_BOTTOM_RIGHT = [420, 0];
 const ORDER_ROUTE_PREVIEW_MAX_ZOOM_TWO_POINTS = 13;
@@ -153,6 +154,7 @@ export default class OrderFormRouteComponent extends Component {
     @action setWaypointPlace(index, place) {
         if (!this.args.resource.payload.waypoints[index]) return;
 
+        place = preparePlaceForSave(this.store, place);
         this.args.resource.payload.waypoints[index].place = place;
         this.args.resource.payload.waypoints[index]?.setProperties({
             street1: place.street1,
@@ -186,6 +188,7 @@ export default class OrderFormRouteComponent extends Component {
     }
 
     @action setPayloadPlace(prop, place) {
+        place = preparePlaceForSave(this.store, place);
         this.args.resource.payload[prop] = place;
         this.previewRoute();
         this.requestServiceQuoteRefresh(`route.${prop}.changed`);

--- a/addon/utils/prepare-place-for-save.js
+++ b/addon/utils/prepare-place-for-save.js
@@ -1,0 +1,13 @@
+export default function preparePlaceForSave(store, place) {
+    if (!place || place.isNew || place.public_id) {
+        return place;
+    }
+
+    const attributes = {};
+
+    place.constructor.eachAttribute((attribute) => {
+        attributes[attribute] = place[attribute];
+    });
+
+    return store.createRecord('place', attributes);
+}

--- a/server/src/Models/Place.php
+++ b/server/src/Models/Place.php
@@ -129,7 +129,7 @@ class Place extends Model
      *
      * @var array
      */
-    protected $filterParams = ['vendor', 'contact', 'vendor_uuid', 'vendor_name'];
+    protected $filterParams = ['vendor', 'contact', 'vendor_uuid', 'vendor_name', 'avatar_value', 'eta'];
 
     /**
      * @return \Illuminate\Database\Eloquent\Relations\MorphTo

--- a/server/tests/Feature/Http/Internal/PlaceControllerTest.php
+++ b/server/tests/Feature/Http/Internal/PlaceControllerTest.php
@@ -36,6 +36,18 @@ if (!Request::hasMacro('resolveFilesFromIds')) {
     Request::macro('resolveFilesFromIds', fn () => FleetOpsInternalPlaceEndpointsState::$files);
 }
 
+if (!Request::hasMacro('or')) {
+    Request::macro('or', function (array $params = [], $default = null) {
+        foreach ($params as $param) {
+            if ($this->has($param)) {
+                return $this->input($param);
+            }
+        }
+
+        return $default;
+    });
+}
+
 class FleetOpsInternalPlaceEndpointsState
 {
     public static array $files = [];
@@ -78,6 +90,14 @@ class FleetOpsInternalPlaceEndpointsPlaceFake extends Place
         $this->syncedValues[] = $payload;
 
         return $payload;
+    }
+}
+
+class FleetOpsInternalPlaceUpdateFake extends Place
+{
+    public function applyDirectivesToQuery(Request $request, $builder)
+    {
+        return $builder;
     }
 }
 
@@ -128,6 +148,7 @@ function fleetopsInternalPlaceEndpointsBoot(): SQLiteConnection
         $table->string('postal_code')->nullable();
         $table->string('location')->nullable();
         $table->timestamp('created_at')->nullable();
+        $table->timestamp('updated_at')->nullable();
         $table->timestamp('deleted_at')->nullable();
     });
     $schema->create('files', function ($table) {
@@ -249,4 +270,28 @@ test('sync custom field values helper delegates to the place model', function ()
     (new FleetOpsInternalPlaceEndpointsProbe())->callProtected('syncCustomFieldValues', [$place, ['priority' => 'high']]);
 
     expect($place->syncedValues)->toBe([['priority' => 'high']]);
+});
+
+test('place updates accept serialized display-only attributes', function () {
+    $connection = fleetopsInternalPlaceEndpointsBoot();
+    $connection->table('places')->insert([
+        'uuid'         => '77777777-7777-4777-8777-777777777777',
+        'public_id'    => 'place_display1',
+        'company_uuid' => 'company-1',
+        'name'         => 'Original place',
+        'street1'      => '205 Dostyk Avenue',
+    ]);
+
+    $place = (new FleetOpsInternalPlaceUpdateFake())->updateRecordFromRequest(Request::create('/int/v1/places/place_display1', 'PUT', [
+        'place' => [
+            'name'         => 'Updated place',
+            'street2'      => 'Entrance 2',
+            'avatar_value' => 'basic-building',
+            'eta'          => '12 minutes',
+        ],
+    ]), 'place_display1', options: ['return_object' => true]);
+
+    expect($place->name)->toBe('Updated place')
+        ->and($place->street2)->toBe('Entrance 2')
+        ->and($connection->table('places')->where('public_id', 'place_display1')->value('name'))->toBe('Updated place');
 });

--- a/tests/unit/utils/prepare-place-for-save-test.js
+++ b/tests/unit/utils/prepare-place-for-save-test.js
@@ -1,0 +1,54 @@
+import { module, test } from 'qunit';
+import preparePlaceForSave from 'dummy/utils/prepare-place-for-save';
+
+class PlaceRecordStub {
+    static eachAttribute(callback) {
+        ['public_id', 'name', 'street1', 'street2', 'location', 'eta'].forEach(callback);
+    }
+
+    constructor(attributes) {
+        Object.assign(this, attributes);
+    }
+}
+
+module('Unit | Utility | prepare-place-for-save', function () {
+    test('it converts a geocoder-only record into a locally createable place', function (assert) {
+        const geocodedPlace = new PlaceRecordStub({
+            isNew: false,
+            public_id: null,
+            name: 'Delivery entrance',
+            street1: '205 Dostyk Avenue',
+            street2: 'Entrance 2',
+            location: { type: 'Point', coordinates: [76.9585057, 43.2343247] },
+            eta: null,
+        });
+        const store = {
+            createRecord(modelName, attributes) {
+                return { modelName, isNew: true, ...attributes };
+            },
+        };
+
+        const preparedPlace = preparePlaceForSave(store, geocodedPlace);
+
+        assert.notStrictEqual(preparedPlace, geocodedPlace);
+        assert.true(preparedPlace.isNew, 'the edit modal will save the place with POST');
+        assert.strictEqual(preparedPlace.modelName, 'place');
+        assert.strictEqual(preparedPlace.street2, 'Entrance 2');
+        assert.deepEqual(preparedPlace.location, geocodedPlace.location);
+    });
+
+    test('it preserves persisted, new, and empty place selections', function (assert) {
+        const store = {
+            createRecord() {
+                assert.step('createRecord');
+            },
+        };
+        const persistedPlace = new PlaceRecordStub({ isNew: false, public_id: 'place_existing' });
+        const newPlace = new PlaceRecordStub({ isNew: true, public_id: null });
+
+        assert.strictEqual(preparePlaceForSave(store, persistedPlace), persistedPlace);
+        assert.strictEqual(preparePlaceForSave(store, newPlace), newPlace);
+        assert.strictEqual(preparePlaceForSave(store, null), null);
+        assert.verifySteps([]);
+    });
+});


### PR DESCRIPTION
## Summary

- convert geocoder-only place selections into new Ember Data records before attaching them to order routes, so editing and saving uses POST instead of PUT against a client-generated UUID
- preserve existing persisted and already-new place records unchanged
- allow serialized `avatar_value` and `eta` display fields during existing-place updates
- add frontend record-lifecycle and backend update regression coverage

## Validation

- `php scripts/pest-runner.php server/tests/Feature/Http/Internal/PlaceControllerTest.php`
- targeted ESLint for changed JavaScript files
- PHP CS Fixer dry run for changed PHP files
- `git diff --check`
- PR CI enforces the fresh 100% Clover line-coverage gate

Fixes fleetbase/fleetbase#637