### PR TITLE
ci(release): adopt the release/v* branch convention

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,6 @@
 name: Release Tag
 
-# Tags a release when a `dev-v*` branch is merged to main, and pushes the tag. Delegates
+# Tags a release when a release branch is merged to main, and pushes the tag. Delegates
 # to the reusable workflow in fleetbase/fleetbase. Requires org secret _GITHUB_AUTH_TOKEN
 # (inherited); no-ops with a warning until it is set.
 #
@@ -38,7 +38,8 @@ jobs:
   tag:
     if: github.event_name == 'workflow_dispatch' ||
         (github.event.pull_request.merged == true &&
-         startsWith(github.event.pull_request.head.ref, 'dev-v'))
+         (startsWith(github.event.pull_request.head.ref, 'release/v') ||
+          startsWith(github.event.pull_request.head.ref, 'dev-v')))
     uses: fleetbase/fleetbase/.github/workflows/release-tag.yml@main
     with:
       version-files: composer.json,package.json,extension.json


### PR DESCRIPTION
Adopts the `release/v0.0.0` branch convention. Companion to fleetbase/fleetbase#641, which holds the reusable workflow this delegates to.

## What changed

One line, so the caller matches either prefix:

```yaml
if: github.event_name == 'workflow_dispatch' ||
    (github.event.pull_request.merged == true &&
     (startsWith(github.event.pull_request.head.ref, 'release/v') ||
      startsWith(github.event.pull_request.head.ref, 'dev-v')))
```

## Why both, rather than a cutover

A hard switch would leave any release branch **already open** unrecognised — and a merge that produces no tag and no publish looks exactly like a successful one. `dev-v*` keeps working; drop that arm once no such branch remains open.

## Merge order

**fleetbase/fleetbase#641 first.** This caller references the reusable workflow at `@main`, so `release/v*` only starts being accepted once that lands. Merging this one early is harmless — it just keeps behaving as it does today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
