### PR TITLE
fix: keep parent expansions away from nested Vehicle and Fleet resources

### DIFF
--- a/server/src/Http/Resources/v1/Concerns/ResolvesPublicRelationFields.php
+++ b/server/src/Http/Resources/v1/Concerns/ResolvesPublicRelationFields.php
@@ -22,8 +22,13 @@ trait ResolvesPublicRelationFields
     /**
      * The relations the caller asked for, as real Eloquent relation names.
      *
-     * The controller has already normalised, mapped and allowlisted `with` /
-     * `expand` by the time a resource runs, so this is a plain read.
+     * The controller normalises, maps and allowlists `with` / `expand` for the
+     * resource it returns. That guarantee does not travel: this resource is also
+     * rendered nested inside Order and Driver responses, where the request's
+     * `with` names the parent's relations (`payload`, `driverAssigned.vehicle`).
+     * A nested resource re-reads the same request, so only relations the wrapped
+     * model actually defines are kept — a parent's expansion must never reach
+     * this model's loader, where it raises RelationNotFoundException.
      *
      * @return array<int, string>
      */
@@ -39,7 +44,28 @@ trait ResolvesPublicRelationFields
             return [];
         }
 
-        return array_values(array_filter(array_map('strval', $with), 'strlen'));
+        $with = array_values(array_filter(array_map('strval', $with), 'strlen'));
+
+        return array_values(array_filter($with, fn (string $relation): bool => $this->definesRelation($relation)));
+    }
+
+    /**
+     * Whether the wrapped model defines the root of a relation path.
+     *
+     * Only the first segment is checked: nested segments belong to the related
+     * model, and Eloquent validates those itself once the root exists.
+     */
+    private function definesRelation(string $relation): bool
+    {
+        $resource = $this->resource;
+
+        if (!is_object($resource) || !method_exists($resource, 'loadMissing')) {
+            return false;
+        }
+
+        $root = explode('.', $relation, 2)[0];
+
+        return $root !== '' && method_exists($resource, $root);
     }
 
     /**

--- a/server/src/Http/Resources/v1/Fleet.php
+++ b/server/src/Http/Resources/v1/Fleet.php
@@ -24,7 +24,9 @@ class Fleet extends FleetbaseResource
         // dropped anything outside the public allowlist, so they are safe to
         // hand to the loader. `subfleets` used to arrive here spelled exactly
         // that and reach `load('subfleets')`, which is not the relation —
-        // the documented expansion raised instead of resolving.
+        // the documented expansion raised instead of resolving. Relations the
+        // fleet does not define are dropped as well: nested under another
+        // response the request's `with` describes the parent, not the fleet.
         $with = $this->requestedRelations($request);
 
         if ($with !== []) {

--- a/server/tests/Feature/Http/Api/VehiclePublicContractTest.php
+++ b/server/tests/Feature/Http/Api/VehiclePublicContractTest.php
@@ -452,3 +452,26 @@ test('an unsupported expansion on retrieve cannot reach eloquent', function () {
         ->and($payload)->not->toHaveKey('not_a_relation')
         ->and($request->input('with'))->toBe(['vendor']);
 });
+
+test('a vehicle nested in an order response ignores the order expansions', function () {
+    fleetopsVehicleContractBoot();
+
+    $controller    = new VehicleController();
+    $createRequest = fleetopsVehicleContractRequest(CreateVehicleRequest::class, 'POST', ['make' => 'Ford', 'driver' => 'driver_contract1']);
+    $created       = $controller->create($createRequest)->resolve($createRequest);
+    $vehicle       = Vehicle::where('public_id', $created['id'])->firstOrFail();
+
+    // An order fetch expands the order's own relations. The Order resource nests
+    // the assigned vehicle as a full Vehicle resource, which re-reads the same
+    // request: `payload` is not a vehicle relation and used to reach load(),
+    // answering the whole order request with a RelationNotFoundException.
+    $orderRequest = fleetopsVehicleContractRequest(Request::class, 'GET', ['with' => ['payload', 'driverAssigned.vehicle', 'driver']], 'v1/orders');
+    $payload      = (new Fleetbase\FleetOps\Http\Resources\v1\Vehicle($vehicle))->resolve($orderRequest);
+
+    expect($payload['id'])->toBe($created['id'])
+        ->and($payload)->not->toHaveKey('payload')
+        ->and($vehicle->relationLoaded('payload'))->toBeFalse()
+        // The vehicle's own expansion in the same list still resolves.
+        ->and($payload['driver'])->toBeObject()
+        ->and($payload['driver_id'])->toBe('driver_contract1');
+});

--- a/server/tests/Unit/Http/Resources/FleetResourceTest.php
+++ b/server/tests/Unit/Http/Resources/FleetResourceTest.php
@@ -144,3 +144,20 @@ test('fleet resource accepts the explicit nested expansion spelling', function (
     expect($subFleet->relationLoaded('drivers'))->toBeTrue()
         ->and($subFleet->relationLoaded('vehicles'))->toBeFalse();
 });
+
+test('fleet resource ignores expansions that describe a parent resource', function () {
+    fleetopsFleetResourceBoot();
+
+    $fleet = Fleet::where('uuid', 'fleet-parent-1')->first();
+
+    // Rendered inside another response, the request's `with` is the parent's
+    // list. `payload` is not a fleet relation and used to raise from load();
+    // the fleet's own relation in the same list still loads.
+    $request  = Request::create('/v1/orders', 'GET', ['with' => ['payload', 'drivers']]);
+    $resolved = (new FleetResource($fleet))->resolve($request);
+
+    expect($resolved['name'])->toBe('Parent Fleet')
+        ->and($resolved)->not->toHaveKey('payload')
+        ->and($fleet->relationLoaded('payload'))->toBeFalse()
+        ->and($fleet->relationLoaded('drivers'))->toBeTrue();
+});

--- a/server/tests/VehicleResourceContractsTest.php
+++ b/server/tests/VehicleResourceContractsTest.php
@@ -311,3 +311,42 @@ test('vehicle without driver resource omits driver relationships and serializes 
         ])
         ->and($webhook)->not->toHaveKey('driver');
 });
+
+/**
+ * Resolve the request's `with` list the way a nested resource does.
+ *
+ * @return array<int, string>
+ */
+function fleetopsVehicleResourceRequestedRelations(mixed $resource, array $query): array
+{
+    $request = Request::create('/api/v1/fleet-ops/orders', 'GET', $query);
+    $method  = new ReflectionMethod(VehicleResource::class, 'requestedRelations');
+    $method->setAccessible(true);
+
+    return $method->invoke(new VehicleResource($resource), $request);
+}
+
+test('requested relations keep only what the wrapped model defines', function () {
+    $vehicle = new class(['uuid' => 'vehicle-uuid']) extends FleetOpsVehicleResourceFixture {
+        public function driver(): void
+        {
+        }
+    };
+
+    // Nested under an Order, the request's `with` describes the order:
+    // `payload` and `driverAssigned.vehicle` are not vehicle relations and must
+    // never reach this model's loader. The vehicle's own relations still pass,
+    // including a nested path whose root the vehicle defines.
+    expect(fleetopsVehicleResourceRequestedRelations($vehicle, ['with' => ['payload', 'driverAssigned.vehicle', 'driver', 'driver.user', '']]))->toBe(['driver', 'driver.user'])
+        ->and(fleetopsVehicleResourceRequestedRelations($vehicle, ['with' => 'payload,driver']))->toBe(['driver'])
+        ->and(fleetopsVehicleResourceRequestedRelations($vehicle, ['with' => ['.driver']]))->toBe([])
+        ->and(fleetopsVehicleResourceRequestedRelations($vehicle, []))->toBe([]);
+});
+
+test('requested relations are empty when the resource cannot load any', function () {
+    // Webhook fixtures and compact serializers hand the resource plain data;
+    // there is no loader to feed, so nothing is requested from it.
+    expect(fleetopsVehicleResourceRequestedRelations(['uuid' => 'vehicle-uuid'], ['with' => ['driver']]))->toBe([])
+        ->and(fleetopsVehicleResourceRequestedRelations((object) ['uuid' => 'vehicle-uuid'], ['with' => ['driver']]))->toBe([])
+        ->and(fleetopsVehicleResourceRequestedRelations(fleetopsVehicleResourceFixture(), ['with' => ['driver']]))->toBe([]);
+});


