### PR TITLE
fix(map): invoke leaflet-tile-url instead of passing it by name

### DIFF
--- a/addon/components/modals/place-details.hbs
+++ b/addon/components/modals/place-details.hbs
@@ -3,7 +3,7 @@
         <div class="flex">
             <div class="w-48 mb-6 mr-6">
                 <LeafletMap class="w-full h-48 mb-2 rounded-md shadow-md" @lat={{@options.place.latitude}} @lng={{@options.place.longitude}} @zoom={{12}} as |layers|>
-                    <layers.tile @url={{leaflet-tile-url}} />
+                    <layers.tile @url={{(leaflet-tile-url)}} />
 
                     <layers.marker @location={{@options.place.coordinates}} />
                 </LeafletMap>

--- a/addon/components/modals/point-map.hbs
+++ b/addon/components/modals/point-map.hbs
@@ -1,7 +1,7 @@
 <Modal::Default @modalIsOpened={{@modalIsOpened}} @options={{@options}} @confirm={{@onConfirm}} @decline={{@onDecline}}>
     <div class="fleetbase-leaflet-map-container">
         <LeafletMap class="map-height-base" @lat={{@options.latitude}} @lng={{@options.longitude}} @zoom={{12}} as |layers|>
-            <layers.tile @url={{leaflet-tile-url}} />
+            <layers.tile @url={{(leaflet-tile-url)}} />
 
             <layers.marker @icon={{@options.icon}} @location={{point-to-coordinates @options.location}} @riseOnHover={{true}} as |marker|>
                 <marker.popup @maxWidth="500" @minWidth="180">

--- a/addon/components/place/details.hbs
+++ b/addon/components/place/details.hbs
@@ -75,7 +75,7 @@
             @zoomControl={{false}}
             as |layers|
         >
-            <layers.tile @url={{leaflet-tile-url}} />
+            <layers.tile @url={{(leaflet-tile-url)}} />
             <layers.marker
                 @id={{@resource.id}}
                 @icon={{icon iconUrl=(or @resource.avatar_url "/engines-dist/images/building-marker.png") iconSize=(array 40 40)}}

--- a/addon/components/service-area/details.hbs
+++ b/addon/components/service-area/details.hbs
@@ -27,7 +27,7 @@
             @zoomControl={{false}}
             as |layers|
         >
-            <layers.tile @url={{leaflet-tile-url}} />
+            <layers.tile @url={{(leaflet-tile-url)}} />
             <layers.polygon
                 @id={{@resource.id}}
                 @record={{@resource}}

--- a/addon/components/zone/details.hbs
+++ b/addon/components/zone/details.hbs
@@ -22,7 +22,7 @@
             @zoomControl={{false}}
             as |layers|
         >
-            <layers.tile @url={{leaflet-tile-url}} />
+            <layers.tile @url={{(leaflet-tile-url)}} />
             <layers.polygon
                 @id={{@resource.id}}
                 @record={{@resource}}

--- a/addon/helpers/leaflet-tile-url.js
+++ b/addon/helpers/leaflet-tile-url.js
@@ -5,8 +5,13 @@ import { inject as service } from '@ember/service';
  * Resolves the Leaflet tile URL from Fleet-Ops map settings.
  *
  * Usage:
- *   <layers.tile @url={{leaflet-tile-url}} />
+ *   <layers.tile @url={{(leaflet-tile-url)}} />
  *   <layers.tile @url={{leaflet-tile-url theme="dark"}} />
+ *
+ * With no arguments it must be invoked in parentheses. A bare
+ * `@url={{leaflet-tile-url}}` passes the helper by name, which Glimmer refuses
+ * with "A resolved helper cannot be passed as a named argument" and the whole
+ * template fails to render.
  *
  * Recomputes automatically when map settings load or change.
  */


### PR DESCRIPTION
## What

Opening a place's details throws, and the details tab doesn't render:

```
Error: A resolved helper cannot be passed as a named argument as the syntax is ambiguously a pass-by-reference or invocation. Use the `{{helper 'foo-helper}}` helper to pass by reference or explicitly invoke the helper with parens: `{{(fooHelper)}}`.
```

The map's tile layer passed the `leaflet-tile-url` helper by name, `<layers.tile @url={{leaflet-tile-url}} />`. With no arguments, Glimmer can't tell whether that means pass the helper or call it, so it refuses and the whole template fails. It is now called in parentheses, `@url={{(leaflet-tile-url)}}`.

## Where

The same line was in five templates, all from the configurable tile provider change (a5a4f1cd), so each failed the same way:

- `place/details.hbs`, the reported one
- `zone/details.hbs`
- `service-area/details.hbs`
- `modals/place-details.hbs`
- `modals/point-map.hbs`

It has shipped in every release since, v0.6.62 through v0.6.65, so this targets the `release/v0.6.66` branch (#321).

The helper's own usage comment showed the broken form. It now shows the invocation and says why.

## Validation

- template-lint passes on the five templates, and ESLint on the helper.
- No bare `{{leaflet-tile-url}}` is left in the addon's templates. The calls that pass `theme=` were never affected, because an argument makes it an unambiguous invocation.

Not checked in a browser.
