### PR TITLE
Fix live fleet map settings render-time mutation

### DIFF
--- a/addon/services/map-settings.js
+++ b/addon/services/map-settings.js
@@ -18,7 +18,10 @@ export default class MapSettingsService extends Service {
     @service fetch;
     @tracked settings = { ...DEFAULT_SETTINGS };
     @tracked isLoaded = false;
-    @tracked loadPromise = null;
+    // Internal request deduplication state is not rendered. Keeping this tracked
+    // makes load() read and then dirty the same tag when called during component
+    // construction, which Ember correctly rejects as a render-time mutation.
+    loadPromise = null;
 
     get mapProvider() {
         return this.settings.mapProvider ?? 'leaflet';


### PR DESCRIPTION
## Summary

- keep the map settings in-flight request promise as internal, non-rendered state
- prevent Ember from dirtying the tracked `loadPromise` tag after it is read during live-fleet widget construction
- resolve the runtime assertion that prevented the live fleet widget from rendering

## Verification

Lint and tests were intentionally not run while the reported local runtime errors are being cleared. The change is isolated to `addon/services/map-settings.js`.