### PR DESCRIPTION
## Problem

Since the public relation contract change (6e5434ad / 4c72cf68), `Vehicle` and `Fleet` resources read the request's `with` list and pass it straight to `loadMissing()`. On their own endpoints the controller has already allowlisted that list, but both resources are also rendered **nested** inside Order and Driver responses (`Order.vehicle_assigned`, `Driver.vehicle`). Nested resources re-read the same request, whose `with` describes the parent (`payload`, `driverAssigned.vehicle`), so any order request such as `GET /fleet-ops/v1/orders?with=payload` with a vehicle assigned failed during `json_encode`:

```
Illuminate\Database\Eloquent\RelationNotFoundException: Call to undefined relationship [payload] on model [Fleetbase\FleetOps\Models\Vehicle]
  at fleetops/server/src/Http/Resources/v1/Vehicle.php:27
```

Navigator driver order fetches and the console scheduler route (`with: ['payload', 'driverAssigned.vehicle']`) both trigger it.

## Fix

`ResolvesPublicRelationFields::requestedRelations()` keeps only entries whose root segment is a relation method on the wrapped model, and returns nothing for resources wrapping plain data (webhook fixtures, compact serializers). Direct endpoint behaviour is unchanged: the controller allowlist still applies first, and nested paths are validated by Eloquent once the root exists.

## Tests

- `VehicleResourceContractsTest`: parent relations (`payload`, `driverAssigned.vehicle`) are dropped, the vehicle's own relations and nested paths are kept, string and empty forms handled, plain-data resources request nothing.
- `VehiclePublicContractTest`: a real vehicle resolved against an order-shaped request with `with=payload,driverAssigned.vehicle,driver` no longer raises, does not load `payload`, and still expands `driver`.
- `FleetResourceTest`: same for the fleet resource.

## Verification

- `composer test:lint` clean on changed files.
- Full suite under coverage (`scripts/coverage-file-runner.php`) with the 100% gate: **100.00% statements (34,791/34,791), 531/531 classes**, no failures.
